### PR TITLE
Improve RPI support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN luet install -y system/systemd-boot
 
 ## RPI64
 ## Both arches have the same package files so no matter the arch here.
-RUN luet install -y firmware/u-boot firmware/rpi --system-target /rpi/
+RUN luet install -y firmware//u-boot-rpi64 firmware/rpi --system-target /rpi/
 
 ## PineBook64 Pro
 RUN luet install -y arm-vendor-blob/u-boot-rockchip --system-target /pinebookpro/u-boot

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN luet install -y system/systemd-boot
 
 ## RPI64
 ## Both arches have the same package files so no matter the arch here.
-RUN luet install -y firmware//u-boot-rpi64 firmware/rpi --system-target /rpi/
+RUN luet install -y firmware/u-boot-rpi64 firmware/rpi --system-target /rpi/
 
 ## PineBook64 Pro
 RUN luet install -y arm-vendor-blob/u-boot-rockchip --system-target /pinebookpro/u-boot

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN luet install -y system/systemd-boot
 
 ## RPI64
 ## Both arches have the same package files so no matter the arch here.
-RUN luet install -y firmware/rpi --system-target /rpi/
+RUN luet install -y firmware/u-boot firmware/rpi --system-target /rpi/
 
 ## PineBook64 Pro
 RUN luet install -y arm-vendor-blob/u-boot-rockchip --system-target /pinebookpro/u-boot

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN luet repo update
 RUN luet install -y system/systemd-boot
 
 ## RPI64
-RUN luet install -y firmware/u-boot-rpi64 firmware/raspberrypi-firmware firmware/raspberrypi-firmware-config firmware/raspberrypi-firmware-dt --system-target /rpi/
+## Both arches have the same package files so no matter the arch here.
+RUN luet install -y firmware/rpi --system-target /rpi/
 
 ## PineBook64 Pro
 RUN luet install -y arm-vendor-blob/u-boot-rockchip --system-target /pinebookpro/u-boot

--- a/image-assets/luet-amd64.yaml
+++ b/image-assets/luet-amd64.yaml
@@ -13,4 +13,4 @@ repositories:
     urls:
       - "quay.io/kairos/packages"
     # renovate: datasource=docker depName=quay.io/kairos/packages
-    reference: 202503030850-git5cf196f2-repository.yaml
+    reference: 202503031305-git39d38b2e-repository.yaml

--- a/image-assets/luet-arm64.yaml
+++ b/image-assets/luet-arm64.yaml
@@ -13,4 +13,4 @@ repositories:
     urls:
       - "quay.io/kairos/packages-arm64"
     # renovate: datasource=docker depName=quay.io/kairos/packages-arm64
-    reference: 202503030849-git5cf196f2-repository.yaml
+    reference: 202503031304-git39d38b2e-repository.yaml

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -390,7 +390,7 @@ func (r *RawImage) createEFIPartitionImage() (string, error) {
 		File:       filepath.Join(r.TempDir(), "efi.img"),
 		FS:         agentConstants.EfiFs,
 		Label:      agentConstants.EfiLabel,
-		Size:       agentConstants.EfiSize * 2,
+		Size:       agentConstants.EfiSize,
 		Source:     v1.NewDirSrc(tmpDirEfi),
 		MountPoint: tmpDirEfiMount,
 	}

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -377,11 +377,11 @@ func (r *RawImage) createEFIPartitionImage() (string, error) {
 		return "", err
 	}
 
-	// Do board specific stuff
-	if model == "rpi4" {
-		err = copyFirmwareRpi4(tmpDirEfi)
+	// Copy RPI firmware, should be valid for rpi3,4,5 and beyond if the rpi firmware files are updated
+	if strings.HasPrefix(model, "rpi") {
+		err = copyFirmwareRpi(tmpDirEfi)
 		if err != nil {
-			internal.Log.Logger.Error().Err(err).Msg("failed to copy rpi4 firmware")
+			internal.Log.Logger.Error().Err(err).Msg("failed to copy rpi firmware")
 			return "", err
 		}
 	}

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -390,7 +390,7 @@ func (r *RawImage) createEFIPartitionImage() (string, error) {
 		File:       filepath.Join(r.TempDir(), "efi.img"),
 		FS:         agentConstants.EfiFs,
 		Label:      agentConstants.EfiLabel,
-		Size:       agentConstants.EfiSize,
+		Size:       agentConstants.EfiSize * 2,
 		Source:     v1.NewDirSrc(tmpDirEfi),
 		MountPoint: tmpDirEfiMount,
 	}

--- a/pkg/ops/rawDiskOutput.go
+++ b/pkg/ops/rawDiskOutput.go
@@ -327,11 +327,11 @@ func chsCalculation(sectors uint64) chs {
 	}
 }
 
-// Model specific funtions
+// Model specific functions
 
-// copyFirmwareRpi4 will copy the proper firmware files for a Raspberry Pi 4 into the EFI partition
-func copyFirmwareRpi4(target string) error {
-	internal.Log.Logger.Info().Str("target", target).Msg("Copying Raspberry Pi 4 firmware")
+// copyFirmwareRpi will copy the proper firmware files for a Raspberry Pi into the EFI partition
+func copyFirmwareRpi(target string) error {
+	internal.Log.Logger.Info().Str("target", target).Msg("Copying Raspberry Pi firmware")
 	// Copy the firmware files from /rpi/ into target
 	return utils.CopyDir("/rpi/", target)
 }


### PR DESCRIPTION
Use a single package for all firmware config
Use the files directly from upstream
Improve support for building rpi models, the firmware files should support all current rpi models


Co-Authored-By:  Lukasz Zajaczkowski @zreigz