### PR TITLE
Fix different behaviour between usb and cd in efi

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"path/filepath"
 )
 
 // Eltorito image is basically a grub cdboot.img + grub core image
@@ -107,11 +106,11 @@ func GetXorrisoBooloaderArgs(root string) []string {
 		"-boot_image", "any", "platform_id=0x00",
 		"-boot_image", "any", "emul_type=no_emulation",
 		"-boot_image", "any", "load_size=2048",
-		"-append_partition", "2", "0xef", filepath.Join(root, IsoEFIPath),
 		"-boot_image", "any", "next",
-		"-boot_image", "any", "efi_path=--interval:appended_partition_2:all::",
 		"-boot_image", "any", "platform_id=0xef",
 		"-boot_image", "any", "emul_type=no_emulation",
+		"-boot_image", "any", "efi_path=" + IsoEFIPath, // Tell where the efi path is
+		"-boot_image", "any", "efi_boot_part=--efi-boot-image", // Tell where the efi path is for booting
 	}
 	return args
 }

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -397,7 +397,7 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 	// the uefi.img is loaded into memory and run, but grub only sees the livecd root
 	// WARNING: If we load the image into an usb stick, grub will not use the livecd root as the grub root, so it cannot find the grub.cfg
 	// So we copy in 2 places, into the livecd and into the img
