### PR TITLE
Don't shell out to the same binary

### DIFF
--- a/internal/web/app.go
+++ b/internal/web/app.go
@@ -202,22 +202,14 @@ func webSocketHandler(c echo.Context) error {
 		}
 
 		websocket.Message.Send(ws, "Generating raw image...")
-		err = runBashProcessWithOutput(
-			ws,
-			buildRawDisk("my-image", jobOutputDir),
-		)
-		if err != nil {
-			websocket.Message.Send(ws, fmt.Sprintf("Failed to save image: %v", err))
+		if err := buildRawDisk("my-image", jobOutputDir, ws); err != nil {
+			websocket.Message.Send(ws, fmt.Sprintf("Failed to generate raw image: %v", err))
 			return
 		}
 
 		websocket.Message.Send(ws, "Generating ISO...")
-		err = runBashProcessWithOutput(
-			ws,
-			buildISO("my-image", jobOutputDir, "custom-kairos"),
-		)
-		if err != nil {
-			websocket.Message.Send(ws, fmt.Sprintf("Failed to save image: %v", err))
+		if err := buildISO("my-image", jobOutputDir, "custom-kairos", ws); err != nil {
+			websocket.Message.Send(ws, fmt.Sprintf("Failed to generate ISO: %v", err))
 			return
 		}
 

--- a/internal/web/commands.go
+++ b/internal/web/commands.go
@@ -1,33 +1,137 @@
 package web
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os/exec"
+
+	"github.com/kairos-io/AuroraBoot/deployer"
+	"github.com/kairos-io/AuroraBoot/internal"
+	"github.com/kairos-io/AuroraBoot/pkg/schema"
+	"github.com/spectrocloud-labs/herd"
 )
 
-func buildRawDisk(containerImage, outputDir string) string {
-	return fmt.Sprintf(`auroraboot \
-	--debug  \
-	--set "disable_http_server=true" \
-	--set "disable_netboot=true" \
-	--set "container_image=%s" \
-	--set "state_dir=%s" \
-	--set "disk.raw=true" \
-	`, containerImage, outputDir)
+// WebsocketWriter wraps an io.Writer to write to a websocket
+type WebsocketWriter struct {
+	w io.Writer
 }
 
-func buildISO(containerImage, outputDir, artifactName string) string {
-	return fmt.Sprintf(`auroraboot --debug build-iso \
-	--output %s \
-	--name %s \
-	docker:%s`, outputDir, artifactName, containerImage)
+func NewWebsocketWriter(w io.Writer) *WebsocketWriter {
+	return &WebsocketWriter{w: w}
 }
 
-func buildOCI(
-	contextDir,
-	image string,
-) string {
+func (w *WebsocketWriter) Write(p []byte) (n int, err error) {
+	return w.w.Write(p)
+}
+
+func buildRawDisk(containerImage, outputDir string, ws io.Writer) error {
+	// Create a websocket writer
+	wsWriter := NewWebsocketWriter(ws)
+
+	// Set the logger to use our websocket writer
+	internal.Log.Logger = internal.Log.Logger.Output(wsWriter)
+
+	// Create the release artifact
+	artifact := schema.ReleaseArtifact{
+		ContainerImage: fmt.Sprintf("docker://%s", containerImage),
+	}
+
+	// Create the config
+	config := schema.Config{
+		State: outputDir,
+		Disk: schema.Disk{
+			EFI: true, // This is what disk.raw=true maps to
+		},
+		DisableHTTPServer: true,
+		DisableNetboot:    true,
+	}
+
+	// Create the deployer
+	d := deployer.NewDeployer(config, artifact, herd.EnableInit)
+
+	// Register the necessary steps
+	for _, step := range []func() error{
+		d.StepPrepNetbootDir,
+		d.StepPrepTmpRootDir,
+		d.StepDumpSource,
+		d.StepGenRawDisk,
+	} {
+		if err := step(); err != nil {
+			fmt.Fprintf(wsWriter, "Error registering step: %v\n", err)
+			return fmt.Errorf("error registering step: %v", err)
+		}
+	}
+
+	// Run the deployer
+	if err := d.Run(context.Background()); err != nil {
+		fmt.Fprintf(wsWriter, "Error running deployer: %v\n", err)
+		return fmt.Errorf("error running deployer: %v", err)
+	}
+
+	// Collect any errors
+	if err := d.CollectErrors(); err != nil {
+		fmt.Fprintf(wsWriter, "Error collecting errors: %v\n", err)
+		return fmt.Errorf("error collecting errors: %v", err)
+	}
+
+	return nil
+}
+
+func buildISO(containerImage, outputDir, artifactName string, ws io.Writer) error {
+	// Create a websocket writer
+	wsWriter := NewWebsocketWriter(ws)
+
+	// Set the logger to use our websocket writer
+	internal.Log.Logger = internal.Log.Logger.Output(wsWriter)
+
+	// Create the release artifact
+	artifact := schema.ReleaseArtifact{
+		ContainerImage: fmt.Sprintf("docker://%s", containerImage),
+	}
+
+	// Create the config
+	config := schema.Config{
+		State: outputDir,
+		ISO: schema.ISO{
+			OverrideName: artifactName,
+		},
+	}
+
+	// Create the deployer
+	d := deployer.NewDeployer(config, artifact, herd.EnableInit)
+
+	// Register the necessary steps
+	for _, step := range []func() error{
+		d.StepPrepNetbootDir,
+		d.StepPrepTmpRootDir,
+		d.StepPrepISODir,
+		d.StepCopyCloudConfig,
+		d.StepDumpSource,
+		d.StepGenISO,
+	} {
+		if err := step(); err != nil {
+			fmt.Fprintf(wsWriter, "Error registering step: %v\n", err)
+			return fmt.Errorf("error registering step: %v", err)
+		}
+	}
+
+	// Run the deployer
+	if err := d.Run(context.Background()); err != nil {
+		fmt.Fprintf(wsWriter, "Error running deployer: %v\n", err)
+		return fmt.Errorf("error running deployer: %v", err)
+	}
+
+	// Collect any errors
+	if err := d.CollectErrors(); err != nil {
+		fmt.Fprintf(wsWriter, "Error collecting errors: %v\n", err)
+		return fmt.Errorf("error collecting errors: %v", err)
+	}
+
+	return nil
+}
+
+func buildOCI(contextDir, image string) string {
 	return fmt.Sprintf(`docker build %s -t %s`, contextDir, image)
 }
 


### PR DESCRIPTION
calling `auroraboot` from within the `auroraboot` go binary is weird and makes development harder (since a simple `go run .` doesn't cut it, you also need to build the `auroraboot` binary and put it in the PATH). We probalby did it because of the packages not being very well structured, easily leading to circular imports.