### PR TITLE
Add missing log to build-iso

### DIFF
--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/kairos-io/AuroraBoot/internal"
+	sdkTypes "github.com/kairos-io/kairos-sdk/types"
 	"os"
 
 	"github.com/kairos-io/AuroraBoot/deployer"
@@ -50,9 +52,16 @@ var BuildISOCmd = cli.Command{
 			Name:  "overlay-iso",
 			Usage: "Path of the overlayed iso data",
 		},
+		&cli.StringFlag{
+			Name:    "loglevel",
+			Aliases: []string{"l"},
+			Usage:   "Set the log level",
+			Value:   "info",
+		},
 	},
 	ArgsUsage: "<source>",
 	Action: func(ctx *cli.Context) error {
+		internal.Log = sdkTypes.NewKairosLogger("aurora", ctx.String("loglevel"), false)
 		source := ctx.Args().Get(0)
 		if source == "" {
 			// Hack to prevent ShowAppHelpAndExit from checking only subcommands.

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -3,3 +3,7 @@ package internal
 import sdkTypes "github.com/kairos-io/kairos-sdk/types"
 
 var Log sdkTypes.KairosLogger
+
+func init() {
+	Log = sdkTypes.NewKairosLogger("aurora", "info", false)
+}

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -4,6 +4,8 @@ import sdkTypes "github.com/kairos-io/kairos-sdk/types"
 
 var Log sdkTypes.KairosLogger
 
+// The init function initializes the default logger for the package.
+// This ensures that logging is configured and ready for use throughout the package.
 func init() {
 	Log = sdkTypes.NewKairosLogger("aurora", "info", false)
 }


### PR DESCRIPTION
Somehow we missed initializing the log when running the build-iso command so there was no logging done at all.

This adds the logging init back, always inits the log in case we forgot again and adds the loglevel flag to build-iso