### PR TITLE
chore(builder): change renovate so it can auto-bump the kairos init image

### DIFF
--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -439,7 +439,7 @@ func (b *Builder) ensureKairosified(ctx context.Context, image string, opts buil
 		kairosInitImage = os.Getenv("KAIROS_INIT_IMAGE")
 	}
 	if kairosInitImage == "" {
-		kairosInitImage = "quay.io/kairos/kairos-init:latest"
+		kairosInitImage = "quay.io/kairos/kairos-init:v0.13.0"
 	}
 
 	// Build kairos-init flags

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -439,7 +439,7 @@ func (b *Builder) ensureKairosified(ctx context.Context, image string, opts buil
 		kairosInitImage = os.Getenv("KAIROS_INIT_IMAGE")
 	}
 	if kairosInitImage == "" {
-		kairosInitImage = "quay.io/kairos/kairos-init:v0.13.0"
+		kairosInitImage = defaultKairosInitImage + ":" + defaultKairosInitVersion
 	}
 
 	// Build kairos-init flags

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -439,7 +439,7 @@ func (b *Builder) ensureKairosified(ctx context.Context, image string, opts buil
 		kairosInitImage = os.Getenv("KAIROS_INIT_IMAGE")
 	}
 	if kairosInitImage == "" {
-		kairosInitImage = "quay.io/kairos/kairos-init:v0.8.4"
+		kairosInitImage = "quay.io/kairos/kairos-init:latest"
 	}
 
 	// Build kairos-init flags

--- a/internal/builder/auroraboot/constants.go
+++ b/internal/builder/auroraboot/constants.go
@@ -1,0 +1,6 @@
+package auroraboot
+
+const (
+	defaultKairosInitImage   = "quay.io/kairos/kairos-init"
+	defaultKairosInitVersion = "v0.13.0"
+)

--- a/renovate.json
+++ b/renovate.json
@@ -62,10 +62,10 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/internal/worker/worker.go$/"
+        "/internal/builder/auroraboot/builder\\.go$/"
       ],
       "matchStrings": [
-        "FROM quay\\.io/kairos/kairos-init:v(?<currentValue>[0-9.]+) AS kairos-init"
+        "kairosInitImage\\s*=\\s*\"quay\\.io/kairos/kairos-init:v(?<currentValue>[0-9.]+)\""
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "quay.io/kairos/kairos-init"

--- a/renovate.json
+++ b/renovate.json
@@ -62,10 +62,10 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/internal/builder/auroraboot/builder\\.go$/"
+        "/internal/builder/auroraboot/constants\\.go$/"
       ],
       "matchStrings": [
-        "kairosInitImage\\s*=\\s*\"quay\\.io/kairos/kairos-init:v(?<currentValue>[0-9.]+)\""
+        "defaultKairosInitVersion\\s*=\\s*\"v(?<currentValue>[0-9.]+)\""
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "quay.io/kairos/kairos-init"


### PR DESCRIPTION
Drops the pinned v0.8.4 fallback so fresh builds pick up the most recent kairos-init by default. Explicit pins via opts.KairosInitImage or KAIROS_INIT_IMAGE still win.