### PR TITLE
Cleanup temp files and directories after ISO building

### DIFF
--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -758,17 +758,12 @@ func WithImageExtractor(extractor v1types.ImageExtractor) func(r *agentconfig.Co
 }
 
 func cleanupTempFiles(dst string) error {
-	if err := os.RemoveAll(filepath.Join(dst, "temp-rootfs")); err != nil {
-		return fmt.Errorf("cleanining up directory temp-rootfs: %w", err)
+	paths := []string{"temp-rootfs", "netboot", "config.yaml"}
+	for _, path := range paths {
+		fullPath := filepath.Join(dst, path)
+		if err := os.RemoveAll(fullPath); err != nil {
+			return fmt.Errorf("cleaning up %s: %w", path, err)
+		}
 	}
-
-	if err := os.RemoveAll(filepath.Join(dst, "netboot")); err != nil {
-		return fmt.Errorf("cleanining up directory netboot: %w", err)
-	}
-
-	if err := os.RemoveAll(filepath.Join(dst, "config.yaml")); err != nil {
-		return fmt.Errorf("cleanining up config.yaml: %w", err)
-	}
-
 	return nil
 }

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -166,6 +166,11 @@ func GenISO(srcFunc, dstFunc valueGetOnCall, i schema.ISO) func(ctx context.Cont
 		if err != nil {
 			internal.Log.Logger.Error().Msgf("Failed generating iso '%s' from '%s'. Error: %s", i.Name, src, err.Error())
 		}
+
+		if err := cleanupTempFiles(dst); err != nil {
+			internal.Log.Logger.Error().Msgf("Failed cleaning up temporary files. Error: %s", err.Error())
+		}
+
 		return err
 	}
 }
@@ -750,4 +755,20 @@ func WithImageExtractor(extractor v1types.ImageExtractor) func(r *agentconfig.Co
 		r.ImageExtractor = extractor
 		return nil
 	}
+}
+
+func cleanupTempFiles(dst string) error {
+	if err := os.RemoveAll(filepath.Join(dst, "temp-rootfs")); err != nil {
+		return fmt.Errorf("cleanining up directory temp-rootfs: %w", err)
+	}
+
+	if err := os.RemoveAll(filepath.Join(dst, "netboot")); err != nil {
+		return fmt.Errorf("cleanining up directory netboot: %w", err)
+	}
+
+	if err := os.RemoveAll(filepath.Join(dst, "config.yaml")); err != nil {
+		return fmt.Errorf("cleanining up config.yaml: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/kairos-io/kairos/issues/3192

Doesn't make cleanup optional to keep things simple (no additional config and such). Only cleans up when building an ISO.

Test with:

```bash
rm -rf build/*
docker build -t myauroraboot .
docker run --rm -it -v $PWD/build:/tmp/auroraboot myauroraboot build-iso quay.io/kairos/alpine:3.21-standard-amd64-generic-v3.4.2-k3sv1.32.3-k3s1
ls -liah build
```

there should only be the ISO file and the checksum file.

I'm opening for review. If we want to allow the user to keep the files around with a flag, I'll need to add that.