### PR TITLE
feat: extraCmdline support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "${PORT:-9099}:8080"
     volumes:
       - auroraboot-data:/data
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${AURORABOOT_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
     environment:
       - AURORABOOT_URL=${AURORABOOT_URL:-}
       - AURORABOOT_ADMIN_PASSWORD=${ADMIN_PASSWORD:-}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1150,6 +1150,9 @@ const docTemplate = `{
                 "overlayRootfs": {
                     "type": "string"
                 },
+                "extendCmdline": {
+                    "type": "string"
+                },
                 "provisioning": {
                     "$ref": "#/definitions/handlers.APIArtifactProvisioning"
                 },
@@ -1406,6 +1409,9 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "overlayRootfs": {
+                    "type": "string"
+                },
+                "extendCmdline": {
                     "type": "string"
                 },
                 "phase": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1143,6 +1143,9 @@
                 "overlayRootfs": {
                     "type": "string"
                 },
+                "extendCmdline": {
+                    "type": "string"
+                },
                 "provisioning": {
                     "$ref": "#/definitions/handlers.APIArtifactProvisioning"
                 },
@@ -1399,6 +1402,9 @@
                     "type": "boolean"
                 },
                 "overlayRootfs": {
+                    "type": "string"
+                },
+                "extendCmdline": {
                     "type": "string"
                 },
                 "phase": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -108,6 +108,8 @@ definitions:
         $ref: '#/definitions/handlers.APIArtifactOutputs'
       overlayRootfs:
         type: string
+      extendCmdline:
+        type: string
       provisioning:
         $ref: '#/definitions/handlers.APIArtifactProvisioning'
       signing:
@@ -282,6 +284,8 @@ definitions:
       netboot:
         type: boolean
       overlayRootfs:
+        type: string
+      extendCmdline:
         type: string
       phase:
         type: string

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -196,6 +196,7 @@ func (b *Builder) Build(ctx context.Context, opts builder.BuildOptions) (*builde
 			AutoInstall:      opts.Provisioning.AutoInstall,
 			RegisterAuroraBoot: opts.Provisioning.RegisterAuroraBoot,
 			Dockerfile:       opts.Dockerfile,
+			ExtendCmdline:    opts.ExtendCmdline,
 			CloudConfig:      opts.CloudConfig,
 			CreatedAt:        time.Now(),
 			UpdatedAt:        time.Now(),
@@ -543,17 +544,20 @@ func (b *Builder) buildUKI(ctx context.Context, opts builder.BuildOptions, conta
 	}
 
 	ukiOpts := uki.Options{
-		Source:           "docker:" + containerImage,
-		OutputDir:        outputDir,
-		OutputType:       string(constants.IsoOutput),
-		Name:             "kairos",
-		SBKey:            signing.UKISecureBootKey,
-		SBCert:           signing.UKISecureBootCert,
-		TPMPCRPrivateKey: signing.UKITPMPCRKey,
-		PublicKeysDir:    signing.UKIPublicKeysDir,
-		SecureBootEnroll: signing.UKISecureBootEnroll,
-		OverlayRootfs:    opts.OverlayRootfs,
-		Logger:           &log,
+		Source:                 "docker:" + containerImage,
+		OutputDir:              outputDir,
+		OutputType:             string(constants.IsoOutput),
+		Name:                   "kairos",
+		SBKey:                  signing.UKISecureBootKey,
+		SBCert:                 signing.UKISecureBootCert,
+		TPMPCRPrivateKey:       signing.UKITPMPCRKey,
+		PublicKeysDir:          signing.UKIPublicKeysDir,
+		SecureBootEnroll:       signing.UKISecureBootEnroll,
+		OverlayRootfs:          opts.OverlayRootfs,
+		IncludeVersionInConfig: true,
+		IncludeCmdlineInConfig: true,
+		ExtendCmdline:          opts.ExtendCmdline,
+		Logger:                 &log,
 	}
 
 	errCh := make(chan error, 1)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -79,6 +79,7 @@ type BuildOptions struct {
 	OverlayRootfs   string // path to overlay dir (files copied on top of rootfs)
 	Dockerfile      string // optional Dockerfile content (builds image via docker before ISO)
 	BuildContextDir string // directory with files available to COPY in Dockerfile
+	ExtendCmdline   string
 	KairosInitImage string
 }
 

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -146,36 +146,36 @@ const (
 // image and used for upgrade tracking), not the Kairos framework
 // version of the base image.
 type Artifact struct {
-	ID               string        `json:"id"`
-	Name             string        `json:"name,omitempty"`
-	Saved            bool          `json:"saved,omitempty"`
-	Phase            ArtifactPhase `json:"phase"`
-	Message          string        `json:"message,omitempty"`
-	BaseImage        string        `json:"baseImage"`
-	KairosVersion    string        `json:"kairosVersion"`
-	Model            string        `json:"model"`
-	Arch             string        `json:"arch"`
-	Variant          string        `json:"variant"`
-	KubernetesDistro string        `json:"kubernetesDistro,omitempty"`
-	ISO              bool          `json:"iso"`
-	CloudImage       bool          `json:"cloudImage"`
-	Netboot          bool          `json:"netboot"`
-	RawDisk          bool          `json:"rawDisk"`
-	Tar              bool          `json:"tar"`
-	GCE              bool          `json:"gce"`
-	VHD              bool          `json:"vhd"`
-	UKI              bool          `json:"uki"`
-	FIPS             bool          `json:"fips"`
-	TrustedBoot      bool          `json:"trustedBoot"`
-	AutoInstall      bool          `json:"autoInstall"`
+	ID                 string        `json:"id"`
+	Name               string        `json:"name,omitempty"`
+	Saved              bool          `json:"saved,omitempty"`
+	Phase              ArtifactPhase `json:"phase"`
+	Message            string        `json:"message,omitempty"`
+	BaseImage          string        `json:"baseImage"`
+	KairosVersion      string        `json:"kairosVersion"`
+	Model              string        `json:"model"`
+	Arch               string        `json:"arch"`
+	Variant            string        `json:"variant"`
+	KubernetesDistro   string        `json:"kubernetesDistro,omitempty"`
+	ISO                bool          `json:"iso"`
+	CloudImage         bool          `json:"cloudImage"`
+	Netboot            bool          `json:"netboot"`
+	RawDisk            bool          `json:"rawDisk"`
+	Tar                bool          `json:"tar"`
+	GCE                bool          `json:"gce"`
+	VHD                bool          `json:"vhd"`
+	UKI                bool          `json:"uki"`
+	FIPS               bool          `json:"fips"`
+	TrustedBoot        bool          `json:"trustedBoot"`
+	AutoInstall        bool          `json:"autoInstall"`
 	RegisterAuroraBoot bool          `json:"registerAuroraBoot"`
-	Dockerfile       string        `json:"dockerfile,omitempty"`
-	CloudConfig      string        `json:"cloudConfig,omitempty"`
-	TargetGroupID    string        `json:"targetGroupId,omitempty"`
-	ContainerImage   string        `json:"containerImage,omitempty"`
-	Artifacts        []string      `json:"artifacts,omitempty"`
-	CreatedAt        time.Time     `json:"createdAt"`
-	UpdatedAt        time.Time     `json:"updatedAt"`
+	Dockerfile         string        `json:"dockerfile,omitempty"`
+	CloudConfig        string        `json:"cloudConfig,omitempty"`
+	TargetGroupID      string        `json:"targetGroupId,omitempty"`
+	ContainerImage     string        `json:"containerImage,omitempty"`
+	Artifacts          []string      `json:"artifacts,omitempty"`
+	CreatedAt          time.Time     `json:"createdAt"`
+	UpdatedAt          time.Time     `json:"updatedAt"`
 }
 
 // CreateArtifactRequest is the body of POST /api/v1/artifacts.
@@ -192,6 +192,7 @@ type CreateArtifactRequest struct {
 	KubernetesVersion string                 `json:"kubernetesVersion,omitempty"`
 	Dockerfile        string                 `json:"dockerfile,omitempty"`
 	OverlayRootfs     string                 `json:"overlayRootfs,omitempty"`
+	ExtendCmdline     string                 `json:"extendCmdline,omitempty"`
 	KairosInitImage   string                 `json:"kairosInitImage,omitempty"`
 	Outputs           ArtifactOutputs        `json:"outputs"`
 	Signing           ArtifactSigning        `json:"signing"`
@@ -226,13 +227,13 @@ type ArtifactSigning struct {
 
 // ArtifactProvisioning describes cloud-config injection options.
 type ArtifactProvisioning struct {
-	AutoInstall      bool   `json:"autoInstall"`
+	AutoInstall        bool   `json:"autoInstall"`
 	RegisterAuroraBoot bool   `json:"registerAuroraBoot"`
-	TargetGroupID    string `json:"targetGroupId,omitempty"`
-	UserMode         string `json:"userMode,omitempty"`
-	Username         string `json:"username,omitempty"`
-	Password         string `json:"password,omitempty"`
-	SSHKeys          string `json:"sshKeys,omitempty"`
+	TargetGroupID      string `json:"targetGroupId,omitempty"`
+	UserMode           string `json:"userMode,omitempty"`
+	Username           string `json:"username,omitempty"`
+	Password           string `json:"password,omitempty"`
+	SSHKeys            string `json:"sshKeys,omitempty"`
 }
 
 // UpdateArtifactRequest is the body of PATCH /api/v1/artifacts/:id.

--- a/pkg/handlers/api_dto.go
+++ b/pkg/handlers/api_dto.go
@@ -111,6 +111,7 @@ type APICreateArtifactRequest struct {
 	KubernetesVersion string                  `json:"kubernetesVersion"`
 	Dockerfile        string                  `json:"dockerfile"`
 	OverlayRootfs     string                  `json:"overlayRootfs"`
+	ExtendCmdline     string                  `json:"extendCmdline"`
 	KairosInitImage   string                  `json:"kairosInitImage"`
 	Outputs           APIArtifactOutputs      `json:"outputs"`
 	Signing           APIArtifactSigning      `json:"signing"`

--- a/pkg/handlers/artifacts.go
+++ b/pkg/handlers/artifacts.go
@@ -53,6 +53,7 @@ type createArtifactRequest struct {
 	Dockerfile        string `json:"dockerfile"`
 	BuildContextDir   string `json:"buildContextDir"`
 	OverlayRootfs     string `json:"overlayRootfs"`
+	ExtendCmdline     string `json:"extendCmdline"`
 	KairosInitImage   string `json:"kairosInitImage"`
 
 	Outputs      artifactOutputs    `json:"outputs"`
@@ -177,6 +178,7 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 		OverlayRootfs:     req.OverlayRootfs,
 		Dockerfile:        req.Dockerfile,
 		BuildContextDir:   req.BuildContextDir,
+		ExtendCmdline:     req.ExtendCmdline,
 		KairosInitImage:   req.KairosInitImage,
 	}
 	// Set grouped fields.
@@ -282,6 +284,7 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 			AutoInstall:       autoInstall,
 			RegisterAuroraBoot:  registerAuroraBoot,
 			Dockerfile:        req.Dockerfile,
+			ExtendCmdline:     req.ExtendCmdline,
 			CloudConfig:       opts.CloudConfig,
 			KubernetesDistro:  req.KubernetesDistro,
 			KubernetesVersion: req.KubernetesVersion,

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -151,6 +151,7 @@ type ArtifactRecord struct {
 	TargetGroupID     string `json:"targetGroupId,omitempty"`
 	ContainerImage    string `json:"containerImage,omitempty"`
 	OverlayRootfs string    `json:"overlayRootfs,omitempty"`
+	ExtendCmdline     string `json:"extendCmdline,omitempty"`
 	ArtifactFiles []string  `json:"artifacts" gorm:"serializer:json"`
 	Logs          string    `json:"-" gorm:"type:text"`
 	CreatedAt     time.Time `json:"createdAt"`

--- a/ui/src/api/artifacts.ts
+++ b/ui/src/api/artifacts.ts
@@ -25,6 +25,7 @@ export interface Artifact {
   autoInstall: boolean;
   registerAuroraBoot: boolean;
   dockerfile?: string;
+  extendCmdline?: string;
   cloudConfig?: string;
   kubernetesDistro?: string;
   kubernetesVersion?: string;
@@ -84,6 +85,7 @@ export interface CreateArtifactInput {
   kubernetesVersion?: string;
   dockerfile?: string;
   overlayRootfs?: string;
+  extendCmdline?: string;
   kairosInitImage?: string;
   outputs: CreateArtifactOutputs;
   signing: CreateArtifactSigning;

--- a/ui/src/lib/buildConfig.test.ts
+++ b/ui/src/lib/buildConfig.test.ts
@@ -24,6 +24,7 @@ function makeForm(overrides: Partial<CreateArtifactInput> = {}): CreateArtifactI
     kubernetesVersion: "",
     dockerfile: "",
     overlayRootfs: "",
+    extendCmdline: "",
     kairosInitImage: "",
     outputs: {
       iso: true,

--- a/ui/src/lib/buildConfig.ts
+++ b/ui/src/lib/buildConfig.ts
@@ -53,6 +53,7 @@ export interface BuildConfigPayload {
   };
   dockerfile?: string;
   overlayRootfs?: string;
+  extendCmdline?: string;
   outputs: CreateArtifactInput["outputs"];
   signing: {
     ukiKeySetName?: string;
@@ -107,6 +108,7 @@ export function payloadFromBuilder(args: {
     },
     dockerfile: buildMode === "dockerfile" ? form.dockerfile : undefined,
     overlayRootfs: form.overlayRootfs || undefined,
+    extendCmdline: form.extendCmdline || undefined,
     outputs: { ...form.outputs },
     signing: {
       ukiKeySetName: keySetName,
@@ -152,6 +154,7 @@ export function payloadFromArtifact(artifact: Artifact, groups: Group[]): BuildC
       kairosInitImage: artifact.kairosInitImage || undefined,
     },
     dockerfile: buildMode === "dockerfile" ? artifact.dockerfile : undefined,
+    extendCmdline: artifact.extendCmdline || undefined,
     outputs: {
       iso: artifact.iso,
       cloudImage: artifact.cloudImage,

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -346,6 +346,7 @@ const EMPTY_FORM: CreateArtifactInput = {
   kubernetesVersion: "",
   dockerfile: "",
   overlayRootfs: "",
+  extendCmdline: "",
   kairosInitImage: "",
   outputs: { ...EMPTY_OUTPUTS },
   signing: { ...EMPTY_SIGNING },
@@ -596,6 +597,7 @@ export function ArtifactBuilder() {
       kubernetesVersion: src.kubernetesVersion || "",
       dockerfile: parsed.dockerfile || "",
       overlayRootfs: parsed.overlayRootfs || "",
+      extendCmdline: src.extendCmdline || "",
       kairosInitImage: src.kairosInitImage || "",
       outputs: { ...EMPTY_OUTPUTS, ...out },
       signing: {
@@ -661,6 +663,7 @@ export function ArtifactBuilder() {
           kubernetesDistro: a.kubernetesDistro || "",
           kubernetesVersion: a.kubernetesVersion || "",
           dockerfile: a.dockerfile || "",
+          extendCmdline: a.extendCmdline || "",
           kairosInitImage: a.kairosInitImage || "",
           outputs: {
             iso: a.iso,
@@ -904,6 +907,7 @@ export function ArtifactBuilder() {
       kubernetesVersion: form.variant === "standard" ? form.kubernetesVersion : undefined,
       dockerfile: buildMode === "dockerfile" ? form.dockerfile : undefined,
       overlayRootfs: form.overlayRootfs || undefined,
+      extendCmdline: form.extendCmdline || undefined,
       kairosInitImage: form.kairosInitImage || undefined,
       outputs: { ...form.outputs },
       signing: { ...form.signing },
@@ -1945,6 +1949,31 @@ export function ArtifactBuilder() {
                       />
                       <p className="text-xs text-muted-foreground">
                         Appended to the generated config. AuroraBoot registration is auto-injected by the server.
+                      </p>
+                    </div>
+                    <div className="grid gap-2">
+                      <Label className="text-xs">
+                        Extend Cmdline
+                        <InfoTooltip>
+                          Extra kernel command line arguments. Advanced — leave empty to use the default.{" "}
+                          <a
+                            href="https://kairos.io/docs/reference/kairos-factory/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline"
+                          >
+                            Docs
+                          </a>
+                        </InfoTooltip>
+                      </Label>
+                      <Input
+                        placeholder="e.g. intel_iommu=on"
+                        value={form.extendCmdline || ""}
+                        onChange={(e) => update("extendCmdline", e.target.value)}
+                        className="font-mono text-xs"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Extra kernel command line arguments.
                       </p>
                     </div>
                     <div className="grid gap-2">


### PR DESCRIPTION
Add support for extraCmdline to be used by the web ui so that it can be encorporated in uki builds. This is needed to enable flags like `intel_iommu=on` when running with vfio and was already supported by the cli backend; this just synchronizes the two implementations.