### PR TITLE
Fail out if cc was specified but contents are empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 ARG VERSION=v0.9.0
 
-FROM golang as builder
-ADD . /work
-RUN cd /work && \
-    CGO_ENABLED=0 go build -o auroraboot
+FROM golang AS builder
+WORKDIR /work
+ADD go.mod .
+ADD go.sum .
+RUN go mod download
+ADD . .
+RUN CGO_ENABLED=0 go build -o auroraboot
 
 FROM quay.io/kairos/osbuilder-tools:$VERSION
-COPY --from=builder /work/auroraboot /usr/bin/auroraboot
 RUN zypper in -y qemu
+COPY --from=builder /work/auroraboot /usr/bin/auroraboot
 ENTRYPOINT ["/usr/bin/auroraboot"]

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -145,7 +145,11 @@ func ReadConfig(fileConfig, cloudConfig string, options []string) (*schema.Confi
 				return c, r, fmt.Errorf("file '%s' not found", cloudConfig)
 			}
 		}
+		if c.CloudConfig == "" {
+			return nil, nil, fmt.Errorf("cloud config set but contents are empty. Check that the content of the file is correct or the path is the proper one")
+		}
 	}
-	log.Print(c.CloudConfig)
+
+	log.Debug().Str("cc", c.CloudConfig).Msg("Cloud config")
 	return c, r, nil
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -148,8 +148,8 @@ func ReadConfig(fileConfig, cloudConfig string, options []string) (*schema.Confi
 		if c.CloudConfig == "" {
 			return nil, nil, fmt.Errorf("cloud config set but contents are empty. Check that the content of the file is correct or the path is the proper one")
 		}
+		log.Debug().Str("cc", c.CloudConfig).Msg("Cloud config")
 	}
-
-	log.Debug().Str("cc", c.CloudConfig).Msg("Cloud config")
+	
 	return c, r, nil
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -150,6 +150,6 @@ func ReadConfig(fileConfig, cloudConfig string, options []string) (*schema.Confi
 		}
 		log.Debug().Str("cc", c.CloudConfig).Msg("Cloud config")
 	}
-	
+
 	return c, r, nil
 }

--- a/tests/e2e/arm_test.go
+++ b/tests/e2e/arm_test.go
@@ -20,7 +20,7 @@ var _ = Describe("ARM image generation", Label("arm"), func() {
 
 			tempDir = t
 
-			err = WriteConfig("", t)
+			err = WriteConfig("test", t)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/disks_test.go
+++ b/tests/e2e/disks_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Disk image generation", Label("raw-disks"), func() {
 
 			tempDir = t
 
-			err = WriteConfig("", t)
+			err = WriteConfig("test", t)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/iso_test.go
+++ b/tests/e2e/iso_test.go
@@ -19,7 +19,7 @@ var _ = Describe("ISO image generation", Label("iso"), func() {
 
 			tempDir = t
 
-			err = WriteConfig("", t)
+			err = WriteConfig("test", t)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -43,6 +43,17 @@ var _ = Describe("ISO image generation", Label("iso"), func() {
 			Expect(err).ToNot(HaveOccurred())
 			_, err = os.Stat(filepath.Join(tempDir, "build/build/kairos.iso"))
 			Expect(err).ToNot(HaveOccurred())
+		})
+		It("fails if cloud config is empty", func() {
+			err := WriteConfig("", tempDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			out, err := RunAurora(fmt.Sprintf(`--set container_image=quay.io/kairos/core-rockylinux:latest \
+			--set "disable_http_server=true" \
+			--set "disable_netboot=true" \
+			--cloud-config /config.yaml \
+			--set "state_dir=/tmp/auroraboot"`), tempDir)
+			Expect(err).To(HaveOccurred(), out)
 		})
 
 		It("generate an iso image from a release", func() {


### PR DESCRIPTION
If we have marked a cloud config file but after parsing and templating,
the contents are empty, error out as it points out to a user error on
choosing the file.

If no cc is set, the check wont fail out.

This also brings some small improvements to dockerfile to not have to fully rebuild the dockerfile each time something is changed on aurora for testing

Probably fixes https://github.com/kairos-io/kairos/issues/2876 as it looks like a wrong naming issue can lead to confusion like this. With this patch, the error will be immediately evident


Signed-off-by: Itxaka <itxaka@kairos.io>