### PR TITLE
Change NameFromRootfs based on naming convention

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -4,13 +4,14 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
-	"github.com/joho/godotenv"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/joho/godotenv"
 
 	containerdCompression "github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -369,7 +370,8 @@ func GetArchFromRootfs(rootfs string, l sdkTypes.KairosLogger) (string, error) {
 // its the callers responsibility to add the rest of the name if its building an iso or raw image
 // also, no extension is added to the name, so its up to the caller to add it
 func NameFromRootfs(rootfs string) string {
-	if _, ok := os.Stat(filepath.Join(rootfs, "etc/kairos-release")); ok == nil {
+	// print the contents of the /etc/kairos-release file
+	if _, err := os.Stat(filepath.Join(rootfs, "etc/kairos-release")); err == nil {
 		flavor, err := sdkUtils.OSRelease("FLAVOR", filepath.Join(rootfs, "etc/kairos-release"))
 		if err != nil {
 			internal.Log.Logger.Error().Err(err).Msg("failed to get image flavor")
@@ -412,7 +414,7 @@ func NameFromRootfs(rootfs string) string {
 				// return normal name without k8s stuff
 				return fmt.Sprintf("%s-%s-%s-%s-%s-%s", flavor, flavorVersion, variant, arch, model, version)
 			}
-			return fmt.Sprintf("%s-%s-%s-%s-%s-%s%s", flavor, flavorVersion, variant, arch, model, k8sversion, k8sprovider)
+			return fmt.Sprintf("%s-%s-%s-%s-%s-%s-%sv%s", flavor, flavorVersion, variant, arch, model, version, k8sprovider, k8sversion)
 
 		} else {
 			return fmt.Sprintf("%s-%s-%s-%s-%s-%s", flavor, flavorVersion, variant, arch, model, version)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
@@ -241,6 +242,198 @@ var _ = Describe("Utils", Label("utils"), func() {
 			Expect(entries[0].Cmdline).To(MatchRegexp(defaultCmdline + "  key=value"))
 			Expect(entries[0].Title).To(ContainSubstring("Kairos (My Entry)"))
 			Expect(entries[0].FileName).To(Equal("My_Entry"))
+		})
+	})
+
+	Describe("NameFromRootfs", Label("NameFromRootfs"), func() {
+		var fs vfs.FS
+		var cleanup func()
+
+		BeforeEach(func() {
+			fs, cleanup, _ = vfst.NewTestFS(nil)
+			fs.Mkdir("/etc", constants.DirPerm)
+		})
+
+		AfterEach(func() {
+			cleanup()
+		})
+
+		It("correctly formats name for standard variant with k8s", func() {
+			// Create a temporary directory for our test
+			tmpDir, err := os.MkdirTemp("", "kairos-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			// Create the etc directory
+			err = os.MkdirAll(filepath.Join(tmpDir, "etc"), 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a test kairos-release file with k8s information
+			kairosRelease := `KAIROS_ARCH="amd64"
+KAIROS_BUG_REPORT_URL="https://github.com/kairos-io/kairos/issues"
+KAIROS_FAMILY="debian"
+KAIROS_FIPS="false"
+KAIROS_FLAVOR="ubuntu"
+KAIROS_FLAVOR_RELEASE="24.04"
+KAIROS_FRAMEWORK_VERSION="v2.22.0"
+KAIROS_HOME_URL="https://github.com/kairos-io/kairos"
+KAIROS_ID="kairos"
+KAIROS_ID_LIKE="kairos-standard-ubuntu-24.04"
+KAIROS_IMAGE_LABEL="24.04-standard-amd64-generic-v3.4.2"
+KAIROS_MODEL="generic"
+KAIROS_NAME="kairos-standard-ubuntu-24.04"
+KAIROS_REGISTRY_AND_ORG="quay.io/kairos"
+KAIROS_RELEASE="v3.4.2"
+KAIROS_SOFTWARE_VERSION="1.32.4+k3s1"
+KAIROS_SOFTWARE_VERSION_PREFIX="k3s"
+KAIROS_TARGETARCH="amd64"
+KAIROS_VARIANT="standard"
+KAIROS_VERSION="v3.4.2"`
+
+			err = os.WriteFile(filepath.Join(tmpDir, "etc/kairos-release"), []byte(kairosRelease), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			name := utils.NameFromRootfs(tmpDir)
+
+			Expect(name).To(Equal("ubuntu-24.04-standard-amd64-generic-v3.4.2-k3sv1.32.4+k3s1"))
+		})
+
+		It("correctly formats name for core variant without k8s", func() {
+			// Create a temporary directory for our test
+			tmpDir, err := os.MkdirTemp("", "kairos-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			// Create the etc directory
+			err = os.MkdirAll(filepath.Join(tmpDir, "etc"), 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a test kairos-release file without k8s information
+			kairosRelease := `KAIROS_ARCH="amd64"
+KAIROS_BUG_REPORT_URL="https://github.com/kairos-io/kairos/issues"
+KAIROS_FAMILY="debian"
+KAIROS_FIPS="false"
+KAIROS_FLAVOR="ubuntu"
+KAIROS_FLAVOR_RELEASE="24.04"
+KAIROS_FRAMEWORK_VERSION="v2.22.0"
+KAIROS_HOME_URL="https://github.com/kairos-io/kairos"
+KAIROS_ID="kairos"
+KAIROS_ID_LIKE="kairos-core-ubuntu-24.04"
+KAIROS_IMAGE_LABEL="24.04-core-amd64-generic-v3.4.2"
+KAIROS_MODEL="generic"
+KAIROS_NAME="kairos-core-ubuntu-24.04"
+KAIROS_REGISTRY_AND_ORG="quay.io/kairos"
+KAIROS_RELEASE="v3.4.2"
+KAIROS_TARGETARCH="amd64"
+KAIROS_VARIANT="core"
+KAIROS_VERSION="v3.4.2"`
+
+			err = os.WriteFile(filepath.Join(tmpDir, "etc/kairos-release"), []byte(kairosRelease), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			name := utils.NameFromRootfs(tmpDir)
+			Expect(name).To(Equal("ubuntu-24.04-core-amd64-generic-v3.4.2"))
+		})
+
+		It("falls back to TARGETARCH if ARCH is missing", func() {
+			tmpDir, err := os.MkdirTemp("", "kairos-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			err = os.MkdirAll(filepath.Join(tmpDir, "etc"), 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			kairosRelease := `KAIROS_FLAVOR="ubuntu"
+KAIROS_FLAVOR_RELEASE="24.04"
+KAIROS_VARIANT="core"
+KAIROS_MODEL="generic"
+KAIROS_VERSION="v3.4.2"
+KAIROS_TARGETARCH="amd64"`
+			err = os.WriteFile(filepath.Join(tmpDir, "etc/kairos-release"), []byte(kairosRelease), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			name := utils.NameFromRootfs(tmpDir)
+			// ARCH is missing, should use TARGETARCH
+			Expect(name).To(ContainSubstring("amd64"))
+		})
+
+		It("falls back to non-k8s name if k8s provider is missing", func() {
+			tmpDir, err := os.MkdirTemp("", "kairos-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			err = os.MkdirAll(filepath.Join(tmpDir, "etc"), 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			kairosRelease := `KAIROS_FLAVOR="ubuntu"
+KAIROS_FLAVOR_RELEASE="24.04"
+KAIROS_VARIANT="standard"
+KAIROS_MODEL="generic"
+KAIROS_VERSION="v3.4.2"
+KAIROS_ARCH="amd64"`
+			err = os.WriteFile(filepath.Join(tmpDir, "etc/kairos-release"), []byte(kairosRelease), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			name := utils.NameFromRootfs(tmpDir)
+			// Should fall back to non-k8s name
+			Expect(name).To(Equal("ubuntu-24.04-standard-amd64-generic-v3.4.2"))
+		})
+
+		It("falls back to non-k8s name if k8s version is missing", func() {
+			tmpDir, err := os.MkdirTemp("", "kairos-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			err = os.MkdirAll(filepath.Join(tmpDir, "etc"), 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			kairosRelease := `KAIROS_FLAVOR="ubuntu"
+KAIROS_FLAVOR_RELEASE="24.04"
+KAIROS_VARIANT="standard"
+KAIROS_MODEL="generic"
+KAIROS_VERSION="v3.4.2"
+KAIROS_ARCH="amd64"
+KAIROS_SOFTWARE_VERSION_PREFIX="k3s"`
+			err = os.WriteFile(filepath.Join(tmpDir, "etc/kairos-release"), []byte(kairosRelease), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			name := utils.NameFromRootfs(tmpDir)
+			// Should fall back to non-k8s name
+			Expect(name).To(Equal("ubuntu-24.04-standard-amd64-generic-v3.4.2"))
+		})
+
+		It("falls back to os-release if kairos-release does not exist", func() {
+			tmpDir, err := os.MkdirTemp("", "kairos-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			err = os.MkdirAll(filepath.Join(tmpDir, "etc"), 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			osRelease := `FLAVOR=ubuntu
+IMAGE_LABEL=custom-label`
+			err = os.WriteFile(filepath.Join(tmpDir, "etc/os-release"), []byte(osRelease), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			name := utils.NameFromRootfs(tmpDir)
+			Expect(name).To(Equal("ubuntu-custom-label"))
+		})
+
+		It("handles missing fields gracefully", func() {
+			tmpDir, err := os.MkdirTemp("", "kairos-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			err = os.MkdirAll(filepath.Join(tmpDir, "etc"), 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			kairosRelease := `KAIROS_FLAVOR="ubuntu"`
+			err = os.WriteFile(filepath.Join(tmpDir, "etc/kairos-release"), []byte(kairosRelease), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			name := utils.NameFromRootfs(tmpDir)
+			// Should not panic, may return incomplete name
+			Expect(name).To(ContainSubstring("ubuntu"))
 		})
 	})
 })


### PR DESCRIPTION
tests on kairos fail becaues it doesn't know how to read the generated tar file e.g.

```
could not parse reference: kairos-ubuntu-24.04-standard-amd64-generic-1.32.4+k3s1k3s-uki.tar
```

see https://github.com/kairos-io/kairos/actions/runs/15138956970/job/42557579069?pr=3413#step:17:219