### PR TITLE
chore(ui): bump hadron template to v0.2.0 + kairos v4.1.0

### DIFF
--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -205,9 +205,9 @@ interface BuildTemplate {
 }
 
 // renovate: datasource=docker depName=ghcr.io/kairos-io/hadron extractVersion=^(?<version>v\d+\.\d+\.\d+)
-const HADRON_VERSION = "v0.0.4";
+const HADRON_VERSION = "v0.2.0";
 // renovate: datasource=github-releases depName=kairos-io/kairos
-const KAIROS_VERSION = "v4.0.3";
+const KAIROS_VERSION = "v4.1.0";
 // renovate: datasource=docker depName=ubuntu
 const UBUNTU_VERSION = "24.04";
 // renovate: datasource=docker depName=fedora


### PR DESCRIPTION
The Hadron + K3s template image is built from HADRON_VERSION and KAIROS_VERSION together, and at quay.io/kairos/hadron only matching pairs are published (e.g. v0.2.0 with v4.1.0). Bumping just one would yield a 404 tag, so move both forward together to the latest pair present in the registry.

Notes:
- The kairos-init default is already v0.13.0, which matches the latest kairos-io/kairos-init GitHub release; no bump needed there.
- hadron v0.2.1 is the latest GitHub release but not yet published to quay, so we stop at v0.2.0.