### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# .github/CODEOWNERS
+* @kairos-io/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# .github/CODEOWNERS
+# This CODEOWNERS file is used to automatically assign maintainers as reviewers for all pull requests.
 * @kairos-io/maintainers


### PR DESCRIPTION
I think if we add a codeowners file we should be assigned as reviewers whenever there's a new PR. It should be one click less to do for us, but most importantly it can help with PRs from the community that we don't notice.