### PR TITLE
fix: avoid grub label clash between iso and target

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -43,7 +43,7 @@ const (
 	KairosDefaultArtifactName = "kairos"
 	IsoEFIPath                = "/boot/uefi.img"
 	EfiBootPath               = "/EFI/BOOT"
-	EfiLabel                  = "COS_GRUB"
+	EfiLabel                  = "COS_GRUB_LIVE"
 	EfiFs                     = "vfat"
 	IsoRootFile               = "rootfs.squashfs"
 	ISOLabel                  = "COS_LIVE"


### PR DESCRIPTION
By labeling the grub partition on the ISO as COS_GRUB_LIVE, we avoid any potential installation issues with kairos-agent.

Previously, both the ISO and the target partitions were labeled COS_GRUB and in some circumstances, the wrong partition was selected by the agent

Note - the other hard coded reference to COS_GRUB is in prepare_nvidia_orin_images.sh - but I don't believe this needs to change.