### PR TITLE
Add support for Nvidia Thor cmdline options

### DIFF
--- a/pkg/constants/grub_live_bios.cfg
+++ b/pkg/constants/grub_live_bios.cfg
@@ -9,46 +9,54 @@ if [ -f ${font} ];then
     loadfont ${font}
 fi
 
+# Get model
+smbios --type 4 --get-string 5 --set model
+# For Thor we need to set the ignored clk and pd, otherwise devices will die during boot
+if test $model == "Thor"; then
+  echo "Thor device detected, setting ignored clocks and power domains and proper console output"
+  set thor_options="pd_ignore_unused clk_ignore_unused console=ttyUTC0,115200 earlycon=tegra_utc,mmio32,0xc5a0000"
+fi
+
 # Add nomodeset only on x86/amd64-class arches.
 # Template placeholders: {{NOMODESET}} and {{EXTEND_CMDLINE}} are replaced at build time.
 menuentry "Kairos" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} install-mode selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} install-mode selinux=0 $thor_options rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "Kairos (manual)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} selinux=0 $thor_options rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "kairos (interactive install)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} install-mode-interactive selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} install-mode-interactive selinux=0 $thor_options rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "Kairos (remote recovery mode)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} kairos.remote_recovery_mode selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} kairos.remote_recovery_mode selinux=0 $thor_options rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "Kairos (boot local node from livecd)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 kairos.boot_live_mode vga=795{{NOMODESET}} selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 kairos.boot_live_mode vga=795{{NOMODESET}} selinux=0 $thor_options rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "Kairos (debug)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty0 rd.debug rd.shell rd.cos.disable rd.immucore.debug vga=795{{NOMODESET}} selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty0 rd.debug rd.shell rd.cos.disable rd.immucore.debug vga=795{{NOMODESET}} selinux=0 $thor_options rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }

--- a/pkg/constants/grub_live_bios.cfg
+++ b/pkg/constants/grub_live_bios.cfg
@@ -9,46 +9,54 @@ if [ -f ${font} ];then
     loadfont ${font}
 fi
 
+# Get model
+smbios --type 4 --get-string 5 --set model
+# For Thor we need to set the ignored clk and pd, otherwise devices will die during boot
+if test $model == "Thor"; then
+  echo "Thor device detected, setting ignored clocks and power domains"
+  set unused_clocks="pd_ignore_unused clk_ignore_unused"
+fi
+
 # Add nomodeset only on x86/amd64-class arches.
 # Template placeholders: {{NOMODESET}} and {{EXTEND_CMDLINE}} are replaced at build time.
 menuentry "Kairos" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} install-mode selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} install-mode selinux=0 $unused_clocks rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "Kairos (manual)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} selinux=0 $unused_clocks rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "kairos (interactive install)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} install-mode-interactive selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} install-mode-interactive selinux=0 $unused_clocks rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "Kairos (remote recovery mode)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} kairos.remote_recovery_mode selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable vga=795{{NOMODESET}} kairos.remote_recovery_mode selinux=0 $unused_clocks rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "Kairos (boot local node from livecd)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 kairos.boot_live_mode vga=795{{NOMODESET}} selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=ttyS0 console=tty1 kairos.boot_live_mode vga=795{{NOMODESET}} selinux=0 $unused_clocks rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }
 
 menuentry "Kairos (debug)" --class os --unrestricted {
     echo Loading kernel...
-    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty0 rd.debug rd.shell rd.cos.disable rd.immucore.debug vga=795{{NOMODESET}} selinux=0 rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+    linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 console=tty0 rd.debug rd.shell rd.cos.disable rd.immucore.debug vga=795{{NOMODESET}} selinux=0 $unused_clocks rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
     echo Loading initrd...
     initrd ($root)/boot/initrd
 }


### PR DESCRIPTION
While console options are not strictly needed, the ignore unused options should be always used, otherwise the kernel will shut down those devices and we wont be able to boot properly