### PR TITLE
Don't put artifacts in a `build/` subdirectory

### DIFF
--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -186,7 +186,7 @@ func (d *Deployer) tmpRootFs() string {
 }
 
 func (d *Deployer) destination() string {
-	return d.Config.StateDir("build")
+	return d.Config.State
 }
 
 func (d *Deployer) isoFile() string {

--- a/examples/airgap/build.sh
+++ b/examples/airgap/build.sh
@@ -27,4 +27,4 @@ docker run -v $PWD/config.yaml:/config.yaml \
              --set "flavor=fedora" \
              --set "repository=kairos-io/provider-kairos"
 
-echo "Custom ISO ready at $PWD/build/build/kairos.iso.custom.iso"
+echo "Custom ISO ready at $PWD/build/kairos.iso.custom.iso"

--- a/examples/airgap/build_docker.sh
+++ b/examples/airgap/build_docker.sh
@@ -27,4 +27,4 @@ docker run -v $PWD/config.yaml:/config.yaml \
              --cloud-config /config.yaml \
              --set "state_dir=/tmp/auroraboot"
 
-echo "Custom ISO ready at $PWD/build/build/kairos.iso"
+echo "Custom ISO ready at $PWD/build/kairos.iso"

--- a/tests/e2e/arm_test.go
+++ b/tests/e2e/arm_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ARM image generation", Label("arm"), func() {
 			Expect(out).To(ContainSubstring("done"), out)
 			Expect(out).To(ContainSubstring("build-arm-image"), out)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.img"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/disk.img"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -60,7 +60,7 @@ var _ = Describe("ARM image generation", Label("arm"), func() {
 			Expect(out).ToNot(ContainSubstring("build-arm-image"), out)
 			Expect(out).To(ContainSubstring("prepare_arm"), out)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/efi.img"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/efi.img"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/tests/e2e/disks_test.go
+++ b/tests/e2e/disks_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Disk image generation", Label("raw-disks"), func() {
 			Expect(out).To(ContainSubstring("extract-squashfs"), out)
 			Expect(out).ToNot(ContainSubstring("dump-source"), out)
 			Expect(err).ToNot(HaveOccurred(), out)
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.raw"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/disk.raw"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -67,7 +67,7 @@ var _ = Describe("Disk image generation", Label("raw-disks"), func() {
 			Expect(out).To(ContainSubstring("extract-squashfs"), out)
 			Expect(out).ToNot(ContainSubstring("dump-source"), out)
 			Expect(err).ToNot(HaveOccurred(), out)
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.raw.gce"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/disk.raw.gce"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -89,7 +89,7 @@ var _ = Describe("Disk image generation", Label("raw-disks"), func() {
 			Expect(out).To(ContainSubstring("extract-squashfs"), out)
 			Expect(out).ToNot(ContainSubstring("dump-source"), out)
 			Expect(err).ToNot(HaveOccurred(), out)
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.raw.vhd"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/disk.raw.vhd"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -111,7 +111,7 @@ var _ = Describe("Disk image generation", Label("raw-disks"), func() {
 		// 	Expect(out).To(ContainSubstring("extract-squashfs"), out)
 		// 	Expect(out).ToNot(ContainSubstring("dump-source"), out)
 		// 	Expect(err).ToNot(HaveOccurred(), out)
-		// 	_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.raw.gce"))
+		// 	_, err = os.Stat(filepath.Join(tempDir, "build/disk.raw.gce"))
 		// 	Expect(err).ToNot(HaveOccurred())
 		// })
 	})
@@ -170,7 +170,7 @@ stages:
 			os.RemoveAll(tempDir)
 		})
 
-		It("generate a raw build/build/disk.raw (EFI) file", Label("efi"), func() {
+		It("generate a raw build/disk.raw (EFI) file", Label("efi"), func() {
 			image := "quay.io/kairos/opensuse:tumbleweed-core-amd64-generic-v3.2.1"
 			_, err := PullImage(image)
 			Expect(err).ToNot(HaveOccurred())
@@ -186,7 +186,7 @@ stages:
 			Expect(out).To(ContainSubstring("gen-raw-disk"), out)
 			Expect(out).To(ContainSubstring("dump-source"), out)
 			Expect(err).ToNot(HaveOccurred(), out)
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.raw"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/disk.raw"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -207,7 +207,7 @@ stages:
 			Expect(out).To(ContainSubstring("convert-gce"), out)
 			Expect(out).To(ContainSubstring("dump-source"), out)
 			Expect(err).ToNot(HaveOccurred(), out)
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.raw.gce"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/disk.raw.gce"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -228,7 +228,7 @@ stages:
 			Expect(out).To(ContainSubstring("convert-vhd"), out)
 			Expect(out).To(ContainSubstring("dump-source"), out)
 			Expect(err).ToNot(HaveOccurred(), out)
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.raw.vhd"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/disk.raw.vhd"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -249,7 +249,7 @@ stages:
 			Expect(out).To(ContainSubstring("gen-raw-mbr-disk"), out)
 			Expect(out).To(ContainSubstring("dump-source"), out)
 			Expect(err).ToNot(HaveOccurred(), out)
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/disk.raw"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/disk.raw"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/tests/e2e/iso_test.go
+++ b/tests/e2e/iso_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ISO image generation", Label("iso"), func() {
 			Expect(out).To(ContainSubstring("gen-iso"), out)
 			Expect(out).ToNot(ContainSubstring("build-arm-image"), out)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/kairos.iso"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/kairos.iso"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -75,7 +75,7 @@ var _ = Describe("ISO image generation", Label("iso"), func() {
 			Expect(out).To(ContainSubstring("inject-cloud-config"), out)
 			Expect(out).ToNot(ContainSubstring("build-arm-image"), out)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = os.Stat(filepath.Join(tempDir, "build/build/kairos.iso.custom.iso"))
+			_, err = os.Stat(filepath.Join(tempDir, "build/kairos.iso.custom.iso"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
When the user says "--output mydir" they really expect the artifacts to be in `mydir`, not in `mydir/build`.

See also:

- https://github.com/kairos-io/osbuilder/pull/192#discussion_r1843594468
- https://github.com/kairos-io/kairos-docs/pull/311#discussion_r1843596680