### PR TITLE
ci: run riscv64 Docker build on amd64 runner

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -60,7 +60,9 @@ jobs:
           push: true
           tags: quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
   build-linux-riscv64:
-    runs-on: 'ubuntu-24.04-riscv'
+    # Run on amd64 with QEMU for riscv64 - more stable than native riscv64
+    # runner trying to emulate amd64 for the js stage (npm install crashes)
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

QEMU on native riscv64 runners crashes when emulating amd64 for the js stage (`npm install` exits with 139/SIGSEGV).

Running on amd64 with QEMU emulating riscv64 for the final stages is more stable because:
- The js stage runs natively on amd64 (no emulation needed)
- QEMU emulating riscv64 on amd64 is more mature than the reverse

## Test plan

- [ ] Release workflow `build-linux-riscv64` job passes

Made with [Cursor](https://cursor.com)