### PR TITLE
Fix persmissions of the build directory after creating it

### DIFF
--- a/tests/e2e/arm_test.go
+++ b/tests/e2e/arm_test.go
@@ -15,7 +15,7 @@ var _ = Describe("ARM image generation", Label("arm"), func() {
 		tempDir := ""
 
 		BeforeEach(func() {
-			t, err := os.MkdirTemp("", "")
+			t, err := os.MkdirTemp("", "auroraboot-test-")
 			Expect(err).ToNot(HaveOccurred())
 
 			tempDir = t

--- a/tests/e2e/arm_test.go
+++ b/tests/e2e/arm_test.go
@@ -11,16 +11,14 @@ import (
 
 var _ = Describe("ARM image generation", Label("arm"), func() {
 	Context("build", func() {
-
-		tempDir := ""
+		var tempDir string
+		var err error
 
 		BeforeEach(func() {
-			t, err := os.MkdirTemp("", "auroraboot-test-")
+			tempDir, err = os.MkdirTemp("", "auroraboot-test-")
 			Expect(err).ToNot(HaveOccurred())
 
-			tempDir = t
-
-			err = WriteConfig("test", t)
+			err = WriteConfig("test", tempDir)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/disks_test.go
+++ b/tests/e2e/disks_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Disk image generation", Label("raw-disks"), func() {
 		tempDir := ""
 
 		BeforeEach(func() {
-			t, err := os.MkdirTemp("", "")
+			t, err := os.MkdirTemp("", "auroraboot-test-")
 			Expect(err).ToNot(HaveOccurred())
 
 			tempDir = t
@@ -158,7 +158,7 @@ stages:
          [[ "$(echo "$(df -h | grep COS_PERSISTENT)" | awk '{print $5}' | tr -d '%')" -ne 100 ]] && resize2fs /dev/disk/by-label/COS_PERSISTENT`
 
 		BeforeEach(func() {
-			t, err := os.MkdirTemp("", "")
+			t, err := os.MkdirTemp("", "auroraboot-test-")
 			Expect(err).ToNot(HaveOccurred())
 
 			tempDir = t

--- a/tests/e2e/disks_test.go
+++ b/tests/e2e/disks_test.go
@@ -12,16 +12,14 @@ import (
 var _ = Describe("Disk image generation", Label("raw-disks"), func() {
 
 	Context("build from an ISO", func() {
-
-		tempDir := ""
+		var tempDir string
+		var err error
 
 		BeforeEach(func() {
-			t, err := os.MkdirTemp("", "auroraboot-test-")
+			tempDir, err = os.MkdirTemp("", "auroraboot-test-")
 			Expect(err).ToNot(HaveOccurred())
 
-			tempDir = t
-
-			err = WriteConfig("test", t)
+			err = WriteConfig("test", tempDir)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -119,10 +117,12 @@ var _ = Describe("Disk image generation", Label("raw-disks"), func() {
 	})
 
 	Context("build from a container image", func() {
+		var tempDir string
+		var err error
+		var config string
 
-		tempDir := ""
-
-		config := `#cloud-config
+		BeforeEach(func() {
+			config = `#cloud-config
 
 hostname: kairos-{{ trunc 4 .MachineID }}
 
@@ -157,13 +157,10 @@ stages:
       - |
          [[ "$(echo "$(df -h | grep COS_PERSISTENT)" | awk '{print $5}' | tr -d '%')" -ne 100 ]] && resize2fs /dev/disk/by-label/COS_PERSISTENT`
 
-		BeforeEach(func() {
-			t, err := os.MkdirTemp("", "auroraboot-test-")
+			tempDir, err = os.MkdirTemp("", "auroraboot-test-")
 			Expect(err).ToNot(HaveOccurred())
 
-			tempDir = t
-
-			err = WriteConfig(config, t)
+			err = WriteConfig(config, tempDir)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/tests/e2e/iso_test.go
+++ b/tests/e2e/iso_test.go
@@ -11,15 +11,14 @@ import (
 
 var _ = Describe("ISO image generation", Label("iso"), func() {
 	Context("build", func() {
+		var tempDir string
+		var err error
 
-		tempDir := ""
 		BeforeEach(func() {
-			t, err := os.MkdirTemp("", "auroraboot-test-")
+			tempDir, err = os.MkdirTemp("", "auroraboot-test-")
 			Expect(err).ToNot(HaveOccurred())
 
-			tempDir = t
-
-			err = WriteConfig("test", t)
+			err = WriteConfig("test", tempDir)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -44,6 +43,7 @@ var _ = Describe("ISO image generation", Label("iso"), func() {
 			_, err = os.Stat(filepath.Join(tempDir, "build/build/kairos.iso"))
 			Expect(err).ToNot(HaveOccurred())
 		})
+
 		It("fails if cloud config is empty", func() {
 			err := WriteConfig("", tempDir)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/e2e/iso_test.go
+++ b/tests/e2e/iso_test.go
@@ -54,6 +54,7 @@ var _ = Describe("ISO image generation", Label("iso"), func() {
 			--cloud-config /config.yaml \
 			--set "state_dir=/tmp/auroraboot"`), tempDir)
 			Expect(err).To(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp("cloud config set but contents are empty"))
 		})
 
 		It("generate an iso image from a release", func() {

--- a/tests/e2e/iso_test.go
+++ b/tests/e2e/iso_test.go
@@ -14,7 +14,7 @@ var _ = Describe("ISO image generation", Label("iso"), func() {
 
 		tempDir := ""
 		BeforeEach(func() {
-			t, err := os.MkdirTemp("", "")
+			t, err := os.MkdirTemp("", "auroraboot-test-")
 			Expect(err).ToNot(HaveOccurred())
 
 			tempDir = t

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -25,7 +25,17 @@ func TestSuite(t *testing.T) {
 
 func RunAurora(cmd, dir string) (string, error) {
 	runCmd := fmt.Sprintf(`cd %s && docker run --privileged -v "$PWD"/config.yaml:/config.yaml -v "$PWD"/build:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm %s --debug %s`, dir, auroraBootImage, cmd)
-	return utils.SH(runCmd)
+	cmdOut, cmdErr := utils.SH(runCmd)
+	if cmdErr != nil {
+		return cmdOut, cmdErr
+	}
+
+	// Fix permissions of build directory to allow running tests locally rootless
+	permCmd := fmt.Sprintf(`cd %s && docker run --privileged -e USERID=$(id -u) -e GROUPID=$(id -g) --entrypoint /usr/bin/sh -v "$PWD"/build:/tmp/auroraboot --rm %s -c 'chown -R $USERID:$GROUPID /tmp/auroraboot'`, dir, auroraBootImage)
+	permOut, permErr := utils.SH(permCmd)
+	Expect(permErr).ToNot(HaveOccurred(), permOut)
+
+	return cmdOut, cmdErr
 }
 
 func PullImage(image string) (string, error) {


### PR DESCRIPTION
because docker runs as root and the directory is owned by root. We set the permissions back to the user that run the docker command to allow inspection of the created dir.