### PR TITLE
fix(nvidia): update fonts path

### DIFF
--- a/image-assets/prepare_nvidia_orin_images.sh
+++ b/image-assets/prepare_nvidia_orin_images.sh
@@ -41,12 +41,12 @@ cp -rfv /arm/raw/grubefi/* $WORKDIR/tmpefi
 cp -rfv /arm/raw/grubartifacts/* $WORKDIR/tmpefi/EFI/BOOT/
 mkdir -p $WORKDIR/tmpefi/EFI/BOOT/fonts
 # Move any .pf2 files from the old location if they exist
-if compgen -G "$WORKDIR/tmpefi/EFI/BOOT/*.pf2" > /dev/null; then
+if compgen -G $WORKDIR/tmpefi/EFI/BOOT/*.pf2 > /dev/null; then
     mv $WORKDIR/tmpefi/EFI/BOOT/*pf2 $WORKDIR/tmpefi/EFI/BOOT/fonts
 fi
 # Move any .pf2 files from the new grub2 location if they exist
-if compgen -G "$WORKDIR/tmpefi/EFI/BOOT/grub2/*.pf2" > /dev/null; then
-    mv $WORKDIR/tmpefi/EFI/BOOT/grub2/"*.pf2 $WORKDIR/tmpefi/EFI/BOOT/fonts
+if compgen -G $WORKDIR/tmpefi/EFI/BOOT/grub2/*.pf2 > /dev/null; then
+    mv $WORKDIR/tmpefi/EFI/BOOT/grub2/*.pf2 $WORKDIR/tmpefi/EFI/BOOT/fonts
 fi
 
 mkfs.fat -F16 -n COS_GRUB bootloader/efi.img

--- a/image-assets/prepare_nvidia_orin_images.sh
+++ b/image-assets/prepare_nvidia_orin_images.sh
@@ -40,7 +40,14 @@ truncate -s $((20*1024*1024)) bootloader/efi.img
 cp -rfv /arm/raw/grubefi/* $WORKDIR/tmpefi
 cp -rfv /arm/raw/grubartifacts/* $WORKDIR/tmpefi/EFI/BOOT/
 mkdir -p $WORKDIR/tmpefi/EFI/BOOT/fonts
-mv $WORKDIR/tmpefi/EFI/BOOT/*pf2 $WORKDIR/tmpefi/EFI/BOOT/fonts
+# Move any .pf2 files from the old location if they exist
+if compgen -G "$WORKDIR/tmpefi/EFI/BOOT/*.pf2" > /dev/null; then
+    mv $WORKDIR/tmpefi/EFI/BOOT/*pf2 $WORKDIR/tmpefi/EFI/BOOT/fonts
+fi
+# Move any .pf2 files from the new grub2 location if they exist
+if compgen -G "$WORKDIR/tmpefi/EFI/BOOT/grub2/*.pf2" > /dev/null; then
+    mv $WORKDIR/tmpefi/EFI/BOOT/grub2/"*.pf2 $WORKDIR/tmpefi/EFI/BOOT/fonts
+fi
 
 mkfs.fat -F16 -n COS_GRUB bootloader/efi.img
 mcopy -s -i bootloader/efi.img $WORKDIR/tmpefi/EFI ::EFI


### PR DESCRIPTION
Script fails due to not finding `*.pf2` files in `EFI/BOOT`.
Files seem to be in `EFI/BOOT/grub2` instead. 

I guess the path might have changed in a certain version so kept the old path to be backwards compatible.  