### PR TITLE
Bump repos and fix packages

### DIFF
--- a/image-assets/luet-amd64.yaml
+++ b/image-assets/luet-amd64.yaml
@@ -13,4 +13,4 @@ repositories:
     urls:
       - "quay.io/kairos/packages"
     # renovate: datasource=docker depName=quay.io/kairos/packages
-    reference: 202503051357-git48eee6e8-repository.yaml
+    reference: 202503171323-git8b2b3bfc-repository.yaml

--- a/image-assets/luet-arm64.yaml
+++ b/image-assets/luet-arm64.yaml
@@ -13,4 +13,4 @@ repositories:
     urls:
       - "quay.io/kairos/packages-arm64"
     # renovate: datasource=docker depName=quay.io/kairos/packages-arm64
-    reference: 202503051354-git48eee6e8-repository.yaml
+    reference: 202503171321-git8b2b3bfc-repository.yaml

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -965,12 +965,12 @@ func (r *RawImage) FinalizeImage(image string) error {
 		}
 	case "pinebookpro":
 		internal.Log.Logger.Debug().Str("model", model).Msg("Running on Pinebook Pro.")
-		err = utils.DD("/arm/pinebookpro/usr/lib/u-boot/pinebook-pro-rk3399/idbloader.img", image, 64, 0, 0, 0)
+		err = utils.DD("/arm/pinebookpro/idbloader.img", image, 64, 0, 0, 0)
 		if err != nil {
 			internal.Log.Logger.Error().Err(err).Msg("failed to dd idbloader.img")
 			return err
 		}
-		err = utils.DD("/arm/pinebookpro/usr/lib/u-boot/pinebook-pro-rk3399/u-boot.itb", image, 16384, 0, 0, 0)
+		err = utils.DD("/arm/pinebookpro/u-boot.itb", image, 16384, 0, 0, 0)
 		if err != nil {
 			internal.Log.Logger.Error().Err(err).Msg("failed to dd u-boot.itb")
 			return err


### PR DESCRIPTION
 - Fix package name for pinebookpro package
 - Fix locations for pinebook uboot
 - Move all ENV into the same place in the Dockerfile
 - Move the install to the same place in the Dockerfile
 - Remove leftovers from a wrong merge (pacakges not needed)