### PR TITLE
fix: (network) set UserAgent for grab

### DIFF
--- a/pkg/ops/network.go
+++ b/pkg/ops/network.go
@@ -12,6 +12,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	UserAgent =  "AuroraBoot"
+)
+
 // ServeArtifacts serve local artifacts as standard http server
 func ServeArtifacts(listenAddr, dir string) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
@@ -43,6 +47,8 @@ func DownloadArtifact(url, dst string) func(ctx context.Context) error {
 func download(ctx context.Context, url, dst string) (string, error) {
 	// create client
 	client := grab.NewClient()
+	// https://github.com/cavaliergopher/grab/issues/104
+	client.UserAgent = UserAgent
 	req, _ := grab.NewRequest(dst, url)
 
 	// start download


### PR DESCRIPTION
https://github.com/cavaliergopher/grab/issues/104

The default UserAgent for grab is "grab" and it appears GitHub is blocking it, at least in some cases.

You'll get log lines like this:

```
8:02PM INF Downloading https://github.com/kairos-io/kairos/releases/download/v2.4.0/kairos-standard-debian-amd64-generic-v2.4.0-k3sv1.27.3+k3s1.iso...
8:02PM INF Downloading https://github.com/kairos-io/kairos/releases/download/v2.4.0/kairos-standard-debian-amd64-generic-v2.4.0-k3sv1.27.3+k3s1.squashfs...
8:02PM INF Downloading https://github.com/kairos-io/kairos/releases/download/v2.4.0/kairos-standard-debian-amd64-generic-v2.4.0-k3sv1.27.3+k3s1-initrd...
8:02PM INF Downloading https://github.com/kairos-io/kairos/releases/download/v2.4.0/kairos-standard-debian-amd64-generic-v2.4.0-k3sv1.27.3+k3s1-kernel...
7 errors occurred:
	* server returned 403 Forbidden
	* server returned 403 Forbidden
	* server returned 403 Forbidden
	* server returned 403 Forbidden
	* 'start-netboot' deps download-squashfs failed
	* 'inject-cloud-config' deps download-iso failed
	* 'start-httpserver' deps inject-cloud-config failed
```