### PR TITLE
Lookup all keys without the KAIROS_ prefix

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -402,13 +402,13 @@ func NameFromRootfs(rootfs string) string {
 		}
 		// Add the k8s version and provider if present
 		if variant == "standard" {
-			k8sprovider, err := sdkUtils.OSRelease("KAIROS_SOFTWARE_VERSION_PREFIX", filepath.Join(rootfs, "etc/kairos-release"))
+			k8sprovider, err := sdkUtils.OSRelease("SOFTWARE_VERSION_PREFIX", filepath.Join(rootfs, "etc/kairos-release"))
 			if err != nil {
 				internal.Log.Logger.Error().Err(err).Msg("failed to get image k8s provider")
 				// return normal name without k8s stuff
 				return fmt.Sprintf("%s-%s-%s-%s-%s-%s", flavor, flavorVersion, variant, arch, model, version)
 			}
-			k8sversion, err := sdkUtils.OSRelease("KAIROS_SOFTWARE_VERSION", filepath.Join(rootfs, "etc/kairos-release"))
+			k8sversion, err := sdkUtils.OSRelease("SOFTWARE_VERSION", filepath.Join(rootfs, "etc/kairos-release"))
 			if err != nil {
 				internal.Log.Logger.Error().Err(err).Msg("failed to get image k8s version")
 				// return normal name without k8s stuff


### PR DESCRIPTION
because it's added later by the method. This doesn't seem to break anything though. Only generates an error like:

ERR failed to get image k8s provider error="KAIROS_KAIROS_SOFTWARE_VERSION_PREFIX key not found"

but the build finishes just fine.