### PR TITLE
Merge all luet packages into arch dirs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,10 +84,10 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          tags: auroraboot:latest
+          tags: auroraboot:test
       - name: Run e2e tests
         run: |
-          sudo go run github.com/onsi/ginkgo/v2/ginkgo -v -r -p --covermode=atomic --coverprofile=coverage.out --timeout=2h --label-filter "e2e" ./e2e
+          go run github.com/onsi/ginkgo/v2/ginkgo -v -r -p --covermode=atomic --coverprofile=coverage.out --timeout=2h --label-filter "e2e" ./e2e
       - name: Codecov
         uses: codecov/codecov-action@v5
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM fedora:$FEDORA_VERSION AS default
 RUN dnf -y update
 ## ISO+ Arm image + Netboot + cloud images Build depedencies
 RUN dnf in -y bc jq genisoimage docker sudo parted e2fsprogs erofs-utils binutils curl util-linux udev rsync \
-    dosfstools mtools xorriso lvm2 zstd sbsigntools squashfs-tools kpartx grub2
+    dosfstools mtools xorriso lvm2 zstd sbsigntools squashfs-tools kpartx grub2 openssl
 
 COPY --from=luet /usr/bin/luet /usr/bin/luet
 ENV LUET_NOLOCK=true
@@ -65,6 +65,10 @@ RUN luet install -y system/kairos-agent
 
 # remove luet tmp files. Side effect of setting the system-target is that it treats it as a root fs
 # so temporal files are stored in each dir
+RUN rm -Rf /arm/systemd-boot/var/tmp
+RUN rm -Rf /amd/systemd-boot/var/tmp
+RUN rm -Rf /arm/systemd-boot/var/cache
+RUN rm -Rf /amd/systemd-boot/var/cache
 RUN rm -Rf /arm/rpi/var/tmp
 RUN rm -Rf /arm/rpi/var/cache
 RUN rm -Rf /arm/pinebookpro/var/tmp
@@ -80,6 +84,8 @@ RUN rm -Rf /amd/raw/grubartifacts/var/cache
 RUN rm -Rf /arm/raw/grubefi/var/tmp
 RUN rm -Rf /arm/raw/grubefi/var/cache
 # Remove the var dir if empty
+RUN rm -d /arm/systemd-boot/var || true
+RUN rm -d /amd/systemd-boot/var || true
 RUN rm -d /arm/rpi/var || true
 RUN rm -d /arm/pinebookpro/var || true
 RUN rm -d /arm/odroid-c2/var || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,17 +35,19 @@ RUN cp /tmp/luet-${TARGETARCH}.yaml /etc/luet/luet.yaml
 # https://github.com/containerd/containerd/blob/7c3aca7a610df76212171d200ca3811ff6096eb8/archive/compression/compression.go#L50
 ENV CONTAINERD_DISABLE_PIGZ=1
 RUN luet repo update
-RUN luet install -y system/systemd-boot
+## Each arch has its own systemd-boot artifacts, we should ship both in both images for multi-arch build support
+RUN luet install --config /tmp/luet-arm64.yaml -y system/systemd-boot --system-target /arm/systemd-boot
+RUN luet install --config /tmp/luet-amd64.yaml -y system/systemd-boot --system-target /amd/systemd-boot
 
 ## RPI64
 ## Both arches have the same package files so no matter the arch here.
-RUN luet install -y firmware/u-boot-rpi64 firmware/rpi --system-target /rpi/
+RUN luet install -y firmware/u-boot-rpi64 firmware/rpi --system-target /arm/rpi/
 
 ## PineBook64 Pro
-RUN luet install -y arm-vendor-blob/u-boot-rockchip --system-target /pinebookpro/u-boot
+RUN luet install -y arm-vendor-blob/u-boot-rockchip --system-target /arm/pinebookpro/
 
 ## Odroid fw
-RUN luet install -y firmware/odroid-c2 --system-target /firmware/odroid-c2
+RUN luet install -y firmware/odroid-c2 --system-target /arm/odroid-c2
 
 ## RAW images for arm64
 
@@ -54,7 +56,7 @@ RUN luet install --config /tmp/luet-arm64.yaml -y static/grub-efi --system-targe
 RUN luet install --config /tmp/luet-arm64.yaml -y static/grub-config --system-target /arm/raw/grubconfig
 # Orin uses these artifacts. Alpine uses these artifacts for fallback efi values
 RUN luet install --config /tmp/luet-arm64.yaml -y static/grub-artifacts --system-target /arm/raw/grubartifacts
