### PR TITLE
Generate artifact name from rootfs values

### DIFF
--- a/e2e/build_uki_test.go
+++ b/e2e/build_uki_test.go
@@ -18,17 +18,17 @@ var _ = Describe("build-uki", Label("build-uki", "e2e"), func() {
 	var auroraboot *Auroraboot
 
 	BeforeEach(func() {
-		kairosVersion := "v2.5.0"
+		kairosVersion := "v3.3.3"
 		resultDir, err = os.MkdirTemp("", "auroraboot-build-uki-test-")
 		Expect(err).ToNot(HaveOccurred())
-		resultFile = filepath.Join(resultDir, fmt.Sprintf("kairos_%s.iso", kairosVersion))
+		image = fmt.Sprintf("quay.io/kairos/fedora:40-core-amd64-generic-%s-uki", kairosVersion)
+		resultFile = filepath.Join(resultDir, fmt.Sprintf("kairos-fedora-40-core-amd64-generic-%s-uki.iso", kairosVersion))
 
 		currentDir, err := os.Getwd()
 		Expect(err).ToNot(HaveOccurred())
 		keysDir = filepath.Join(currentDir, "assets", "keys")
 		Expect(os.MkdirAll(keysDir, 0755)).ToNot(HaveOccurred())
 		auroraboot = NewAuroraboot(resultDir, keysDir)
-		image = fmt.Sprintf("quay.io/kairos/fedora:38-core-amd64-generic-%s", kairosVersion)
 	})
 
 	AfterEach(func() {
@@ -84,6 +84,7 @@ var _ = Describe("build-uki", Label("build-uki", "e2e"), func() {
 })
 
 func buildISO(auroraboot *Auroraboot, image, keysDir, resultDir, resultFile string, additionalArgs ...string) string {
+	By(fmt.Sprintf("building the iso from %s", image))
 	args := []string{"build-uki", "--output-dir", resultDir, "-k", keysDir, "--output-type", "iso"}
 	args = append(args, additionalArgs...)
 	args = append(args, image)
@@ -92,7 +93,7 @@ func buildISO(auroraboot *Auroraboot, image, keysDir, resultDir, resultFile stri
 
 	By("building the iso")
 	_, err = os.Stat(resultFile)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred(), out)
 
 	return out
 }

--- a/e2e/iso_test.go
+++ b/e2e/iso_test.go
@@ -50,7 +50,7 @@ var _ = Describe("ISO image generation", Label("iso", "e2e"), func() {
 			Expect(out).To(ContainSubstring("gen-iso"), out)
 			Expect(out).ToNot(ContainSubstring("build-arm-image"), out)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = os.Stat(filepath.Join(tempDir, "kairos.iso"))
+			_, err = os.Stat(filepath.Join(tempDir, "kairos-rockylinux-9-core-amd64-generic-v3.3.1.iso"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -44,7 +44,6 @@ func GetApp(version string) *cli.App {
 			if err != nil {
 				return err
 			}
-			c.ISO.Name = KairosDefaultArtifactName
 
 			d := deployer.NewDeployer(*c, *r, herd.CollectOrphans)
 			err = deployer.RegisterAll(d)

--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -25,10 +25,10 @@ var BuildISOCmd = cli.Command{
 			Usage:   "The cloud config to embed in the ISO",
 		},
 		&cli.StringFlag{
-			Name:    "name",
+			Name:    "override-name",
 			Aliases: []string{"n"},
-			Value:   KairosDefaultArtifactName,
-			Usage:   "Basename of the generated ISO file",
+			Value:   "",
+			Usage:   "Overrride default ISO file name",
 		},
 		&cli.StringFlag{
 			Name:    "output",
@@ -64,7 +64,7 @@ var BuildISOCmd = cli.Command{
 			cli.ShowCommandHelp(ctx, ctx.Command.Name)
 			fmt.Println("")
 
-			return errors.New("No source defined")
+			return errors.New("no source defined")
 		}
 
 		cloudConfig := ""
@@ -81,12 +81,13 @@ var BuildISOCmd = cli.Command{
 			ContainerImage: source,
 		}
 		isoOptions := schema.ISO{
-			Name:          artifactBaseName(ctx),
+			OverrideName:  ctx.String("override-name"),
 			IncludeDate:   ctx.Bool("date"),
 			OverlayISO:    ctx.String("overlay-iso"),
 			OverlayRootfs: ctx.String("overlay-rootfs"),
 			OverlayUEFI:   ctx.String("overlay-uefi"),
 		}
+
 		if err := validateISOOptions(isoOptions); err != nil {
 			return err
 		}
@@ -119,14 +120,6 @@ var BuildISOCmd = cli.Command{
 	},
 }
 
-func artifactBaseName(ctx *cli.Context) string {
-	if setName := ctx.String("name"); setName != "" {
-		return setName
-	}
-
-	return KairosDefaultArtifactName
-}
-
 func validateISOOptions(i schema.ISO) error {
 	for _, path := range []string{i.OverlayISO, i.OverlayRootfs, i.OverlayUEFI} {
 		if path == "" {
@@ -138,7 +131,7 @@ func validateISOOptions(i schema.ISO) error {
 			continue
 		}
 		if os.IsNotExist(err) {
-			return fmt.Errorf("Invalid path '%s'", path)
+			return fmt.Errorf("invalid path '%s'", path)
 		}
 	}
 

--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -10,10 +10,6 @@ import (
 	"os"
 )
 
-const (
-	KairosDefaultArtifactName = "kairos"
-)
-
 var BuildISOCmd = cli.Command{
 	Name:    "build-iso",
 	Aliases: []string{"bi"},

--- a/internal/cmd/build-iso_test.go
+++ b/internal/cmd/build-iso_test.go
@@ -23,7 +23,7 @@ var _ = Describe("build-iso", Label("iso", "cmd"), func() {
 
 	It("errors out if no rootfs sources are defined", func() {
 		err = app.Run([]string{"", "build-iso"}) // first arg is the path to the program
-		Expect(err).To(MatchError("No source defined"))
+		Expect(err.Error()).To(Equal("no source defined"))
 	})
 
 	It("Errors out if rootfs is a non valid argument", Label("flags"), func() {
@@ -35,18 +35,18 @@ var _ = Describe("build-iso", Label("iso", "cmd"), func() {
 	It("Errors out if overlay roofs path does not exist", Label("flags"), func() {
 		err = app.Run([]string{"", "build-iso", "--overlay-rootfs", "/nonexistingpath", "system/cos"})
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("Invalid path"))
+		Expect(err.Error()).To(ContainSubstring("invalid path"))
 	})
 
 	It("Errors out if overlay uefi path does not exist", Label("flags"), func() {
 		err = app.Run([]string{"", "build-iso", "--overlay-uefi", "/nonexistingpath", "someimage:latest"})
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("Invalid path"))
+		Expect(err.Error()).To(ContainSubstring("invalid path"))
 	})
 
 	It("Errors out if overlay iso path does not exist", Label("flags"), func() {
 		err = app.Run([]string{"", "build-iso", "--overlay-iso", "/nonexistingpath", "some/image:latest"})
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("Invalid path"))
+		Expect(err.Error()).To(ContainSubstring("invalid path"))
 	})
 })

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -40,18 +40,19 @@ var GrubLiveBiosCfg []byte
 type UkiOutput string
 
 const (
-	IsoEFIPath     = "/boot/uefi.img"
-	EfiBootPath    = "/EFI/BOOT"
-	EfiLabel       = "COS_GRUB"
-	EfiFs          = "vfat"
-	IsoRootFile    = "rootfs.squashfs"
-	ISOLabel       = "COS_LIVE"
-	ShimEfiDest    = EfiBootPath + "/bootx64.efi"
-	ShimEfiArmDest = EfiBootPath + "/bootaa64.efi"
-	BuildImgName   = "elemental"
-	GrubCfg        = "grub.cfg"
-	GrubPrefixDir  = "/boot/grub2"
-	GrubEfiCfg     = "search --no-floppy --file --set=root " + IsoKernelPath +
+	KairosDefaultArtifactName = "kairos"
+	IsoEFIPath                = "/boot/uefi.img"
+	EfiBootPath               = "/EFI/BOOT"
+	EfiLabel                  = "COS_GRUB"
+	EfiFs                     = "vfat"
+	IsoRootFile               = "rootfs.squashfs"
+	ISOLabel                  = "COS_LIVE"
+	ShimEfiDest               = EfiBootPath + "/bootx64.efi"
+	ShimEfiArmDest            = EfiBootPath + "/bootaa64.efi"
+	BuildImgName              = "elemental"
+	GrubCfg                   = "grub.cfg"
+	GrubPrefixDir             = "/boot/grub2"
+	GrubEfiCfg                = "search --no-floppy --file --set=root " + IsoKernelPath +
 		"\nset prefix=($root)" + GrubPrefixDir +
 		"\nconfigfile $prefix/" + GrubCfg
 

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -121,6 +121,12 @@ func GenISO(src, dst string, i schema.ISO) func(ctx context.Context) error {
 		if i.DataPath != "" {
 			overlay = i.DataPath
 		}
+		if i.OverrideName != "" {
+			i.Name = i.OverrideName
+		} else {
+			// Generate name from the rootfs kairos-release file
+			i.Name = utils.NameFromRootfs(src)
+		}
 
 		// We are assuming StepCopyCloudConfig has already run, putting it the config in "dst"
 		err = copyFileIfExists(filepath.Join(dst, "config.yaml"), filepath.Join(overlay, "config.yaml"))

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -125,7 +125,7 @@ func GenISO(src, dst string, i schema.ISO) func(ctx context.Context) error {
 			i.Name = i.OverrideName
 		} else {
 			// Generate name from the rootfs kairos-release file
-			i.Name = utils.NameFromRootfs(src)
+			i.Name = fmt.Sprintf("kairos-%s", utils.NameFromRootfs(src))
 		}
 
 		// We are assuming StepCopyCloudConfig has already run, putting it the config in "dst"
@@ -648,6 +648,8 @@ func (b BuildISOAction) burnISO(root string) error {
 	} else {
 		isoFileName = fmt.Sprintf("%s.iso", b.cfg.Name)
 	}
+
+	internal.Log.Logger.Debug().Str("name", isoFileName).Msg("Got output name")
 
 	outputFile = isoFileName
 	if b.cfg.OutDir != "" {

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -422,36 +422,7 @@ func (r *RawImage) Build() error {
 	defer r.config.Fs.RemoveAll(r.TempDir())
 
 	// Get the artifact version from the rootfs
-	var label string
-	var flavor string
-	if _, ok := r.config.Fs.Stat(filepath.Join(r.Source, "etc/kairos-release")); ok == nil {
-		label, err = sdkUtils.OSRelease("IMAGE_LABEL", filepath.Join(r.Source, "etc/kairos-release"))
-		if err != nil {
-			internal.Log.Logger.Error().Err(err).Msg("failed to get image label")
-			return err
-		}
-		flavor, err = sdkUtils.OSRelease("FLAVOR", filepath.Join(r.Source, "etc/kairos-release"))
-		if err != nil {
-			internal.Log.Logger.Error().Err(err).Msg("failed to get image flavor")
-			return err
-		}
-	} else {
-		// Before 3.2.x the kairos info was in /etc/os-release
-		flavor, err = sdkUtils.OSRelease("FLAVOR", filepath.Join(r.Source, "etc/os-release"))
-		if err != nil {
-			internal.Log.Logger.Error().Err(err).Msg("failed to get image label")
-			return err
-		}
-		label, err = sdkUtils.OSRelease("IMAGE_LABEL", filepath.Join(r.Source, "etc/os-release"))
-		if err != nil {
-			internal.Log.Logger.Error().Err(err).Msg("failed to get image label")
-			return err
-		}
-	}
-
-	// name of isos for example so we store them equally:
-	// kairos-ubuntu-24.04-core-amd64-generic-v3.2.4.iso
-	outputName := fmt.Sprintf("kairos-%s-%s.raw", flavor, label)
+	outputName := utils.NameFromRootfs(r.Source) + ".raw"
 	internal.Log.Logger.Debug().Str("name", outputName).Msg("Got output name")
 
 	internal.Log.Logger.Info().Msg("Creating RECOVERY image")

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -422,7 +422,7 @@ func (r *RawImage) Build() error {
 	defer r.config.Fs.RemoveAll(r.TempDir())
 
 	// Get the artifact version from the rootfs
-	outputName := utils.NameFromRootfs(r.Source) + ".raw"
+	outputName := fmt.Sprintf("%s-%s.raw", constants.KairosDefaultArtifactName, utils.NameFromRootfs(r.Source))
 	internal.Log.Logger.Debug().Str("name", outputName).Msg("Got output name")
 
 	internal.Log.Logger.Info().Msg("Creating RECOVERY image")

--- a/pkg/schema/config.go
+++ b/pkg/schema/config.go
@@ -60,6 +60,7 @@ type NetBoot struct {
 type ISO struct {
 	DataPath      string `yaml:"data"`
 	Name          string `yaml:"name"` // Final artifact base name
+	OverrideName  string `yaml:"override_name"`
 	IncludeDate   bool   `yaml:"include_date"`
 	OverlayISO    string `yaml:"overlay_iso"`
 	OverlayRootfs string `yaml:"overlay_rootfs"`

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -365,6 +365,9 @@ func GetArchFromRootfs(rootfs string, l sdkTypes.KairosLogger) (string, error) {
 // for containers we store them under the distro name (ubuntu, opensuse, etc) as the repo name
 // and then the rest is for the tag
 // quay.io/kairos/ubuntu:24.04-core-amd64-generic-v3.2.4
+// so in here we only return the shared part of the name
+// its the callers responsibility to add the rest of the name if its building an iso or raw image
+// also, no extension is added to the name, so its up to the caller to add it
 func NameFromRootfs(rootfs string) string {
 	var label string
 	var flavor string
@@ -390,5 +393,5 @@ func NameFromRootfs(rootfs string) string {
 		}
 	}
 
-	return fmt.Sprintf("kairos-%s-%s", flavor, label)
+	return fmt.Sprintf("%s-%s", flavor, label)
 }


### PR DESCRIPTION
This was already done in the raw image but the iso defaulted to kairos.iso when we had all the info around in the rootfs

This patch just converges the output name for both artifacts into a single method so we produce constant names from a given rootfs values

Still allows to override the iso image name