### PR TITLE
Expose netboot extract command

### DIFF
--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -18,7 +18,7 @@ func GetApp(version string) *cli.App {
 		Version:  version,
 		Authors:  []*cli.Author{{Name: "Kairos authors", Email: "members@kairos.io"}},
 		Usage:    "auroraboot",
-		Commands: []*cli.Command{&BuildISOCmd, &BuildUKICmd, &GenKeyCmd, &SysextCmd},
+		Commands: []*cli.Command{&BuildISOCmd, &BuildUKICmd, &GenKeyCmd, &SysextCmd, &NetBootCmd},
 		Flags: []cli.Flag{
 			&cli.StringSliceFlag{
 				Name: "set",

--- a/internal/cmd/netboot.go
+++ b/internal/cmd/netboot.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/kairos-io/AuroraBoot/internal"
+	"github.com/kairos-io/AuroraBoot/pkg/ops"
+	"github.com/kairos-io/kairos-sdk/types"
+	"github.com/urfave/cli/v2"
+)
+
+var NetBootCmd = cli.Command{
+	Name:      "netboot",
+	Aliases:   []string{"nb"},
+	Usage:     "Extract artifacts for netboot from a given ISO",
+	ArgsUsage: "<iso> <output> <name>",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:  "debug",
+			Usage: "Enable debug logging",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		iso := c.Args().Get(0)
+		if iso == "" {
+			return fmt.Errorf("iso is required")
+		}
+		output := c.Args().Get(1)
+		if output == "" {
+			return fmt.Errorf("output is required")
+		}
+
+		name := c.Args().Get(2)
+		if name == "" {
+			return fmt.Errorf("name is required")
+		}
+		loglevel := "info"
+		if c.Bool("debug") {
+			loglevel = "debug"
+		}
+		internal.Log = types.NewKairosLogger("AuroraBoot", loglevel, false)
+
+		f := ops.ExtractNetboot(iso, output, name)
+		return f(c.Context)
+	},
+}


### PR DESCRIPTION
Looks like the osbuilder is using the netboot script directyl so we need to expose the netboot command directly

Complimentary to https://github.com/kairos-io/AuroraBoot/pull/148