### PR TITLE
Create directories with 755 permissions

### DIFF
--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -12,7 +12,7 @@ import (
 func (d *Deployer) StepPrepNetbootDir() error {
 	return d.Add(opPrepareNetboot, herd.WithCallback(
 		func(ctx context.Context) error {
-			return os.MkdirAll(d.dstNetboot(), 0700)
+			return os.MkdirAll(d.dstNetboot(), 0755)
 		},
 	))
 }
@@ -20,14 +20,14 @@ func (d *Deployer) StepPrepNetbootDir() error {
 func (d *Deployer) StepPrepTmpRootDir() error {
 	return d.Add(opPreparetmproot, herd.WithCallback(
 		func(ctx context.Context) error {
-			return os.MkdirAll(d.tmpRootFs(), 0700)
+			return os.MkdirAll(d.tmpRootFs(), 0755)
 		},
 	))
 }
 
 func (d *Deployer) StepPrepISODir() error {
 	return d.Add(opPrepareISO, herd.WithCallback(func(ctx context.Context) error {
-		return os.MkdirAll(d.destination(), 0700)
+		return os.MkdirAll(d.destination(), 0755)
 	}))
 }
 

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -72,7 +72,7 @@ func TempDir(fs v1.FS, dir, prefix string) (name string, err error) {
 	}
 	// This skips adding random stuff to the created temp dir so the temp dir created is predictable for testing
 	if _, isTestFs := fs.(*vfst.TestFS); isTestFs {
-		err = MkdirAll(fs, filepath.Join(dir, prefix), 0700)
+		err = MkdirAll(fs, filepath.Join(dir, prefix), 0755)
 		if err != nil {
 			return "", err
 		}
@@ -82,7 +82,7 @@ func TempDir(fs v1.FS, dir, prefix string) (name string, err error) {
 	nconflict := 0
 	for i := 0; i < 10000; i++ {
 		try := filepath.Join(dir, prefix+nextRandom())
-		err = MkdirAll(fs, try, 0700)
+		err = MkdirAll(fs, try, 0755)
 		if os.IsExist(err) {
 			if nconflict++; nconflict > 10 {
 				randmu.Lock()


### PR DESCRIPTION
because otherwise the rootfs `/` has permissions 755 which results in all users except "root" to not be able to login or run any commands