### PR TITLE
fix(ui): drop x64-only oxide native dep so arm64 builds work

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,7 +15,6 @@
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-tabs": "^1.1.3",
-        "@tailwindcss/oxide-linux-x64-gnu": "^4.2.2",
         "ansi-to-html": "^0.7.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2547,6 +2546,8 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "optional": true,
       "os": [
         "linux"
       ],

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,6 @@
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.3",
-    "@tailwindcss/oxide-linux-x64-gnu": "^4.2.2",
     "ansi-to-html": "^0.7.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
@tailwindcss/oxide-linux-x64-gnu is the x64 native binary for Tailwind v4's oxide engine and is already declared as an optional dep of @tailwindcss/oxide. Pinning it as a direct dependency forced npm to install the x64 build on every host, breaking arm64 image builds with EBADPLATFORM. Removing it lets npm pick the correct native variant per host arch.