-	
+
 	// This is used when booting from usb
 	if err = b.writeDefaultGrubEfiCfg(temp); err != nil {
 		b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
@@ -424,16 +424,6 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 	b.cfg.Logger.Infof("Detected Flavor: %s", flavor)
 	if strings.Contains(strings.ToLower(flavor), "ubuntu") {
 		b.cfg.Logger.Infof("Ubuntu based ISO detected, copying grub.cfg to /EFI/ubuntu/grub.cfg")
-		err = utils.MkdirAll(b.cfg.Fs, filepath.Join(temp, "EFI/ubuntu/"), constants.DirPerm)
-		if err != nil {
-			b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
-			return err
-		}
-		err = utils.MkdirAll(b.cfg.Fs, filepath.Join(isoDir, "EFI/ubuntu/"), constants.DirPerm)
-		if err != nil {
-			b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
-			return err
-		}
 
 		if err = b.writeUbuntuGrubEfiCfg(temp); err != nil {
 			b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
@@ -485,15 +475,19 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 
 // writeDefaultGrubEfiCfg writes the default grub.cfg for the EFI image in teh given path
 func (b *BuildISOAction) writeDefaultGrubEfiCfg(path string) error {
-        calculatedPath := filepath.Join(path, constants.EfiBootPath, constants.GrubCfg)
+	calculatedPath := filepath.Join(path, constants.EfiBootPath, constants.GrubCfg)
 	return b.cfg.Fs.WriteFile(calculatedPath, []byte(constants.GrubEfiCfg), constants.FilePerm)
 }
 
 func (b *BuildISOAction) writeUbuntuGrubEfiCfg(path string) error {
-        calculatedPath := filepath.Join(path, "EFI/ubuntu/", constants.GrubCfg)
+	calculatedPath := filepath.Join(path, "EFI/ubuntu/", constants.GrubCfg)
+	err := utils.MkdirAll(b.cfg.Fs, calculatedPath, constants.DirPerm)
+	if err != nil {
+		b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
+		return err
+	}
 	return b.cfg.Fs.WriteFile(calculatedPath, []byte(constants.GrubEfiCfg), constants.FilePerm)
 }
-
 
 // copyShim copies the shim files into the EFI partition
 // tempdir is the temp dir where the EFI image is generated from

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -397,13 +397,14 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 	// the uefi.img is loaded into memory and run, but grub only sees the livecd root
 	// WARNING: If we load the image into an usb stick, grub will not use the livecd root as the grub root, so it cannot find the grub.cfg
 	// So we copy in 2 places, into the livecd and into the img
-	err = b.cfg.Fs.WriteFile(filepath.Join(temp, constants.EfiBootPath, constants.GrubCfg), []byte(constants.GrubEfiCfg), constants.FilePerm)
-	if err != nil {
+	
+	// This is used when booting from usb
+	if err = b.writeDefaultGrubEfiCfg(filepath.Join(temp, constants.EfiBootPath, constants.GrubCfg)); err != nil {
 		b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 		return err
 	}
-	err = b.cfg.Fs.WriteFile(filepath.Join(isoDir, constants.EfiBootPath, constants.GrubCfg), []byte(constants.GrubEfiCfg), constants.FilePerm)
-	if err != nil {
+	// This is used when booting from cdrom
+	if err = b.writeDefaultGrubEfiCfg(filepath.Join(isoDir, constants.EfiBootPath, constants.GrubCfg)); err != nil {
 		b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 		return err
 	}
@@ -433,13 +434,12 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 			b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 			return err
 		}
-		err = b.cfg.Fs.WriteFile(filepath.Join(temp, "EFI/ubuntu/", constants.GrubCfg), []byte(constants.GrubEfiCfg), constants.FilePerm)
-		if err != nil {
+
+		if err = b.writeDefaultGrubEfiCfg(filepath.Join(temp, "EFI/ubuntu/", constants.GrubCfg)); err != nil {
 			b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 			return err
 		}
-		err = b.cfg.Fs.WriteFile(filepath.Join(isoDir, "EFI/ubuntu/", constants.GrubCfg), []byte(constants.GrubEfiCfg), constants.FilePerm)
-		if err != nil {
+		if err = b.writeDefaultGrubEfiCfg(filepath.Join(isoDir, "EFI/ubuntu/", constants.GrubCfg)); err != nil {
 			b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 			return err
 		}
@@ -481,6 +481,11 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 	}
 
 	return nil
+}
+
+// writeDefaultGrubEfiCfg writes the default grub.cfg for the EFI image in teh given path
+func (b *BuildISOAction) writeDefaultGrubEfiCfg(path string) error {
+	return b.cfg.Fs.WriteFile(path, []byte(constants.GrubEfiCfg), constants.FilePerm)
 }
 
 // copyShim copies the shim files into the EFI partition

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -399,12 +399,12 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 	// So we copy in 2 places, into the livecd and into the img
 	
 	// This is used when booting from usb
-	if err = b.writeDefaultGrubEfiCfg(filepath.Join(temp, constants.EfiBootPath, constants.GrubCfg)); err != nil {
+	if err = b.writeDefaultGrubEfiCfg(temp); err != nil {
 		b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 		return err
 	}
 	// This is used when booting from cdrom
-	if err = b.writeDefaultGrubEfiCfg(filepath.Join(isoDir, constants.EfiBootPath, constants.GrubCfg)); err != nil {
+	if err = b.writeDefaultGrubEfiCfg(isoDir); err != nil {
 		b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 		return err
 	}
@@ -435,11 +435,11 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 			return err
 		}
 
-		if err = b.writeDefaultGrubEfiCfg(filepath.Join(temp, "EFI/ubuntu/", constants.GrubCfg)); err != nil {
+		if err = b.writeUbuntuGrubEfiCfg(temp); err != nil {
 			b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 			return err
 		}
-		if err = b.writeDefaultGrubEfiCfg(filepath.Join(isoDir, "EFI/ubuntu/", constants.GrubCfg)); err != nil {
+		if err = b.writeUbuntuGrubEfiCfg(isoDir); err != nil {
 			b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 			return err
 		}
@@ -485,8 +485,15 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 
 // writeDefaultGrubEfiCfg writes the default grub.cfg for the EFI image in teh given path
 func (b *BuildISOAction) writeDefaultGrubEfiCfg(path string) error {
-	return b.cfg.Fs.WriteFile(path, []byte(constants.GrubEfiCfg), constants.FilePerm)
+        calculatedPath := filepath.Join(path, constants.EfiBootPath, constants.GrubCfg)
+	return b.cfg.Fs.WriteFile(calculatedPath, []byte(constants.GrubEfiCfg), constants.FilePerm)
 }
+
+func (b *BuildISOAction) writeUbuntuGrubEfiCfg(path string) error {
+        calculatedPath := filepath.Join(path, "EFI/ubuntu/", constants.GrubCfg)
+	return b.cfg.Fs.WriteFile(calculatedPath, []byte(constants.GrubEfiCfg), constants.FilePerm)
+}
+
 
 // copyShim copies the shim files into the EFI partition
 // tempdir is the temp dir where the EFI image is generated from

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -368,6 +368,7 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 
 	// rootfs /efi dir
 	img := filepath.Join(isoDir, constants.IsoEFIPath)
+	// Temp dir is where we will build the EFI image from
 	temp, _ := utils.TempDir(b.cfg.Fs, "", "auroraboot-iso")
 	err = utils.MkdirAll(b.cfg.Fs, filepath.Join(temp, constants.EfiBootPath), constants.DirPerm)
 	if err != nil {


### PR DESCRIPTION
Seems that the actual issue was not that the USB is not recognized, but the usb boots and it gets a grub shell because it cannot load the default grub.cfg for efi.

This seems to be a side issue of how efi booting works differently from livecd or usb in grub.
Looks like when booting from livecd, the efi artifacts are loaded from the efi image file BUT the livecd is mounted as root for grub.
When booting from usb it seems like the efi artifacts are loaded from the efi image AND the efi image is mounted as root for grub.

In both cases, grub is hardcoded to search for the grub config in /EFI/boot/grub.cfg (so alongside the grubx64.efi file)
When we build the ISO we only copy those artifacts on the ISO root, so you got the /EFI/boot/grub.cfg directly accessible when booting from livecd.
But when booting from usb the livecd is ignored and only the contents of the uefi.img are in the root, so /EFI/boot/grub.cfg does not exists.

This is fixed by copying it to both places so it works on both boot methods.