### PR TITLE
Generate new artifact names

### DIFF
--- a/pkg/schema/artifact.go
+++ b/pkg/schema/artifact.go
@@ -2,41 +2,78 @@ package schema
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 type ReleaseArtifact struct {
 	ArtifactVersion string `yaml:"artifact_version"`
-	ReleaseVersion  string `yaml:"release_version"`
+	Model           string `yaml:"model"`
 	Flavor          string `yaml:"flavor"`
+	Platform        string `yaml:"platform"`
+	ReleaseVersion  string `yaml:"release_version"`
 	Repository      string `yaml:"repository"`
+	Variant         string `yaml:"variant"`
 
 	ContainerImage string `yaml:"container_image"`
 }
 
-func urlGen(repository, releaseVersion, flavor, artifactVersion, artifactType string) string {
-	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repository, releaseVersion, fileName(flavor, artifactVersion, artifactType))
+func (a ReleaseArtifact) FileName() string {
+	if a.Model == "" {
+		a.Model = "generic"
+	}
+	if a.Platform == "" {
+		a.Platform = "amd64"
+	}
+	if a.Variant == "" {
+		if strings.Contains(a.ArtifactVersion, "k3s") {
+			a.Variant = "standard"
+		} else {
+			a.Variant = "core"
+		}
+
+	}
+
+	var re = regexp.MustCompile(`v(?P<major>\d+)\.(?P<minor>\d+).+`)
+	match := re.FindStringSubmatch(a.ReleaseVersion)
+	result := make(map[string]string)
+	for i, name := range re.SubexpNames() {
+		if i != 0 && name != "" {
+			result[name] = match[i]
+		}
+	}
+
+	major, _ := strconv.Atoi(result["major"])
+	minor, _ := strconv.Atoi(result["minor"])
+
+	if major < 2 || (major == 2 && minor < 4) {
+		return fmt.Sprintf("kairos-%s-%s", a.Flavor, a.ArtifactVersion)
+	}
+
+	return fmt.Sprintf("kairos-%s-%s-%s-generic-%s", a.Variant, a.Flavor, a.Platform, a.ArtifactVersion)
 }
 
-func fileName(flavor, artifactVersion, artifactType string) string {
-	return fmt.Sprintf("kairos-%s-%s%s", flavor, artifactVersion, artifactType)
+func (a ReleaseArtifact) urlGen(ext string) string {
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s%s", a.Repository, a.ReleaseVersion, a.FileName(), ext)
 }
 
 func (a ReleaseArtifact) NetbootArtifacts() []string {
-
 	return []string{a.InitrdURL()}
 }
+
 func (a ReleaseArtifact) ISOUrl() string {
-	return urlGen(a.Repository, a.ReleaseVersion, a.Flavor, a.ArtifactVersion, ".iso")
+	return a.urlGen(".iso")
 }
 
 func (a ReleaseArtifact) InitrdURL() string {
-	return urlGen(a.Repository, a.ReleaseVersion, a.Flavor, a.ArtifactVersion, "-initrd")
+	return a.urlGen("-initrd")
 }
 
 func (a ReleaseArtifact) KernelURL() string {
-	return urlGen(a.Repository, a.ReleaseVersion, a.Flavor, a.ArtifactVersion, "-kernel")
+	return a.urlGen("-kernel")
 }
 
 func (a ReleaseArtifact) SquashFSURL() string {
-	return urlGen(a.Repository, a.ReleaseVersion, a.Flavor, a.ArtifactVersion, ".squashfs")
+	return a.urlGen(".squashfs")
 }

--- a/pkg/schema/artifact.go
+++ b/pkg/schema/artifact.go
@@ -20,6 +20,10 @@ type ReleaseArtifact struct {
 }
 
 func (a ReleaseArtifact) FileName() string {
+	if a.ContainerImage != "" {
+		return ""
+	}
+
 	if a.Model == "" {
 		a.Model = "generic"
 	}

--- a/pkg/schema/artifact_test.go
+++ b/pkg/schema/artifact_test.go
@@ -1,0 +1,65 @@
+package schema_test
+
+import (
+	"github.com/kairos-io/AuroraBoot/pkg/schema"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Artifact", func() {
+	Describe("FileName", func() {
+		var artifact *schema.ReleaseArtifact
+
+		BeforeEach(func() {
+			artifact = &schema.ReleaseArtifact{
+				ArtifactVersion: "v2.4.0",
+				Model:           "generic",
+				Flavor:          "rockylinux",
+				Platform:        "amd64",
+				ReleaseVersion:  "v2.4.0",
+				Repository:      "kairos-io/kairos",
+				Variant:         "core",
+			}
+		})
+
+		It("should return the correct filename", func() {
+			Expect(artifact.FileName()).To(Equal("kairos-core-rockylinux-amd64-generic-v2.4.0"))
+		})
+
+		Context("when the model is empty", func() {
+			It("should default to generic", func() {
+				artifact.Model = ""
+				Expect(artifact.FileName()).To(Equal("kairos-core-rockylinux-amd64-generic-v2.4.0"))
+			})
+		})
+
+		Context("when the platform is empty", func() {
+			It("should default to amd64", func() {
+				artifact.Platform = ""
+				Expect(artifact.FileName()).To(Equal("kairos-core-rockylinux-amd64-generic-v2.4.0"))
+			})
+		})
+
+		Context("when the variant is empty", func() {
+			It("should default to core", func() {
+				artifact.Variant = ""
+				Expect(artifact.FileName()).To(Equal("kairos-core-rockylinux-amd64-generic-v2.4.0"))
+			})
+
+			It("should default to standard when the artifact version contains k3s", func() {
+				artifact.Variant = ""
+				artifact.ArtifactVersion = "v2.4.0-k3sv1.26.1+k3s1"
+				Expect(artifact.FileName()).To(Equal("kairos-standard-rockylinux-amd64-generic-v2.4.0-k3sv1.26.1+k3s1"))
+			})
+		})
+
+		Context("when the release version is less than v2.4.0", func() {
+			It("should use the old filename format", func() {
+				artifact.ReleaseVersion = "v2.3.0"
+				artifact.ArtifactVersion = "v2.3.0"
+				Expect(artifact.FileName()).To(Equal("kairos-rockylinux-v2.3.0"))
+			})
+		})
+	})
+})

--- a/pkg/schema/artifact_test.go
+++ b/pkg/schema/artifact_test.go
@@ -27,6 +27,13 @@ var _ = Describe("Artifact", func() {
 			Expect(artifact.FileName()).To(Equal("kairos-core-rockylinux-amd64-generic-v2.4.0"))
 		})
 
+		Context("when the container_image is set", func() {
+			It("should return an empty string", func() {
+				artifact.ContainerImage = "docker://quay.io/kairos/core-rockylinux:latest"
+				Expect(artifact.FileName()).To(Equal(""))
+			})
+		})
+
 		Context("when the model is empty", func() {
 			It("should default to generic", func() {
 				artifact.Model = ""

--- a/pkg/schema/schema_suite_test.go
+++ b/pkg/schema/schema_suite_test.go
@@ -1,0 +1,12 @@
+package schema_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestSchema(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Schema Suite")
+}


### PR DESCRIPTION
AuroraBoot doesn't know how to generate the new artifact names. There's a way to hack it and keep this code simple e.g. `--set flavor="standard-opensuse-leap-amd64-generic"` but this is confusing and just goes against the idea of refactoring the flavors to not include things like `arm-rpi`

relates to kairos-io/kairos#1866