### PR TITLE
Remove builds for mac and windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,8 +7,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
-      - windows
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
auroraboot can be run in a container, plus goreleaser fails for those targets