### PR TITLE
ci: run riscv64 tests on push to main

### DIFF
--- a/.github/workflows/test-riscv64.yml
+++ b/.github/workflows/test-riscv64.yml
@@ -2,6 +2,9 @@
 name: 'Test RISC-V build'
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary

Add push trigger to riscv64 test workflow so it runs on main, not just PRs.

## Test plan

- [ ] Workflow runs on push to main

Made with [Cursor](https://cursor.com)