### PR TITLE
Switch to Fedora for the auroraboot image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN go build -ldflags "-X main.version=${VERSION}" -o auroraboot
 FROM fedora:$FEDORA_VERSION AS default
 RUN dnf -y update
 ## ISO+ Arm image + Netboot + cloud images Build depedencies
-RUN dnf in -y bc qemu-tools jq genisoimage docker git curl gdisk kpartx sudo \
-    xfsprogs parted e2fsprogs erofs-utils binutils curl util-linux udev rsync \
+RUN dnf in -y bc qemu-tools qemu-img qemu-system-x86.x86_64 jq genisoimage docker git curl gdisk kpartx \
+    sudo xfsprogs parted e2fsprogs erofs-utils binutils curl util-linux udev rsync \
     grub2 dosfstools mtools xorriso lvm2 zstd sbsigntools squashfs-tools openssl \
     python3-cryptography python3-pefile # ukify deps
 # systemd-ukify systemd-boot

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ RUN go build -ldflags "-X main.version=${VERSION}" -o auroraboot
 FROM fedora:$FEDORA_VERSION AS default
 RUN dnf -y update
 ## ISO+ Arm image + Netboot + cloud images Build depedencies
-RUN dnf in -y bc qemu-tools jq genisoimage docker git curl gdisk kpartx sudo xfsprogs parted e2fsprogs erofs-utils curl  \
-    util-linux udev rsync grub2 dosfstools mtools xorriso lvm2 zstd sbsigntools squashfs-tools openssl \
+RUN dnf in -y bc qemu-tools jq genisoimage docker git curl gdisk kpartx sudo \
+    xfsprogs parted e2fsprogs erofs-utils binutils curl util-linux udev rsync \
+    grub2 dosfstools mtools xorriso lvm2 zstd sbsigntools squashfs-tools openssl \
     python3-cryptography python3-pefile # ukify deps
 # systemd-ukify systemd-boot
 # Install grub2-efi-x64 only on x86 arches


### PR DESCRIPTION
because opensuse/leap doesn't have latest systemd and older systemd-repart doesn't support the flags we are passing in the sysext command (e.g.  --make-ddi).

Our other option would be to switch to Tumbleweed but that might be too unstable for us to use for Auroraboot.

This is reviving the work here:
https://github.com/kairos-io/osbuilder/pull/128

later reverted here:
https://github.com/kairos-io/osbuilder/commit/7813c2eec45a1db8ff9b1283ed2c9fa73e4cf878