### PR TITLE
Simplify function and improve log

### DIFF
--- a/pkg/ops/netboot.go
+++ b/pkg/ops/netboot.go
@@ -35,6 +35,6 @@ func StartPixiecore(cloudConfigFile, squashFSfile, address, netbootPort, initrdF
 			cmdLine = `root=live:{{ ID "%s" }} config_url={{ ID "%s" }} ` + nb.Cmdline
 		}
 
-		return netboot.Server(kernelFile, "AuroraBoot", fmt.Sprintf(cmdLine, squashFSfile, configFile), address, netbootPort, []string{initrdFile}, true)
+		return netboot.Server(kernelFile, fmt.Sprintf(cmdLine, squashFSfile, configFile), address, netbootPort, initrdFile, true)
 	}
 }


### PR DESCRIPTION
The pixiecore spec allows more than one initrd for some reason, but we dont use that at all. Simplify that by just passing the plain initrd and using it directly.

Also drop the bootmsg, its not necessary and it would need a very VERY slow netwok to show up.

Also make the log the same as we use in aurora, splitting it to debug and info so the logging is nicer and falls in line with the previous log