### PR TITLE
Make sure cgo is dissabled for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang as builder
 ADD . /work
 RUN cd /work && \
-    CGO_ENABLED=0 && \
-    go build -o auroraboot
+    CGO_ENABLED=0 go build -o auroraboot
 
 FROM quay.io/kairos/osbuilder-tools
 COPY --from=builder /work/auroraboot /usr/bin/auroraboot


### PR DESCRIPTION
This fixes the issue claiming that glibc is missing on the tests on master. Not exactly what changed between the last run and HEAD though