### PR TITLE
Cleanup temp dirs properly

### DIFF
--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"github.com/hashicorp/go-multierror"
 	"os"
 
 	"github.com/kairos-io/AuroraBoot/deployer"
@@ -55,7 +56,16 @@ func GetApp(version string) *cli.App {
 				return err
 			}
 
-			return d.CollectErrors()
+			err = d.CollectErrors()
+			errCleanup := d.CleanTmpDirs()
+			if err != nil {
+				internal.Log.Logger.Error().Err(err).Msg("Failed to clean up tmp root dir")
+				// Append the cleanup error to the main errors if any
+				err = multierror.Append(err, errCleanup)
+			}
+
+			return err
+
 		},
 	}
 }


### PR DESCRIPTION
We create a couple of temp dirs when starting aurora, it makes sense to remove them when we are done as they are used for several transient things.

Plus it has been reported that leaving things around can break building new artifacts, as we leave kernels around and they are picked up instead of the current ones, so its jsut good behaviour to clean up.

this cleans up before creating the temp dirs (fixed names) and when finished