### PR TITLE
Fix web UI builds

### DIFF
--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -2,12 +2,13 @@ package deployer
 
 import (
 	"context"
-	"github.com/hashicorp/go-multierror"
-	"github.com/kairos-io/AuroraBoot/internal"
-	"github.com/kairos-io/AuroraBoot/pkg/constants"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/kairos-io/AuroraBoot/internal"
+	"github.com/kairos-io/AuroraBoot/pkg/constants"
 
 	"github.com/kairos-io/AuroraBoot/pkg/ops"
 	"github.com/spectrocloud-labs/herd"
@@ -61,6 +62,7 @@ func (d *Deployer) StepCopyCloudConfig() error {
 	return d.Add(constants.OpCopyCloudConfig,
 		herd.WithDeps(constants.OpPrepareISO),
 		herd.WithCallback(func(ctx context.Context) error {
+			internal.Log.Logger.Info().Str("cloudConfig", d.Config.CloudConfig).Msg("Copying cloud config")
 			return os.WriteFile(d.cloudConfigPath(), []byte(d.Config.CloudConfig), 0600)
 		}))
 }

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kairos-io/AuroraBoot/deployer"
 	"github.com/kairos-io/AuroraBoot/internal"
+	"github.com/kairos-io/AuroraBoot/internal/config"
 	sdkTypes "github.com/kairos-io/kairos-sdk/types"
 	"github.com/spectrocloud-labs/herd"
 	"github.com/urfave/cli/v2"
@@ -48,7 +49,7 @@ func GetApp(version string) *cli.App {
 			if ctx.Bool("debug") {
 				internal.Log.SetLevel("debug")
 			}
-			c, r, err := ReadConfig(ctx.Args().First(), ctx.String("cloud-config"), ctx.StringSlice("set"))
+			c, r, err := config.ReadConfig(ctx.Args().First(), ctx.String("cloud-config"), ctx.StringSlice("set"))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/kairos-io/AuroraBoot/deployer"
+	"github.com/kairos-io/AuroraBoot/internal/config"
 	"github.com/kairos-io/AuroraBoot/pkg/schema"
 	"github.com/spectrocloud-labs/herd"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 var BuildISOCmd = cli.Command{
@@ -68,7 +70,7 @@ var BuildISOCmd = cli.Command{
 		if ctx.String("cloud-config") != "" {
 			// we don't allow templating in this command (like we do at the top level one)
 			// TODO: Should we allow it?
-			cloudConfig, err = readCloudConfig(ctx.String("cloud-config"), map[string]interface{}{})
+			cloudConfig, err = config.ReadCloudConfig(ctx.String("cloud-config"), map[string]interface{}{})
 			if err != nil {
 				return fmt.Errorf("reading cloud config: %w", err)
 			}

--- a/internal/web/commands.go
+++ b/internal/web/commands.go
@@ -48,21 +48,18 @@ func buildRawDisk(containerImage, outputDir string, ws io.Writer) error {
 		DisableNetboot:    true,
 	}
 
-	// Create the deployer
+	// Create the deployer with proper initialization
 	d := deployer.NewDeployer(config, artifact, herd.EnableInit)
 
-	// Register the necessary steps
-	for _, step := range []func() error{
-		d.StepPrepNetbootDir,
-		d.StepPrepTmpRootDir,
-		d.StepDumpSource,
-		d.StepGenRawDisk,
-	} {
-		if err := step(); err != nil {
-			fmt.Fprintf(wsWriter, "Error registering step: %v\n", err)
-			return fmt.Errorf("error registering step: %v", err)
-		}
+	// Register all steps
+	err := deployer.RegisterAll(d)
+	if err != nil {
+		fmt.Fprintf(wsWriter, "Error registering steps: %v\n", err)
+		return fmt.Errorf("error registering steps: %v", err)
 	}
+
+	// Write the DAG for debugging
+	d.WriteDag()
 
 	// Run the deployer
 	if err := d.Run(context.Background()); err != nil {
@@ -98,27 +95,24 @@ func buildISO(containerImage, outputDir, artifactName string, ws io.Writer) erro
 		return fmt.Errorf("error reading config: %v", err)
 	}
 
-	// Override the state and ISO name
+	// Override the state and ISO name, and ensure netboot is disabled
 	config.State = outputDir
 	config.ISO.OverrideName = artifactName
+	config.DisableNetboot = true
+	config.DisableHTTPServer = true
 
-	// Create the deployer
+	// Create the deployer with proper initialization
 	d := deployer.NewDeployer(*config, artifact, herd.EnableInit)
 
-	// Register the necessary steps
-	for _, step := range []func() error{
-		d.StepPrepNetbootDir,
-		d.StepPrepTmpRootDir,
-		d.StepPrepISODir,
-		d.StepCopyCloudConfig,
-		d.StepDumpSource,
-		d.StepGenISO,
-	} {
-		if err := step(); err != nil {
-			fmt.Fprintf(wsWriter, "Error registering step: %v\n", err)
-			return fmt.Errorf("error registering step: %v", err)
-		}
+	// Register all steps
+	err = deployer.RegisterAll(d)
+	if err != nil {
+		fmt.Fprintf(wsWriter, "Error registering steps: %v\n", err)
+		return fmt.Errorf("error registering steps: %v", err)
 	}
+
+	// Write the DAG for debugging
+	d.WriteDag()
 
 	// Run the deployer
 	if err := d.Run(context.Background()); err != nil {

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -3,6 +3,11 @@ package ops
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
 	"github.com/diskfs/go-diskfs"
 	fileBackend "github.com/diskfs/go-diskfs/backend/file"
 	"github.com/diskfs/go-diskfs/partition"
@@ -20,10 +25,6 @@ import (
 	sdkUtils "github.com/kairos-io/kairos-sdk/utils"
 	"github.com/twpayne/go-vfs/v5"
 	"golang.org/x/sys/unix"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 )
 
 // What it does


### PR DESCRIPTION
The builds where broken since we stopped shelling out to the same binary: https://github.com/kairos-io/AuroraBoot/pull/258

because the DAG we build didn't have the step to copy the cloud config in place. I tried to "cherry-pick" only the relevant steps but I can't get a working DAG. I decided to just call RegisterAll and disable what's possible using conditions like `DisableNetboot`.