-# You can build amd64 raw images for alpine so....we need this.
+# You can build amd64 raw images for alpine so....we need this in both images
 RUN luet install --config /tmp/luet-amd64.yaml -y static/grub-artifacts --system-target /amd/raw/grubartifacts
 
 # kairos-agent so we can use the pull-image
@@ -63,12 +65,12 @@ RUN luet install -y system/kairos-agent
 
 # remove luet tmp files. Side effect of setting the system-target is that it treats it as a root fs
 # so temporal files are stored in each dir
-RUN rm -Rf /rpi/var/tmp
-RUN rm -Rf /rpi/var/cache
-RUN rm -Rf /pinebookpro/u-boot/var/tmp
-RUN rm -Rf /pinebookpro/u-boot/var/cache
-RUN rm -Rf /firmware/odroid-c2/var/tmp
-RUN rm -Rf /firmware/odroid-c2/var/cache
+RUN rm -Rf /arm/rpi/var/tmp
+RUN rm -Rf /arm/rpi/var/cache
+RUN rm -Rf /arm/pinebookpro/var/tmp
+RUN rm -Rf /arm/pinebookpro/var/cache
+RUN rm -Rf /arm/odroid-c2/var/tmp
+RUN rm -Rf /arm/odroid-c2/var/cache
 RUN rm -Rf /arm/raw/grubconfig/var/tmp
 RUN rm -Rf /arm/raw/grubconfig/var/cache
 RUN rm -Rf /arm/raw/grubartifacts/var/tmp
@@ -78,9 +80,9 @@ RUN rm -Rf /amd/raw/grubartifacts/var/cache
 RUN rm -Rf /arm/raw/grubefi/var/tmp
 RUN rm -Rf /arm/raw/grubefi/var/cache
 # Remove the var dir if empty
-RUN rm -d /rpi/var || true
-RUN rm -d /pinebookpro/u-boot/var || true
-RUN rm -d /firmware/odroid-c2/var || true
+RUN rm -d /arm/rpi/var || true
+RUN rm -d /arm/pinebookpro/var || true
+RUN rm -d /arm/odroid-c2/var || true
 RUN rm -d /arm/raw/grubconfig/var || true
 RUN rm -d /arm/raw/grubartifacts/var || true
 RUN rm -d /amd/raw/grubartifacts/var || true

--- a/e2e/build_uki_test.go
+++ b/e2e/build_uki_test.go
@@ -27,29 +27,12 @@ var _ = Describe("build-uki", Label("build-uki", "e2e"), func() {
 		Expect(err).ToNot(HaveOccurred())
 		keysDir = filepath.Join(currentDir, "assets", "keys")
 		Expect(os.MkdirAll(keysDir, 0755)).ToNot(HaveOccurred())
-
-		auroraboot = NewAuroraboot("quay.io/kairos/osbuilder-tools", resultDir, keysDir)
+		auroraboot = NewAuroraboot(resultDir, keysDir)
 		image = fmt.Sprintf("quay.io/kairos/fedora:38-core-amd64-generic-%s", kairosVersion)
 	})
 
 	AfterEach(func() {
 		os.RemoveAll(resultDir)
-		auroraboot.Cleanup()
-	})
-
-	When("some dependency is missing", func() {
-		BeforeEach(func() {
-			auroraboot = NewAuroraboot("busybox", resultDir, keysDir)
-		})
-
-		It("returns an error about missing deps", func() {
-			out, err := auroraboot.Run("build-uki", "--output-dir", resultDir, "-k", keysDir, "--output-type", "iso", image)
-			Expect(err).To(HaveOccurred(), out)
-			Expect(out).To(Or(
-				MatchRegexp("executable file not found in \\$PATH"),
-				MatchRegexp("no such file or directory"),
-			))
-		})
 	})
 
 	Describe("single-efi-cmdline", func() {
@@ -62,12 +45,12 @@ var _ = Describe("build-uki", Label("build-uki", "e2e"), func() {
 
 		It("creates additional .efi and .conf files", func() {
 			content := listEfiFiles(auroraboot, resultFile)
-			Expect(string(content)).To(MatchRegexp("my_entry.efi"))
-			Expect(string(content)).To(MatchRegexp("my_other_entry.efi"))
+			Expect(content).To(MatchRegexp("my_entry.efi"))
+			Expect(content).To(MatchRegexp("my_other_entry.efi"))
 
 			content = listConfFiles(auroraboot, resultFile)
-			Expect(string(content)).To(MatchRegexp("my_entry.conf"))
-			Expect(string(content)).To(MatchRegexp("my_other_entry.conf"))
+			Expect(content).To(MatchRegexp("my_entry.conf"))
+			Expect(content).To(MatchRegexp("my_other_entry.conf"))
 		})
 	})
 
@@ -81,7 +64,7 @@ var _ = Describe("build-uki", Label("build-uki", "e2e"), func() {
 			It("sets the secure-boot-enroll correctly", func() {
 				By("checking if the default value for secure-boot-enroll is set")
 				content := readLoaderConf(auroraboot, resultFile)
-				Expect(string(content)).To(MatchRegexp("secure-boot-enroll if-safe"))
+				Expect(content).To(MatchRegexp("secure-boot-enroll if-safe"))
 			})
 		})
 
@@ -94,7 +77,7 @@ var _ = Describe("build-uki", Label("build-uki", "e2e"), func() {
 			It("sets the secure-boot-enroll correctly", func() {
 				By("checking if the user value for secure-boot-enroll is set")
 				content := readLoaderConf(auroraboot, resultFile)
-				Expect(string(content)).To(MatchRegexp("secure-boot-enroll manual"))
+				Expect(content).To(MatchRegexp("secure-boot-enroll manual"))
 			})
 		})
 	})

