### PR TITLE
ci: build UI separately for riscv64 to avoid QEMU issues

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -105,6 +105,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v6
         with:
+          context: .
           file: ./Dockerfile.riscv64
           build-args: |
             VERSION=${{ github.ref_name }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,6 +13,29 @@ concurrency:
   group: ci-image-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: false # we never want to cancel a running job on release
 jobs:
+  build-ui:
+    # Build UI on amd64 for riscv64 - QEMU emulation of amd64 on riscv64 is unstable
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+      - name: Build UI
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+      - name: Upload UI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-dist
+          path: internal/ui/dist
+          retention-days: 1
   build-linux-amd64:
     runs-on: 'ubuntu-24.04'
     steps:
@@ -61,11 +84,15 @@ jobs:
           tags: quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
   build-linux-riscv64:
     runs-on: 'ubuntu-24.04-riscv'
+    needs: build-ui
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Download UI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-dist
+          path: internal/ui/dist
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/test-riscv64.yml
+++ b/.github/workflows/test-riscv64.yml
@@ -5,29 +5,53 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:  # allows manual trigger from Actions tab
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  build-linux-riscv64:
-    runs-on: 'ubuntu-24.04-riscv'
+  build-ui:
+    # Build UI on amd64 - mirrors image.yml release workflow
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+      - name: Build UI
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+      - name: Upload UI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-dist
+          path: internal/ui/dist
+          retention-days: 1
+
+  build-linux-riscv64:
+    runs-on: 'ubuntu-24.04-riscv'
+    needs: build-ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download UI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-dist
+          path: internal/ui/dist
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - name: Create placeholder UI dist
-        run: |
-          # Skip UI build on riscv64 - Node.js/V8 has known issues on this arch
-          # https://github.com/nodejs/build/issues/4099
-          mkdir -p internal/ui/dist
-          echo '<!DOCTYPE html><html><body>Placeholder</body></html>' > internal/ui/dist/index.html
 
       - name: Build binary
         run: |
@@ -44,5 +68,14 @@ jobs:
           file auroraboot
           ./auroraboot --version || true
 
-      # Docker image build is tested in image.yml during release.
-      # QEMU emulation on riscv64 runners is unstable for npm install.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test Docker image build for riscv64
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.riscv64
+          platforms: linux/riscv64
+          push: false
+          load: false

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -4,14 +4,8 @@ ARG SWAGGER_STAGE=with-swagger
 
 FROM quay.io/luet/base:$LUET_VERSION AS luet
 
-# Build the React UI on amd64 (node:24 lacks riscv64 support).
-# Output is platform-independent.
-FROM --platform=linux/amd64 node:24 AS js
-WORKDIR /work/ui
-COPY ui/package.json ui/package-lock.json* ./
-RUN npm install
-COPY ui/ .
-RUN npm run build
+# UI is pre-built and passed via build context (internal/ui/dist)
+# This avoids QEMU emulation issues on riscv64 runners.
 
 FROM golang:1.26 AS with-swagger
 WORKDIR /app
@@ -31,7 +25,7 @@ ADD go.mod .
 ADD go.sum .
 RUN go mod download
 ADD . .
-COPY --from=js /work/internal/ui/dist ./internal/ui/dist
+# UI is pre-built and included in the build context
 COPY --from=swagger /app/docs ./docs
 ENV VERSION=$VERSION
 RUN go build -ldflags "-X main.version=${VERSION}" -o auroraboot


### PR DESCRIPTION
## Summary

QEMU on native riscv64 runners crashes when emulating amd64 for `npm install` (exit code 139/SIGSEGV).

## Solution

- Add `build-ui` job that builds UI on amd64 runner
- Upload UI as artifact
- `build-linux-riscv64` downloads pre-built UI before Docker build
- `Dockerfile.riscv64` uses pre-built UI from build context (no `js` stage)

This keeps the Go binary building natively on riscv64 (required for CGO dependencies like `crypto11`/`pkcs11`) while avoiding QEMU instability for Node.js.

## Test plan

- [ ] `build-ui` job passes
- [ ] `build-linux-riscv64` job passes
- [ ] riscv64 image works correctly

Made with [Cursor](https://cursor.com)