### PR TITLE
chore(renovate): track distro base images in ArtifactBuilder templates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,15 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "quay.io/kairos/kairos-init"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/ui/src/pages/ArtifactBuilder\\.tsx$/"
+      ],
+      "matchStrings": [
+        "//\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s*\\n\\s*baseImage:\\s*\"[^\"]+:(?<currentValue>[^\"]+)\""
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -76,7 +76,8 @@
         "/ui/src/pages/ArtifactBuilder\\.tsx$/"
       ],
       "matchStrings": [
-        "//\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s*\\n\\s*baseImage:\\s*\"[^\"]+:(?<currentValue>[^\"]+)\""
+        "//\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*baseImage:\\s*\"[^\"]+:(?<currentValue>[^\"]+)\"",
+        "//\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*const\\s+\\w+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ]
     }
   ]

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -208,6 +208,18 @@ interface BuildTemplate {
 const HADRON_VERSION = "v0.0.4";
 // renovate: datasource=github-releases depName=kairos-io/kairos
 const KAIROS_VERSION = "v4.0.3";
+// renovate: datasource=docker depName=ubuntu
+const UBUNTU_VERSION = "24.04";
+// renovate: datasource=docker depName=fedora
+const FEDORA_VERSION = "40";
+// renovate: datasource=docker depName=opensuse/leap
+const OPENSUSE_LEAP_VERSION = "15.6";
+// renovate: datasource=docker depName=debian
+const DEBIAN_VERSION = "12";
+// renovate: datasource=docker depName=alpine
+const ALPINE_VERSION = "3.21";
+// renovate: datasource=docker depName=rockylinux
+const ROCKYLINUX_VERSION = "9";
 
 const TEMPLATES: BuildTemplate[] = [
   {
@@ -227,8 +239,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Ubuntu 24.04",
     description: "Ubuntu base, auto-kairosified, ISO",
     values: {
-      // renovate: datasource=docker depName=ubuntu
-      baseImage: "ubuntu:24.04",
+      baseImage: `ubuntu:${UBUNTU_VERSION}`,
       kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
@@ -240,8 +251,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Fedora 40",
     description: "Fedora base, auto-kairosified, ISO",
     values: {
-      // renovate: datasource=docker depName=fedora
-      baseImage: "fedora:40",
+      baseImage: `fedora:${FEDORA_VERSION}`,
       kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
@@ -253,8 +263,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "openSUSE Leap 15.6",
     description: "openSUSE Leap base, auto-kairosified, ISO",
     values: {
-      // renovate: datasource=docker depName=opensuse/leap
-      baseImage: "opensuse/leap:15.6",
+      baseImage: `opensuse/leap:${OPENSUSE_LEAP_VERSION}`,
       kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
@@ -266,8 +275,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Debian 12",
     description: "Debian Bookworm base, auto-kairosified, ISO",
     values: {
-      // renovate: datasource=docker depName=debian
-      baseImage: "debian:12",
+      baseImage: `debian:${DEBIAN_VERSION}`,
       kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
@@ -279,8 +287,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Alpine 3.21",
     description: "Alpine Linux base, auto-kairosified, ISO",
     values: {
-      // renovate: datasource=docker depName=alpine
-      baseImage: "alpine:3.21",
+      baseImage: `alpine:${ALPINE_VERSION}`,
       kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
@@ -292,8 +299,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Rocky Linux 9",
     description: "Rocky Linux 9 base, auto-kairosified, ISO",
     values: {
-      // renovate: datasource=docker depName=rockylinux
-      baseImage: "rockylinux:9",
+      baseImage: `rockylinux:${ROCKYLINUX_VERSION}`,
       kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -222,6 +222,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Ubuntu 24.04",
     description: "Ubuntu base, auto-kairosified, ISO",
     values: {
+      // renovate: datasource=docker depName=ubuntu
       baseImage: "ubuntu:24.04",
       kairosVersion: "v4.0.3",
       model: "generic",
@@ -234,6 +235,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Fedora 40",
     description: "Fedora base, auto-kairosified, ISO",
     values: {
+      // renovate: datasource=docker depName=fedora
       baseImage: "fedora:40",
       kairosVersion: "v4.0.3",
       model: "generic",
@@ -246,6 +248,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "openSUSE Leap 15.6",
     description: "openSUSE Leap base, auto-kairosified, ISO",
     values: {
+      // renovate: datasource=docker depName=opensuse/leap
       baseImage: "opensuse/leap:15.6",
       kairosVersion: "v4.0.3",
       model: "generic",
@@ -258,6 +261,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Debian 12",
     description: "Debian Bookworm base, auto-kairosified, ISO",
     values: {
+      // renovate: datasource=docker depName=debian
       baseImage: "debian:12",
       kairosVersion: "v4.0.3",
       model: "generic",
@@ -270,6 +274,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Alpine 3.21",
     description: "Alpine Linux base, auto-kairosified, ISO",
     values: {
+      // renovate: datasource=docker depName=alpine
       baseImage: "alpine:3.21",
       kairosVersion: "v4.0.3",
       model: "generic",
@@ -282,6 +287,7 @@ const TEMPLATES: BuildTemplate[] = [
     name: "Rocky Linux 9",
     description: "Rocky Linux 9 base, auto-kairosified, ISO",
     values: {
+      // renovate: datasource=docker depName=rockylinux
       baseImage: "rockylinux:9",
       kairosVersion: "v4.0.3",
       model: "generic",

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -204,13 +204,18 @@ interface BuildTemplate {
   values: Partial<CreateArtifactInput>;
 }
 
+// renovate: datasource=docker depName=ghcr.io/kairos-io/hadron extractVersion=^(?<version>v\d+\.\d+\.\d+)
+const HADRON_VERSION = "v0.0.4";
+// renovate: datasource=github-releases depName=kairos-io/kairos
+const KAIROS_VERSION = "v4.0.3";
+
 const TEMPLATES: BuildTemplate[] = [
   {
     name: "Hadron + K3s",
     description: "Hadron Linux with K3s, generic model, ISO",
     values: {
-      baseImage: "quay.io/kairos/hadron:v0.0.4-core-amd64-generic-v4.0.3",
-      kairosVersion: "v4.0.3",
+      baseImage: `quay.io/kairos/hadron:${HADRON_VERSION}-core-amd64-generic-${KAIROS_VERSION}`,
+      kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
       variant: "core",
@@ -224,7 +229,7 @@ const TEMPLATES: BuildTemplate[] = [
     values: {
       // renovate: datasource=docker depName=ubuntu
       baseImage: "ubuntu:24.04",
-      kairosVersion: "v4.0.3",
+      kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
       variant: "core",
@@ -237,7 +242,7 @@ const TEMPLATES: BuildTemplate[] = [
     values: {
       // renovate: datasource=docker depName=fedora
       baseImage: "fedora:40",
-      kairosVersion: "v4.0.3",
+      kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
       variant: "core",
@@ -250,7 +255,7 @@ const TEMPLATES: BuildTemplate[] = [
     values: {
       // renovate: datasource=docker depName=opensuse/leap
       baseImage: "opensuse/leap:15.6",
-      kairosVersion: "v4.0.3",
+      kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
       variant: "core",
@@ -263,7 +268,7 @@ const TEMPLATES: BuildTemplate[] = [
     values: {
       // renovate: datasource=docker depName=debian
       baseImage: "debian:12",
-      kairosVersion: "v4.0.3",
+      kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
       variant: "core",
@@ -276,7 +281,7 @@ const TEMPLATES: BuildTemplate[] = [
     values: {
       // renovate: datasource=docker depName=alpine
       baseImage: "alpine:3.21",
-      kairosVersion: "v4.0.3",
+      kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
       variant: "core",
@@ -289,7 +294,7 @@ const TEMPLATES: BuildTemplate[] = [
     values: {
       // renovate: datasource=docker depName=rockylinux
       baseImage: "rockylinux:9",
-      kairosVersion: "v4.0.3",
+      kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
       variant: "core",


### PR DESCRIPTION
Adds Renovate marker comments above each plain distro baseImage in the template list (ubuntu, fedora, opensuse/leap, debian, alpine, rockylinux) and a custom regex manager that extracts the version. The hadron template is skipped because its compound tag (v0.0.4-core-amd64-generic-v4.0.3) doesn't follow a single semver component Renovate can bump safely.