### PR TITLE
Cleanup dirs on ISO creation

### DIFF
--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/hashicorp/go-multierror"
 	"github.com/kairos-io/AuroraBoot/internal"
 	sdkTypes "github.com/kairos-io/kairos-sdk/types"
 	"os"
@@ -125,7 +126,15 @@ var BuildISOCmd = cli.Command{
 			return err
 		}
 
-		return d.CollectErrors()
+		err = d.CollectErrors()
+
+		errCleanup := d.CleanTmpDirs()
+		if errCleanup != nil {
+			// Append the cleanup error to the main errors if any
+			err = multierror.Append(err, errCleanup)
+		}
+
+		return err
 	},
 }
 


### PR DESCRIPTION
This uses the same function that we use on the generic deployer to cleanup stuff and append the errors to the final errors

Fixes https://github.com/kairos-io/kairos/issues/3192