### PR TITLE
feat(ui): Redfish deploy pre-flight hardware gate + live deploy progress

### DIFF
--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kairos-io/AuroraBoot/pkg/isoserve"
 	"github.com/kairos-io/AuroraBoot/pkg/redfish"
 	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/kairos-io/AuroraBoot/pkg/ws"
 	"github.com/labstack/echo/v4"
 )
 
@@ -35,6 +36,11 @@ type DeployHandler struct {
 	// isoServe serves a local artifact ISO over a tokenized, BMC-reachable URL.
 	// May be nil, in which case a Redfish deploy must supply an explicit imageUrl.
 	isoServe *isoserve.Server
+
+	// hub is the WebSocket hub used to broadcast live deploy-step progress to UI
+	// clients. May be nil (e.g. in tests or when no hub is wired), in which case
+	// progress is only persisted to the Deployment row and surfaced via polling.
+	hub *ws.Hub
 
 	// baseCtx is the parent context for every background deploy goroutine. It is
 	// tied to the server lifecycle so a shutdown cancels in-flight deploys. When
@@ -55,6 +61,7 @@ func NewDeployHandler(
 	nb *netbootmgr.Manager,
 	artifactsDir string,
 	isoServe *isoserve.Server,
+	hub *ws.Hub,
 ) *DeployHandler {
 	return &DeployHandler{
 		artifacts:    artifacts,
@@ -63,6 +70,7 @@ func NewDeployHandler(
 		netboot:      nb,
 		artifactsDir: artifactsDir,
 		isoServe:     isoServe,
+		hub:          hub,
 		baseCtx:      context.Background(),
 		runs:         make(map[string]context.CancelFunc),
 	}
@@ -380,10 +388,34 @@ func (h *DeployHandler) runRedfishDeploy(ctx context.Context, cancel context.Can
 	h.completeDeployment(deploymentID, msg)
 }
 
+// broadcastProgress fans a live deploy-progress event to all connected UI
+// clients over the existing UI WebSocket. It is best-effort and nil-safe: when
+// no hub is wired the event is simply dropped, and clients fall back to polling
+// the deployment store. Broadcast does its own marshalling and write fan-out, so
+// this never blocks the deploy on a slow client. The payload is nested under
+// "data" to match the existing UI message envelope ({"type":…,"data":…}).
+func (h *DeployHandler) broadcastProgress(id, status, step, message string, progress int) {
+	if h.hub == nil || h.hub.UI == nil {
+		return
+	}
+	h.hub.UI.Broadcast(map[string]any{
+		"type": "deploy-progress",
+		"data": map[string]any{
+			"deploymentId": id,
+			"status":       status,
+			"progress":     progress,
+			"step":         step,
+			"message":      message,
+		},
+	})
+}
+
 // progressUpdater returns a redfish progress callback that writes live step and
 // percentage onto the Deployment row. It only advances Progress (never regresses)
 // and leaves the terminal Completed/Failed write to the caller. A read/update
 // failure is best-effort and silently ignored — progress is non-authoritative.
+// Alongside the store write it broadcasts the step to UI clients so the
+// Deployments page reflects progress in real time rather than only on poll.
 func (h *DeployHandler) progressUpdater(id string) func(step string, percent int) {
 	return func(step string, percent int) {
 		dep, err := h.deployments.GetByID(context.Background(), id)
@@ -398,6 +430,7 @@ func (h *DeployHandler) progressUpdater(id string) func(step string, percent int
 		}
 		dep.Message = step
 		_ = h.deployments.Update(context.Background(), dep)
+		h.broadcastProgress(id, dep.Status, step, dep.Message, dep.Progress)
 	}
 }
 
@@ -412,6 +445,7 @@ func (h *DeployHandler) completeDeployment(id, message string) {
 	dep.Progress = 100
 	dep.CompletedAt = &now
 	_ = h.deployments.Update(context.Background(), dep)
+	h.broadcastProgress(id, dep.Status, "completed", message, dep.Progress)
 }
 
 func (h *DeployHandler) failDeployment(id, message string) {
@@ -424,6 +458,7 @@ func (h *DeployHandler) failDeployment(id, message string) {
 	dep.Message = message
 	dep.CompletedAt = &now
 	_ = h.deployments.Update(context.Background(), dep)
+	h.broadcastProgress(id, dep.Status, "failed", message, dep.Progress)
 }
 
 // --- Hardware inspection ---

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -143,7 +143,7 @@ var _ = Describe("DeployHandler.DeployRedfish", func() {
 		} else {
 			serve = nil
 		}
-		return handlers.NewDeployHandler(artifacts, deployments, bmcTargets, nil, artifactsDir, serve)
+		return handlers.NewDeployHandler(artifacts, deployments, bmcTargets, nil, artifactsDir, serve, nil)
 	}
 
 	// doDeploy posts a deploy request for artifact "art-1" with the given body.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -245,7 +245,7 @@ func New(cfg Config) *echo.Echo {
 
 	// Deploy hub
 	if cfg.DeploymentStore != nil {
-		deployHandler := handlers.NewDeployHandler(cfg.ArtifactStore, cfg.DeploymentStore, cfg.BMCTargetStore, cfg.NetbootManager, cfg.ArtifactsDir, cfg.ISOServe).
+		deployHandler := handlers.NewDeployHandler(cfg.ArtifactStore, cfg.DeploymentStore, cfg.BMCTargetStore, cfg.NetbootManager, cfg.ArtifactsDir, cfg.ISOServe, hub).
 			WithBaseContext(cfg.BaseContext)
 		adminGroup.POST("/netboot/start", deployHandler.StartNetboot)
 		adminGroup.POST("/netboot/stop", deployHandler.StopNetboot)

--- a/redfish.md
+++ b/redfish.md
@@ -319,6 +319,80 @@ completion. The `progress` field is an integer 0–100 that only advances, never
 If the server restarts while a deployment is `Active`, the orphaned row is flipped to
 `Failed` with the message `"interrupted by server restart"` on the next startup.
 
+### Web UI (dashboard)
+
+The AuroraBoot web dashboard (`auroraboot web`) provides a point-and-click Redfish deploy
+workflow with two features that are not available through the REST API alone: a pre-flight
+hardware gate in the deploy dialog, and live per-step progress in the Deployments view.
+
+#### Opening the deploy dialog
+
+Navigate to an artifact's detail page and click **Deploy**. If the artifact includes an
+ISO file the dialog opens with a **RedFish** tab alongside the PXE tab. Select a saved BMC
+target from the dropdown (targets must be created first — see
+[BMC target management](#bmc-target-management) or use **+ Add new target** inline).
+
+#### Pre-flight hardware gate
+
+After selecting a saved BMC target, click **Pre-flight inspect**. The dialog calls
+`POST /api/v1/bmc-targets/:id/inspect` and displays the hardware facts the server reads
+from the BMC:
+
+- Model, manufacturer, and serial number
+- Memory (GiB) and processor count
+- Supported features (e.g. `UEFI`, `SecureBoot`)
+
+The UI enforces minimum thresholds: **2 GiB memory** and **1 processor**. A node that
+reports less than either value is highlighted in red and a warning banner blocks the
+**Deploy via RedFish** button. The operator must tick **Deploy anyway (override)** to
+unblock the button; the warning is intentional friction, not a hard server-side rejection.
+
+Limitation: pre-flight inspection requires a saved BMC target. There is no
+by-credentials inspect endpoint, so the gate is skipped when a deploy uses inline
+credentials supplied directly in the form. Deploy is still allowed in that case — the
+button is not blocked.
+
+#### Starting a deploy
+
+Click **Deploy via RedFish** to call
+`POST /api/v1/artifacts/:id/deploy/redfish` with the selected target's ID. The server
+responds immediately with `202 Accepted`; the actual Redfish flow (InsertMedia → boot
+override → reset → optional task poll) runs asynchronously. The dialog shows a success
+banner when the request is accepted. Switch to the **Deployments** view to follow
+progress.
+
+#### Live deploy-step progress (Deployments view)
+
+The Deployments page subscribes to the UI WebSocket channel. The server broadcasts a
+`deploy-progress` event after each step of the deploy flow, in the envelope:
+
+```json
+{
+  "type": "deploy-progress",
+  "data": {
+    "deploymentId": "<uuid>",
+    "status":       "Active",
+    "progress":     40,
+    "step":         "inserting media",
+    "message":      "inserting media"
+  }
+}
+```
+
+The page patches the matching row in-place (status badge, progress bar, step text) on
+every event without a full refetch. The `progress` field is an integer 0–100 that only
+advances; the `message` field shows the current step label (`discovering`,
+`inserting media`, `setting boot`, `resetting`, `polling task`, `completed`, or
+`failed`).
+
+`GET /api/v1/deployments` remains authoritative. The page also runs a REST poll every
+**15 seconds** while any deployment is `Active` or `Running` as a fallback for events
+missed during a WebSocket reconnect. If the hub is not wired (e.g. in test builds) all
+updates arrive via this poll path.
+
+Not yet in the UI: a dedicated BMC-management page, deployment-to-node linkage, and
+per-deployment error drill-down are planned follow-on work.
+
 ### REST API summary
 
 All Redfish-related endpoints require admin bearer authentication.
@@ -354,3 +428,10 @@ All Redfish-related endpoints require admin bearer authentication.
 - Session cleanup (Redfish session DELETE) runs on both success and error paths. If the
   process is killed hard (e.g. `kill -9`), the session is leaked and must be cleaned up
   on the BMC manually.
+- The dashboard pre-flight gate (2 GiB / 1 CPU thresholds) is UI-side only and applies
+  only to saved BMC targets. It is not enforced by the server on the deploy endpoint.
+  Inline-credential deploys from the UI skip the gate entirely. The CLI enforces
+  `--min-memory` and `--min-cpus` server-side regardless.
+- The Deployments view receives live progress via the UI WebSocket (`deploy-progress`
+  events) and falls back to a 15-second REST poll when the WebSocket is unavailable or
+  reconnecting. Either path converges on the same deployment store state.

--- a/ui/src/api/deployments.ts
+++ b/ui/src/api/deployments.ts
@@ -23,6 +23,29 @@ export interface BMCTarget {
   createdAt: string;
 }
 
+// InspectResult mirrors the server's inspectResponse (POST
+// /api/v1/bmc-targets/:id/inspect): the hardware facts AuroraBoot read off a
+// saved BMC target, used to drive the deploy pre-flight gate.
+export interface InspectResult {
+  memoryGiB: number;
+  processorCount: number;
+  model: string;
+  manufacturer: string;
+  serialNumber: string;
+  supportedFeatures: string[];
+}
+
+// DeployProgress is the live deploy-step event broadcast over the UI WebSocket
+// ({"type":"deploy-progress",...}). It carries the same step/percent the server
+// records on the Deployment row so the Deployments page can update in real time.
+export interface DeployProgress {
+  deploymentId: string;
+  status: string;
+  progress: number;
+  step: string;
+  message: string;
+}
+
 export interface NetbootStatus {
   running: boolean;
   artifactId: string;
@@ -52,7 +75,7 @@ export const deleteBMCTarget = (id: string) =>
   apiFetch(`/api/v1/bmc-targets/${id}`, { method: "DELETE" });
 
 export const inspectHardware = (id: string) =>
-  apiFetch(`/api/v1/bmc-targets/${id}/inspect`, { method: "POST" });
+  apiFetch<InspectResult>(`/api/v1/bmc-targets/${id}/inspect`, { method: "POST" });
 
 export const deployRedfish = (
   artifactId: string,

--- a/ui/src/components/DeployDialog.tsx
+++ b/ui/src/components/DeployDialog.tsx
@@ -18,17 +18,25 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { StatusBadge } from "@/components/StatusBadge";
-import { Wifi, Server, Loader2 } from "lucide-react";
+import { Wifi, Server, Loader2, Cpu, MemoryStick, AlertTriangle, Search } from "lucide-react";
 import {
   type BMCTarget,
   type NetbootStatus,
+  type InspectResult,
   listBMCTargets,
   createBMCTarget,
+  inspectHardware,
   deployRedfish,
   getNetbootStatus,
   startNetboot,
   stopNetboot,
 } from "@/api/deployments";
+
+// Minimum hardware AuroraBoot wants before deploying. Kept deliberately simple
+// and visible: a node below either threshold raises a warning that the operator
+// must explicitly override before Deploy is enabled.
+const MIN_MEMORY_GIB = 2;
+const MIN_CPU_COUNT = 1;
 
 interface DeployDialogProps {
   artifactId: string;
@@ -56,6 +64,13 @@ export function DeployDialog({
   const [deploying, setDeploying] = useState(false);
   const [deployError, setDeployError] = useState("");
   const [deploySuccess, setDeploySuccess] = useState(false);
+
+  // Pre-flight inspection state (saved targets only — there is no by-credentials
+  // inspect endpoint).
+  const [inspecting, setInspecting] = useState(false);
+  const [inspectResult, setInspectResult] = useState<InspectResult | null>(null);
+  const [inspectError, setInspectError] = useState("");
+  const [overrideWarning, setOverrideWarning] = useState(false);
 
   // New BMC target form
   const [showNewTarget, setShowNewTarget] = useState(false);
@@ -86,6 +101,39 @@ export function DeployDialog({
     }, 3000);
     return () => clearInterval(interval);
   }, [hasNetboot, netbootStatus?.running]);
+
+  // Clear any prior inspection when the operator picks a different target.
+  useEffect(() => {
+    setInspectResult(null);
+    setInspectError("");
+    setOverrideWarning(false);
+  }, [selectedTarget]);
+
+  // belowMinimum reports whether an inspected node is under either threshold.
+  const belowMinimum =
+    inspectResult !== null &&
+    (inspectResult.memoryGiB < MIN_MEMORY_GIB ||
+      inspectResult.processorCount < MIN_CPU_COUNT);
+
+  // deployBlocked gates the Deploy button: a node that failed pre-flight must be
+  // explicitly overridden before it can be deployed.
+  const deployBlocked = belowMinimum && !overrideWarning;
+
+  async function handleInspect() {
+    if (!selectedTarget) return;
+    setInspecting(true);
+    setInspectError("");
+    setInspectResult(null);
+    setOverrideWarning(false);
+    try {
+      const result = await inspectHardware(selectedTarget);
+      setInspectResult(result);
+    } catch (err) {
+      setInspectError(err instanceof Error ? err.message : "Inspection failed");
+    } finally {
+      setInspecting(false);
+    }
+  }
 
   async function handlePxeToggle() {
     setPxeLoading(true);
@@ -201,15 +249,112 @@ export function DeployDialog({
                     ))}
                   </SelectContent>
                 </Select>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-xs text-[#EE5007]"
-                  onClick={() => setShowNewTarget(!showNewTarget)}
-                >
-                  {showNewTarget ? "Cancel" : "+ Add new target"}
-                </Button>
+                <div className="flex items-center justify-between">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs text-[#EE5007]"
+                    onClick={() => setShowNewTarget(!showNewTarget)}
+                  >
+                    {showNewTarget ? "Cancel" : "+ Add new target"}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-xs gap-1.5"
+                    onClick={handleInspect}
+                    disabled={!selectedTarget || inspecting}
+                  >
+                    {inspecting ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Search className="h-3.5 w-3.5" />
+                    )}
+                    Pre-flight inspect
+                  </Button>
+                </div>
               </div>
+
+              {/* Pre-flight: inspection error */}
+              {inspectError && (
+                <div className="bg-red-500/10 border border-red-500/25 text-red-700 rounded-md p-3 text-sm">
+                  {inspectError}
+                </div>
+              )}
+
+              {/* Pre-flight: inspection result */}
+              {inspectResult && (
+                <div className="rounded-md border p-4 space-y-3">
+                  <div className="text-sm font-medium">Hardware pre-flight</div>
+                  <div className="grid grid-cols-2 gap-2 text-xs">
+                    <div className="text-muted-foreground">Model</div>
+                    <div className="font-mono">{inspectResult.model || "-"}</div>
+                    <div className="text-muted-foreground">Manufacturer</div>
+                    <div className="font-mono">{inspectResult.manufacturer || "-"}</div>
+                    <div className="text-muted-foreground">Serial</div>
+                    <div className="font-mono">{inspectResult.serialNumber || "-"}</div>
+                    <div className="text-muted-foreground flex items-center gap-1">
+                      <MemoryStick className="h-3.5 w-3.5" /> Memory
+                    </div>
+                    <div
+                      className={
+                        inspectResult.memoryGiB < MIN_MEMORY_GIB
+                          ? "font-mono text-red-600 font-semibold"
+                          : "font-mono"
+                      }
+                    >
+                      {inspectResult.memoryGiB} GiB
+                    </div>
+                    <div className="text-muted-foreground flex items-center gap-1">
+                      <Cpu className="h-3.5 w-3.5" /> Processors
+                    </div>
+                    <div
+                      className={
+                        inspectResult.processorCount < MIN_CPU_COUNT
+                          ? "font-mono text-red-600 font-semibold"
+                          : "font-mono"
+                      }
+                    >
+                      {inspectResult.processorCount}
+                    </div>
+                  </div>
+                  {inspectResult.supportedFeatures.length > 0 && (
+                    <div className="space-y-1">
+                      <div className="text-xs text-muted-foreground">Supported features</div>
+                      <div className="flex flex-wrap gap-1">
+                        {inspectResult.supportedFeatures.map((f) => (
+                          <span
+                            key={f}
+                            className="rounded bg-secondary px-1.5 py-0.5 text-xs font-mono"
+                          >
+                            {f}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {belowMinimum && (
+                    <div className="bg-amber-500/10 border border-amber-500/30 text-amber-800 rounded-md p-3 text-xs space-y-2">
+                      <div className="flex items-start gap-2">
+                        <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                        <span>
+                          This node is below the recommended minimum (
+                          {MIN_MEMORY_GIB} GiB memory, {MIN_CPU_COUNT} CPU). Deploy
+                          may fail or the installed system may be unusable.
+                        </span>
+                      </div>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={overrideWarning}
+                          onChange={(e) => setOverrideWarning(e.target.checked)}
+                        />
+                        Deploy anyway (override)
+                      </label>
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* New target form */}
               {showNewTarget && (
@@ -289,11 +434,14 @@ export function DeployDialog({
               <Button
                 className="w-full"
                 onClick={handleRedfishDeploy}
-                disabled={!selectedTarget || deploying}
+                disabled={!selectedTarget || deploying || deployBlocked}
               >
                 {deploying && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
                 Deploy via RedFish
               </Button>
+              <p className="text-xs text-muted-foreground">
+                Pre-flight inspection is available for saved BMC targets only.
+              </p>
             </TabsContent>
           )}
         </Tabs>

--- a/ui/src/pages/Deployments.tsx
+++ b/ui/src/pages/Deployments.tsx
@@ -12,7 +12,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Wifi, Server, Rocket } from "lucide-react";
-import { listDeployments, type Deployment } from "@/api/deployments";
+import {
+  listDeployments,
+  type Deployment,
+  type DeployProgress,
+} from "@/api/deployments";
+import { useUIWebSocket } from "@/hooks/useUIWebSocket";
 
 export function Deployments() {
   const [deployments, setDeployments] = useState<Deployment[]>([]);
@@ -30,13 +35,29 @@ export function Deployments() {
     fetchDeployments();
   }, []);
 
-  // Auto-poll every 5s when any deployment is active
+  // Live updates: apply deploy-progress events streamed over the UI WebSocket so
+  // the table reflects each step in real time. This is the primary path; the
+  // poll below is a fallback for clients that miss an event (e.g. mid-reconnect).
+  useUIWebSocket((msg) => {
+    if (msg.type !== "deploy-progress") return;
+    const p = msg.data as DeployProgress;
+    setDeployments((prev) =>
+      prev.map((d) =>
+        d.id === p.deploymentId
+          ? { ...d, status: p.status, progress: p.progress, message: p.message }
+          : d
+      )
+    );
+  });
+
+  // Auto-poll every 15s as a fallback while a deployment is active. Live
+  // WebSocket events drive most updates; this catches anything the socket missed.
   useEffect(() => {
     const hasActive = deployments.some(
       (d) => d.status.toLowerCase() === "active" || d.status.toLowerCase() === "running"
     );
     if (!hasActive) return;
-    const interval = setInterval(fetchDeployments, 5000);
+    const interval = setInterval(fetchDeployments, 15000);
     return () => clearInterval(interval);
   }, [deployments]);
 
@@ -115,16 +136,23 @@ export function Deployments() {
                     </TableCell>
                     <TableCell>
                       {d.progress > 0 ? (
-                        <div className="flex items-center gap-2">
-                          <div className="h-2 w-24 rounded-full bg-secondary overflow-hidden">
-                            <div
-                              className="h-full rounded-full bg-[#EE5007] transition-all"
-                              style={{ width: `${Math.min(d.progress, 100)}%` }}
-                            />
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <div className="h-2 w-24 rounded-full bg-secondary overflow-hidden">
+                              <div
+                                className="h-full rounded-full bg-[#EE5007] transition-all"
+                                style={{ width: `${Math.min(d.progress, 100)}%` }}
+                              />
+                            </div>
+                            <span className="text-xs text-muted-foreground">
+                              {d.progress}%
+                            </span>
                           </div>
-                          <span className="text-xs text-muted-foreground">
-                            {d.progress}%
-                          </span>
+                          {d.message && (
+                            <span className="text-xs text-muted-foreground block truncate max-w-[16rem]">
+                              {d.message}
+                            </span>
+                          )}
                         </div>
                       ) : (
                         <span className="text-xs text-muted-foreground">-</span>


### PR DESCRIPTION
## What

Phase 6 (UX) of the Redfish production-readiness work, building on the merged gofish deployer (#535). Two UI features over the existing fleet-server surface:

1. **Pre-flight hardware gate** in `DeployDialog` — a "Pre-flight inspect" action (saved BMC targets) calls `POST /bmc-targets/:id/inspect` and renders model / manufacturer / serial / memory / CPU / supported-features. A node below `MIN_MEMORY_GIB` / `MIN_CPU_COUNT` raises an amber warning and **blocks Deploy until an override checkbox is ticked**. Inline (unsaved) credentials can't be inspected (no by-creds endpoint) — noted in the UI; deploy still allowed.
2. **Live deploy-step progress** over the existing UI WebSocket — `DeployHandler` now holds `*ws.Hub` (nil-safe); `progressUpdater` and the terminal complete/fail paths broadcast `{"type":"deploy-progress","data":{deploymentId,status,progress,step,message}}` (nested under `data` to match the UI envelope). `Deployments.tsx` subscribes via `useUIWebSocket`, patches the matching row live, shows the step text, and the 5s poll is relaxed to a 15s fallback. REST `GET /deployments` stays authoritative.

## Testing

- `go build ./...`, `go vet`, `go test ./pkg/handlers/... ./pkg/server/...` — green
- UI `tsc --noEmit` + `vite build` — clean
- `internal/ui/dist` is gitignored and rebuilt by the `build-ui` CI job; not committed.

## Notes

- Closes Phase 6 (#4116) of the Redfish epic (#4109).
- Rebased onto `main` after #534 + #535 merged.
- Deferred fast-follow (not in this PR): BMC-management page, deployment↔node linkage, error drill-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)