### PR TITLE
Detect version correctly so that we also push "latest" tag

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -32,7 +32,7 @@ jobs:
           # If the VERSION looks like a version number, assume that
           # this is the most recent version of the image and also
           # tag it 'latest'.
-          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest"
           fi
           # Set output parameters.


### PR DESCRIPTION
Something was pushed as `latest` but not the tagged image. Not sure what:

<img width="1773" alt="image" src="https://github.com/user-attachments/assets/7b746252-8bd5-4940-8189-680a02560700">
