### PR TITLE
Several fixes to Aurora

### DIFF
--- a/deployer/register.go
+++ b/deployer/register.go
@@ -19,7 +19,6 @@ func RegisterAll(d *Deployer) error {
 		d.StepDownloadISO,
 		d.StepExtractNetboot,
 		// Ops to generate RAW disk images
-		d.StepExtractSquashFS,
 		d.StepGenRawDisk,
 		d.StepGenMBRRawDisk,
 		d.StepConvertGCE,

--- a/deployer/register.go
+++ b/deployer/register.go
@@ -10,19 +10,14 @@ import (
 // This registers all steps for the top level Auroraboot command.
 func RegisterAll(d *Deployer) error {
 	for _, step := range []func() error{
+		d.StepPrepDestination,
 		d.StepPrepTmpRootDir,
 		d.StepPrepNetbootDir,
-		d.StepPrepISODir,
 		d.StepCopyCloudConfig,
 		d.StepDumpSource,
 		d.StepGenISO,
-		d.StepExtractNetboot,
-		//TODO: add Validate step
-		// Ops to download from releases
-		d.StepDownloadInitrd,
-		d.StepDownloadKernel,
-		d.StepDownloadSquashFS,
 		d.StepDownloadISO,
+		d.StepExtractNetboot,
 		// Ops to generate RAW disk images
 		d.StepExtractSquashFS,
 		d.StepGenRawDisk,

--- a/e2e/iso_test.go
+++ b/e2e/iso_test.go
@@ -87,7 +87,7 @@ var _ = Describe("ISO image generation", Label("iso", "e2e"), func() {
 			Expect(out).To(ContainSubstring("inject-cloud-config"), out)
 			Expect(out).ToNot(ContainSubstring("build-arm-image"), out)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = os.Stat(filepath.Join(tempDir, "kairos.iso.custom.iso"))
+			_, err = os.Stat(filepath.Join(tempDir, "kairos.iso"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kairos-io/AuroraBoot
 
-go 1.24.2
+go 1.24.4
 
 // https://github.com/golang/go/blob/583d750fa119d504686c737be6a898994b674b69/src/crypto/x509/parser.go#L1014-L1018
 // For keys with negative serial number:

--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -105,6 +105,10 @@ var BuildISOCmd = cli.Command{
 			CloudConfig: cloudConfig,
 		}
 
+		if c.State == "" {
+			c.State = "/tmp/auroraboot"
+		}
+
 		d := deployer.NewDeployer(c, r, herd.EnableInit)
 		for _, step := range []func() error{
 			d.StepPrepDestination,

--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -107,9 +107,9 @@ var BuildISOCmd = cli.Command{
 
 		d := deployer.NewDeployer(c, r, herd.EnableInit)
 		for _, step := range []func() error{
+			d.StepPrepDestination,
 			d.StepPrepNetbootDir,
 			d.StepPrepTmpRootDir,
-			d.StepPrepISODir,
 			d.StepCopyCloudConfig,
 			d.StepDumpSource,
 			d.StepGenISO,

--- a/internal/cmd/netboot.go
+++ b/internal/cmd/netboot.go
@@ -50,7 +50,10 @@ var NetBootCmd = cli.Command{
 		isoGet := func() string {
 			return iso
 		}
-		f := ops.ExtractNetboot(isoGet, output, name)
+		outputGet := func() string {
+			return output
+		}
+		f := ops.ExtractNetboot(isoGet, outputGet, name)
 		return f(c.Context)
 	},
 }

--- a/internal/cmd/netboot.go
+++ b/internal/cmd/netboot.go
@@ -47,8 +47,10 @@ var NetBootCmd = cli.Command{
 			loglevel = "debug"
 		}
 		internal.Log = types.NewKairosLogger("AuroraBoot", loglevel, false)
-
-		f := ops.ExtractNetboot(iso, output, name)
+		isoGet := func() string {
+			return iso
+		}
+		f := ops.ExtractNetboot(isoGet, output, name)
 		return f(c.Context)
 	},
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -141,17 +141,14 @@ func GetDefaultSquashfsOptions() []string {
 
 // Ops constants
 const (
-	OpDownloadISO     = "download-iso"
-	OpCopyCloudConfig = "copy-cloud-config"
-	OpPrepareISO      = "prepare-iso"
-	OpStartHTTPServer = "start-httpserver"
-	OpInjectCC        = "inject-cloud-config"
+	OpDownloadISO        = "download-iso"
+	OpCopyCloudConfig    = "copy-cloud-config"
+	OpPrepareDestination = "prepare-destination"
+	OpStartHTTPServer    = "start-httpserver"
+	OpInjectCC           = "inject-cloud-config"
 
-	OpDownloadInitrd   = "download-initrd"
-	OpDownloadKernel   = "download-kernel"
-	OpDownloadSquashFS = "download-squashfs"
-	OpPrepareNetboot   = "prepare-netboot"
-	OpStartNetboot     = "start-netboot"
+	OpPrepareNetboot = "prepare-netboot"
+	OpStartNetboot   = "start-netboot"
 
 	OpDumpSource     = "dump-source"
 	OpGenISO         = "gen-iso"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -158,8 +158,6 @@ const (
 	OpGenEFIRawDisk  = "gen-raw-efi-disk"
 	OpGenBIOSRawDisk = "gen-raw-bios-disk"
 
-	OpExtractSquashFS = "extract-squashfs"
-
 	OpConvertGCE = "convert-gce"
 	OpConvertVHD = "convert-vhd"
 )

--- a/pkg/ops/container.go
+++ b/pkg/ops/container.go
@@ -16,6 +16,9 @@ import (
 func DumpSource(image string, dstFunc valueGetOnCall) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		dst := dstFunc()
+		if image == "" {
+			return fmt.Errorf("image source is empty, cannot dump to %s", dst)
+		}
 		cfg := NewConfig(
 			WithImageExtractor(v1.OCIImageExtractor{}),
 			WithLogger(internal.Log),

--- a/pkg/ops/container.go
+++ b/pkg/ops/container.go
@@ -13,8 +13,9 @@ import (
 // or simply copies the directory to the destination.
 // Supports these prefixes:
 // https://github.com/kairos-io/kairos-agent/blob/1e81cdef38677c8a36cae50d3334559976f66481/pkg/types/v1/common.go#L30-L33
-func DumpSource(image, dst string) func(ctx context.Context) error {
+func DumpSource(image string, dstFunc valueGetOnCall) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
+		dst := dstFunc()
 		cfg := NewConfig(
 			WithImageExtractor(v1.OCIImageExtractor{}),
 			WithLogger(internal.Log),

--- a/pkg/ops/disks.go
+++ b/pkg/ops/disks.go
@@ -38,8 +38,10 @@ func GenBiosRawDisk(src, dst string, size uint64, stateSize int64) func(ctx cont
 	}
 }
 
-func ExtractSquashFS(src, dst string) func(ctx context.Context) error {
+func ExtractSquashFS(srcFunc, dstFunc valueGetOnCall) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
+		src := srcFunc()
+		dst := dstFunc()
 		tmp, err := os.MkdirTemp("", "gendisk")
 		if err != nil {
 			return err

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -109,8 +109,10 @@ func NewConfig(opts ...GenericOptions) *agentconfig.Config {
 }
 
 // GenISO generates an ISO from a rootfs, and stores results in dst
-func GenISO(src, dst string, i schema.ISO) func(ctx context.Context) error {
+func GenISO(srcFunc, dstFunc valueGetOnCall, i schema.ISO) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
+		dst := dstFunc()
+		src := srcFunc()
 		tmp, err := os.MkdirTemp("", "geniso")
 		if err != nil {
 			return err
@@ -168,8 +170,9 @@ func GenISO(src, dst string, i schema.ISO) func(ctx context.Context) error {
 	}
 }
 
-func InjectISO(dst string, isoFunc valueGetOnCall, i schema.ISO) func(ctx context.Context) error {
+func InjectISO(dstFunc, isoFunc valueGetOnCall, i schema.ISO) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
+		dst := dstFunc()
 		os.Chdir(dst)
 		isoFile := isoFunc() // call it just on time so we get the latest iso file path
 		injectedIso := isoFile + ".temp.iso"

--- a/pkg/ops/netboot.go
+++ b/pkg/ops/netboot.go
@@ -11,9 +11,15 @@ import (
 	"github.com/kairos-io/kairos-sdk/iso"
 )
 
+type isoGet func() string
+
 // ExtractNetboot extracts all the required netbooting artifacts
-func ExtractNetboot(src, dst, prefix string) func(ctx context.Context) error {
+// isoFunc is a function that returns the path to the ISO file
+// we need the function to be passed so its executed in the context of the deployer as otherwise
+// the ISO file might not be available at the time of the call
+func ExtractNetboot(isoFunc isoGet, dst, prefix string) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
+		src := isoFunc()
 		internal.Log.Logger.Info().Str("prefix", prefix).Str("source", src).Str("destination", dst).Msg("Extracting netboot artifacts")
 
 		artifact := filepath.Join(dst, fmt.Sprintf("%s.squashfs", prefix))

--- a/pkg/ops/netboot.go
+++ b/pkg/ops/netboot.go
@@ -3,6 +3,7 @@ package ops
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/kairos-io/AuroraBoot/internal"
@@ -11,15 +12,29 @@ import (
 	"github.com/kairos-io/kairos-sdk/iso"
 )
 
-type isoGet func() string
+// valueGetOnCall is a function type that returns a string value.
+// It is used to defer the retrieval of a value until the function is called,
+// allowing for dynamic values to be fetched at the time of the call.
+// This is mainly due to the fact that the deployer might not have the values available at the time of the registration,
+// but rather at the time of the call, e.g. when the ISO file is downloaded or the destination directory is created.
+type valueGetOnCall func() string
 
 // ExtractNetboot extracts all the required netbooting artifacts
 // isoFunc is a function that returns the path to the ISO file
 // we need the function to be passed so its executed in the context of the deployer as otherwise
 // the ISO file might not be available at the time of the call
-func ExtractNetboot(isoFunc isoGet, dst, prefix string) func(ctx context.Context) error {
+func ExtractNetboot(isoFunc, dstFunc valueGetOnCall, prefix string) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		src := isoFunc()
+		dst := dstFunc()
+
+		if prefix == "" {
+			prefix = "kairos"
+		}
+
+		if _, err := os.Stat(dst); err != nil && os.IsNotExist(err) {
+			return fmt.Errorf("destination directory %s does not exist: %w", dst, err)
+		}
 		internal.Log.Logger.Info().Str("prefix", prefix).Str("source", src).Str("destination", dst).Msg("Extracting netboot artifacts")
 
 		artifact := filepath.Join(dst, fmt.Sprintf("%s.squashfs", prefix))
@@ -46,9 +61,13 @@ func ExtractNetboot(isoFunc isoGet, dst, prefix string) func(ctx context.Context
 	}
 }
 
-func StartPixiecore(cloudConfigFile, squashFSfile, address, netbootPort, initrdFile, kernelFile string, nb schema.NetBoot) func(ctx context.Context) error {
+func StartPixiecore(cloudConfigFile, address, netbootPort string, squashFSfileGet, initrdFileGet, kernelFileGet valueGetOnCall, nb schema.NetBoot) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		internal.Log.Logger.Info().Msgf("Start pixiecore")
+		// do them in the context of the deployer so we can use the functions at the time of the call
+		squashFSfile := squashFSfileGet()
+		initrdFile := initrdFileGet()
+		kernelFile := kernelFileGet()
 
 		configFile := cloudConfigFile
 

--- a/pkg/ops/network.go
+++ b/pkg/ops/network.go
@@ -17,9 +17,9 @@ const (
 )
 
 // ServeArtifacts serve local artifacts as standard http server
-func ServeArtifacts(listenAddr, dir string) func(ctx context.Context) error {
+func ServeArtifacts(listenAddr string, dirFunc valueGetOnCall) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
-
+		dir := dirFunc()
 		fs := http.FileServer(http.Dir(dir))
 		http.Handle("/", fs)
 		serverOne := &http.Server{


### PR DESCRIPTION
As we can have different iso names for some of the steps, we should try to get the most recent iso based on some basic parameters:

 - default to kairos.iso so we maintain backwards compatibility
 - otherwise iterate over the dest dir to pick up whatever iso image was generated

this seems to work as expected but has the side effect of moving the iso argument to be a function so it can be executed when the step is runnig instead of being run at the start of the deployment, where the image may not be available yet.

This fixed netbooting from an iso, which is built from a container before netboot starts


Fixes (and things to test before approving):

 - Downloading from a released ISO and serving netboot artifacts: 
 ```
docker run -v "$PWD"/config.yaml:/config.yaml --rm -ti --net host aurora \
        --set "artifact_version=v3.4.2" --set "release_version=v3.4.2" \
        --set "flavor=debian" --set "flavor_release=12" \
        --set repository="kairos-io/kairos" --debug
```
 - Building an iso from a docker image and serving netboot artifacts from it:
```
docker run --rm -ti -v /var/run/docker.sock:/var/run/docker.sock --net host aurora --debug --set "container_image=ubuntu-init:24.04"
```
 - Not passing the state_dir on some calls, now it will default to a decent dir and create it beforehand
 - Raw image building. Not sure what the hell we were thinking having 2 different paths for sources? Lets keep this straigth until we can rework this but seems simple enough, raw images are generated from container sources, its like that on the docs and generating them from isos is not documented anywhere so lets drop that and keep a single straigth way of building them until we can rework the entrypoints, otherwise everything is flimsy.

Things changed:

 - Reorder some stuff, like state dir should come next os netboot and rootfs dirs and created on top of it
 - Drop some uneeded steps and merged them with existing one. Extract artifacts or download artifacts are now converged
 - Add some deps between steps, like inject cloud config for downloaded+generated isos
 - MOVE EVERYTHING RELATED TO PATHS INTO CALLBACKS. This one was biting us. We resolved all paths on the deploy step, when we generated the DAG but that didnt work as expected. Some stuff is not there as it depends on previous steps, so we have to call the path resolve inside the callback so they are done at that exact moment, not beforehand. This solved a lot of issues with passing around names and paths and artifacts.


Fixes https://github.com/kairos-io/kairos/issues/3475
Fixes https://github.com/kairos-io/kairos/issues/3425