--- a/e2e/disks_test.go
+++ b/e2e/disks_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Disk image generation", Label("raw-disks", "e2e"), Serial, Ord
 		err = WriteConfig("test", tempDir)
 		Expect(err).ToNot(HaveOccurred())
 
-		aurora = NewAuroraboot("auroraboot")
+		aurora = NewAuroraboot()
 		// Map the config.yaml file to the container and the temp dir to the state dir
 		aurora.ManualDirs = map[string]string{
 			fmt.Sprintf("%s/config.yaml", tempDir): "/config.yaml",
@@ -43,7 +43,6 @@ var _ = Describe("Disk image generation", Label("raw-disks", "e2e"), Serial, Ord
 
 	AfterEach(func() {
 		os.RemoveAll(tempDir)
-		aurora.Cleanup()
 	})
 
 	Context("source is an ISO", func() {

--- a/e2e/genkey_test.go
+++ b/e2e/genkey_test.go
@@ -28,12 +28,11 @@ var _ = Describe("genkey", Label("genkey", "e2e"), func() {
 		Expect(err).ToNot(HaveOccurred())
 		asusKeysDir = filepath.Join(currentDir, "assets", "asus-PN64-vendor-keys")
 
-		auroraboot = NewAuroraboot("quay.io/kairos/osbuilder-tools", resultDir, asusKeysDir)
+		auroraboot = NewAuroraboot(resultDir, asusKeysDir)
 	})
 
 	AfterEach(func() {
 		os.RemoveAll(resultDir)
-		auroraboot.Cleanup()
 	})
 
 	When("expiration-in-days is not specified", func() {

--- a/e2e/iso_test.go
+++ b/e2e/iso_test.go
@@ -22,7 +22,7 @@ var _ = Describe("ISO image generation", Label("iso", "e2e"), func() {
 
 			err = WriteConfig("test", tempDir)
 			Expect(err).ToNot(HaveOccurred())
-			aurora = NewAuroraboot("auroraboot")
+			aurora = NewAuroraboot()
 			// Map the config.yaml file to the container and the temp dir to the state dir
 			aurora.ManualDirs = map[string]string{
 				fmt.Sprintf("%s/config.yaml", tempDir): "/config.yaml",
@@ -32,7 +32,6 @@ var _ = Describe("ISO image generation", Label("iso", "e2e"), func() {
 
 		AfterEach(func() {
 			os.RemoveAll(tempDir)
-			aurora.Cleanup()
 		})
 
 		It("generate an iso image from a container", func() {

--- a/image-assets/luet-amd64.yaml
+++ b/image-assets/luet-amd64.yaml
@@ -13,4 +13,4 @@ repositories:
     urls:
       - "quay.io/kairos/packages"
     # renovate: datasource=docker depName=quay.io/kairos/packages
-    reference: 202503051120-git5dc408ba-repository.yaml
+    reference: 202503051357-git48eee6e8-repository.yaml

--- a/image-assets/luet-arm64.yaml
+++ b/image-assets/luet-arm64.yaml
@@ -13,4 +13,4 @@ repositories:
     urls:
       - "quay.io/kairos/packages-arm64"
     # renovate: datasource=docker depName=quay.io/kairos/packages-arm64
-    reference: 202503051056-git5dc408ba-repository.yaml
+    reference: 202503051354-git48eee6e8-repository.yaml

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,10 +81,10 @@ const (
 
 	UkiCmdline            = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 panic=5 rd.shell=0 systemd.crash_reboot=yes"
 	UkiCmdlineInstall     = "install-mode"
-	UkiSystemdBootx86     = "/usr/kairos/systemd-bootx64.efi"
-	UkiSystemdBootArm     = "/usr/kairos/systemd-bootaa64.efi"
-	UkiSystemdBootStubx86 = "/usr/kairos/linuxx64.efi.stub"
-	UkiSystemdBootStubArm = "/usr/kairos/linuxaa64.efi.stub"
+	UkiSystemdBootx86     = "/amd/systemd-boot/systemd-bootx64.efi"
+	UkiSystemdBootStubx86 = "/amd/systemd-boot/linuxx64.efi.stub"
+	UkiSystemdBootArm     = "/arm/systemd-boot/systemd-bootaa64.efi"
+	UkiSystemdBootStubArm = "/arm/systemd-boot/linuxaa64.efi.stub"
 
 	EfiFallbackNamex86 = "BOOTX64.EFI"
 	EfiFallbackNameArm = "BOOTAA64.EFI"

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -946,32 +946,33 @@ func (r *RawImage) FinalizeImage(image string) error {
 	// Do board specific stuff
 	switch model {
 	case "rpi4", "rpi3":
+		// RPI firmware is done in the EFI partition
 		internal.Log.Logger.Debug().Str("model", model).Msg("Running on RPI.")
 	case "odroid-c2":
 		internal.Log.Logger.Debug().Str("model", model).Msg("Running on Odroid-C2.")
-		err = utils.DD("/firmware/odroid-c2/bl1.bin.hardkernel", image, 1, 442, 0, 0)
+		err = utils.DD("/arm/odroid-c2/bl1.bin.hardkernel", image, 1, 442, 0, 0)
 		if err != nil {
 			internal.Log.Logger.Error().Err(err).Msg("failed to dd bl1.bin.hardkernel")
 			return err
 		}
-		err = utils.DD("/firmware/odroid-c2/bl1.bin.hardkernel", image, 512, 0, 1, 1)
+		err = utils.DD("/arm/odroid-c2/bl1.bin.hardkernel", image, 512, 0, 1, 1)
 		if err != nil {
 			internal.Log.Logger.Error().Err(err).Msg("failed to dd bl1.bin.hardkernel")
 			return err
 		}
-		err = utils.DD("/firmware/odroid-c2/u-boot.odroidc2", image, 512, 0, 0, 97)
+		err = utils.DD("/arm/odroid-c2/u-boot.odroidc2", image, 512, 0, 0, 97)
 		if err != nil {
 			internal.Log.Logger.Error().Err(err).Msg("failed to dd u-boot.odroidc2")
 			return err
 		}
 	case "pinebookpro":
 		internal.Log.Logger.Debug().Str("model", model).Msg("Running on Pinebook Pro.")
-		err = utils.DD("/pinebookpro/u-boot/usr/lib/u-boot/pinebook-pro-rk3399/idbloader.img", image, 64, 0, 0, 0)
+		err = utils.DD("/arm/pinebookpro/usr/lib/u-boot/pinebook-pro-rk3399/idbloader.img", image, 64, 0, 0, 0)
 		if err != nil {
 			internal.Log.Logger.Error().Err(err).Msg("failed to dd idbloader.img")
 			return err
 		}
-		err = utils.DD("/pinebookpro/u-boot/usr/lib/u-boot/pinebook-pro-rk3399/u-boot.itb", image, 16384, 0, 0, 0)
+		err = utils.DD("/arm/pinebookpro/usr/lib/u-boot/pinebook-pro-rk3399/u-boot.itb", image, 16384, 0, 0, 0)
 		if err != nil {
 			internal.Log.Logger.Error().Err(err).Msg("failed to dd u-boot.itb")
 			return err

--- a/pkg/ops/rawDiskOutput.go
+++ b/pkg/ops/rawDiskOutput.go
@@ -333,5 +333,5 @@ func chsCalculation(sectors uint64) chs {
 func copyFirmwareRpi(target string) error {
 	internal.Log.Logger.Info().Str("target", target).Msg("Copying Raspberry Pi firmware")
 	// Copy the firmware files from /rpi/ into target
-	return utils.CopyDir("/rpi/", target)
+	return utils.CopyDir("/arm/rpi/", target)
 }


### PR DESCRIPTION
Moves from having several dirs around to merge everything into either an arm or an amd folder.

Also installs both systemd-boot packages archs into a their own folder so we can multi arch build from any arch

This way, all the luet stuff is installed either under /arm or /amd and under that, they are either separated by board (rpi,odroid,pinebook) or raw artifacts (/arm/raw)