### PR TITLE
feat(sysext): include /opt directory in systemd extensions

### DIFF
--- a/internal/cmd/sysext.go
+++ b/internal/cmd/sysext.go
@@ -34,6 +34,11 @@ var SysextCmd = cli.Command{
 			Value:   false,
 			Usage:   "Make systemctl reload the service when loading the sysext. This is useful for sysext that provide systemd service files.",
 		},
+		&cli.BoolFlag{
+			Name:  "with-opt",
+			Value: false,
+			Usage: "Include files from /opt in the sysext (requires SYSTEMD_SYSEXT_HIERARCHIES to be set to include /opt subdirs to avoid making whole /opt as read-only)",
+		},
 	),
 	Before: validateSysextConfextArgs,
 	Action: generateSysextConfext,
@@ -132,7 +137,11 @@ func generateSysextConfext(ctx *cli.Context) error {
 
 	// We only want to extract files from /usr for sysext and /etc for confext, so we create a regex allowlist based on the build type
 	// Users including /opt must set SYSTEMD_SYSEXT_HIERARCHIES accordingly.
-	allowList := regexp.MustCompile(`^usr/*|^/usr/*|^opt/*|^/opt/*`)
+	allowList := regexp.MustCompile(`^usr/*|^/usr/*`)
+	if ctx.Bool("with-opt") {
+		logger.Logger.Debug().Msg("including /opt in the allowlist")
+		allowList = regexp.MustCompile(`^usr/*|^/usr/*|^opt/*|^/opt/*`)
+	}
 	// The directory where the extension-release file will be created, based on the build type
 	extensionReleaseDir := filepath.Join(dir, "/usr/lib/extension-release.d/")
 

--- a/internal/cmd/sysext.go
+++ b/internal/cmd/sysext.go
@@ -131,7 +131,8 @@ func generateSysextConfext(ctx *cli.Context) error {
 	}
 
 	// We only want to extract files from /usr for sysext and /etc for confext, so we create a regex allowlist based on the build type
-	allowList := regexp.MustCompile(`^usr/*|^/usr/*`)
+	// Users including /opt must set SYSTEMD_SYSEXT_HIERARCHIES accordingly.
+	allowList := regexp.MustCompile(`^usr/*|^/usr/*|^opt/*|^/opt/*`)
 	// The directory where the extension-release file will be created, based on the build type
 	extensionReleaseDir := filepath.Join(dir, "/usr/lib/extension-release.d/")
 


### PR DESCRIPTION
By default, auroraboot only includes /usr hierarchy. This change allows
extracting files from /opt in addition to /usr.