### PR TITLE
fix: fleet-server hardening — concurrency (#4117 Medium) + Redfish deploy ISO path

### DIFF
--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -64,6 +64,9 @@ func (a *CommandStoreAdapter) GetPending(ctx context.Context, nodeID string) ([]
 func (a *CommandStoreAdapter) MarkDelivered(ctx context.Context, ids []string) error {
 	return a.S.MarkDelivered(ctx, ids)
 }
+func (a *CommandStoreAdapter) ClaimForDelivery(ctx context.Context, id string) (bool, error) {
+	return a.S.ClaimForDelivery(ctx, id)
+}
 func (a *CommandStoreAdapter) UpdateStatus(ctx context.Context, id string, phase string, result string) error {
 	return a.S.UpdateStatus(ctx, id, phase, result)
 }

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -324,6 +324,26 @@ func (s *Store) MarkDelivered(ctx context.Context, ids []string) error {
 	}).Error
 }
 
+// ClaimForDelivery atomically transitions a single Pending command to Delivered.
+// The conditional WHERE (id = ? AND phase = Pending) plus a RowsAffected check
+// makes the claim a race-free compare-and-set: when a WS push and an agent poll
+// (or two concurrent polls) both target the same command, exactly one UPDATE
+// matches the still-Pending row and the loser sees RowsAffected == 0. Mirrors
+// the RowsAffected pattern in UpdateStatusForNode.
+func (s *Store) ClaimForDelivery(ctx context.Context, id string) (bool, error) {
+	now := time.Now()
+	res := s.db.WithContext(ctx).Model(&store.NodeCommand{}).
+		Where("id = ? AND phase = ?", id, store.CommandPending).
+		Updates(map[string]any{
+			"phase":        store.CommandDelivered,
+			"delivered_at": &now,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
 func (s *Store) UpdateStatus(ctx context.Context, id string, phase string, result string) error {
 	updates := map[string]any{
 		"phase":  phase,

--- a/internal/store/gorm/store_test.go
+++ b/internal/store/gorm/store_test.go
@@ -2,6 +2,8 @@ package gorm_test
 
 import (
 	"context"
+	"path/filepath"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -346,6 +348,75 @@ var _ = Describe("Gorm Store", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found.Phase).To(Equal(store.CommandDelivered))
 			Expect(found.DeliveredAt).NotTo(BeNil())
+		})
+
+		It("claims a pending command for delivery exactly once", func() {
+			cmd := &store.NodeCommand{ManagedNodeID: node.ID, Command: store.CmdReset}
+			Expect(s.CommandCreate(ctx, cmd)).To(Succeed())
+
+			// First claim wins and flips the phase to Delivered.
+			claimed, err := s.ClaimForDelivery(ctx, cmd.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(claimed).To(BeTrue())
+
+			found, err := s.CommandGetByID(ctx, cmd.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found.Phase).To(Equal(store.CommandDelivered))
+			Expect(found.DeliveredAt).NotTo(BeNil())
+
+			// Second claim sees a non-Pending row and loses.
+			claimed, err = s.ClaimForDelivery(ctx, cmd.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(claimed).To(BeFalse())
+		})
+
+		It("does not claim a missing command", func() {
+			claimed, err := s.ClaimForDelivery(ctx, "no-such-command")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(claimed).To(BeFalse())
+		})
+
+		It("yields exactly one winner under concurrent claims", func() {
+			// Use a file-backed DB so concurrent goroutines share one SQLite
+			// database with WAL/busy_timeout, rather than the per-connection
+			// :memory: DB which has no table on a fresh pooled connection.
+			fs, err := gormstore.New(filepath.Join(GinkgoT().TempDir(), "claim.db"))
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = fs.Close() })
+
+			fnode := &store.ManagedNode{MachineID: "claim-node"}
+			Expect(fs.Register(ctx, fnode)).To(Succeed())
+			cmd := &store.NodeCommand{ManagedNodeID: fnode.ID, Command: store.CmdReset}
+			Expect(fs.CommandCreate(ctx, cmd)).To(Succeed())
+
+			const n = 16
+			type claimResult struct {
+				ok  bool
+				err error
+			}
+			results := make(chan claimResult, n)
+			var wg sync.WaitGroup
+			for i := 0; i < n; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					// Assertions must run on the spec goroutine; collect results
+					// and check them after the wait.
+					ok, claimErr := fs.ClaimForDelivery(ctx, cmd.ID)
+					results <- claimResult{ok: ok, err: claimErr}
+				}()
+			}
+			wg.Wait()
+			close(results)
+
+			wins := 0
+			for r := range results {
+				Expect(r.err).NotTo(HaveOccurred())
+				if r.ok {
+					wins++
+				}
+			}
+			Expect(wins).To(Equal(1))
 		})
 
 		It("updates status to completed with result and completedAt", func() {

--- a/pkg/handlers/commands.go
+++ b/pkg/handlers/commands.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -68,7 +69,7 @@ func (h *CommandHandler) Create(c echo.Context) error {
 	}
 
 	// Push command via WebSocket if node is online.
-	h.pushCommand(cmd)
+	h.pushCommand(c.Request().Context(), cmd)
 
 	return c.JSON(http.StatusCreated, cmd)
 }
@@ -113,7 +114,7 @@ func (h *CommandHandler) CreateBulk(c echo.Context) error {
 		if err := h.commands.Create(ctx, cmd); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create command"})
 		}
-		h.pushCommand(cmd)
+		h.pushCommand(ctx, cmd)
 		created = append(created, cmd)
 	}
 
@@ -150,7 +151,7 @@ func (h *CommandHandler) CreateForGroup(c echo.Context) error {
 		if err := h.commands.Create(ctx, cmd); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create command"})
 		}
-		h.pushCommand(cmd)
+		h.pushCommand(ctx, cmd)
 		created = append(created, cmd)
 	}
 
@@ -158,10 +159,21 @@ func (h *CommandHandler) CreateForGroup(c echo.Context) error {
 }
 
 // pushCommand attempts to deliver a command via WebSocket if the hub is available
-// and the target node is online. Errors are silently ignored since the command
-// is already persisted and can be picked up on next connect.
-func (h *CommandHandler) pushCommand(cmd *store.NodeCommand) {
-	if h.hub == nil {
+// and the target node is online.
+//
+// To avoid double-delivery (push over WS, then the agent re-polls the same
+// still-Pending command via GetCommands), the command is atomically claimed
+// Pending→Delivered first and only pushed if this call won the claim. When the
+// node is offline we do NOT claim, leaving the command Pending for the next poll
+// or reconnect. Errors are best-effort: the command is persisted either way.
+func (h *CommandHandler) pushCommand(ctx context.Context, cmd *store.NodeCommand) {
+	if h.hub == nil || !h.hub.IsOnline(cmd.ManagedNodeID) {
+		return
+	}
+	claimed, err := h.commands.ClaimForDelivery(ctx, cmd.ID)
+	if err != nil || !claimed {
+		// Either the claim failed or another path (a concurrent poll) already
+		// claimed it and will deliver it; don't push a duplicate.
 		return
 	}
 	payload := struct {

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -291,7 +291,15 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 				"error": "local ISO serving is not configured on this server; provide imageUrl with a URL the BMC can reach",
 			})
 		}
-		absISO := filepath.Join(h.artifactsDir, artifactID, isoFile)
+		// ArtifactFiles stores each file's path relative to the server's working
+		// directory (e.g. "data/artifacts/<id>/foo.iso"). Resolve it to an
+		// absolute path: isoserve.Register requires an absolute path, and
+		// re-joining it with artifactsDir/artifactID would double the prefix into
+		// a bogus path that does not exist.
+		absISO, err := filepath.Abs(isoFile)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("resolving artifact ISO path: %v", err)})
+		}
 		servedURL, token, err := h.isoServe.Register(absISO, redfishDeployTimeout+5*time.Minute)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to serve artifact ISO: %v", err)})

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -163,12 +163,16 @@ var _ = Describe("DeployHandler.DeployRedfish", func() {
 		artifactsDir = GinkgoT().TempDir()
 		// Lay down the artifact's on-disk ISO at <dir>/art-1/kairos.iso.
 		Expect(os.MkdirAll(filepath.Join(artifactsDir, "art-1"), 0755)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(artifactsDir, "art-1", "kairos.iso"), []byte("ISO-BYTES"), 0644)).To(Succeed())
+		isoPath := filepath.Join(artifactsDir, "art-1", "kairos.iso")
+		Expect(os.WriteFile(isoPath, []byte("ISO-BYTES"), 0644)).To(Succeed())
 
 		artifacts = &fakeArtifactStore{}
+		// ArtifactFiles stores each file's FULL path (as the builder writes it),
+		// not a bare basename. Modelling it as a basename previously masked a
+		// path-doubling bug in DeployRedfish, so use the real format here.
 		Expect(artifacts.Create(context.Background(), &store.ArtifactRecord{
 			ID:            "art-1",
-			ArtifactFiles: []string{"kairos.iso"},
+			ArtifactFiles: []string{isoPath},
 		})).To(Succeed())
 		deployments = &fakeDeploymentStore{}
 		bmcTargets = &fakeBMCTargetStore{}

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -228,6 +228,18 @@ func (f *fakeCommandStore) MarkDelivered(_ context.Context, ids []string) error 
 	return nil
 }
 
+func (f *fakeCommandStore) ClaimForDelivery(_ context.Context, id string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, cmd := range f.cmds {
+		if cmd.ID == id && cmd.Phase == store.CommandPending {
+			cmd.Phase = store.CommandDelivered
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (f *fakeCommandStore) UpdateStatus(_ context.Context, id string, phase string, result string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -209,7 +209,11 @@ func (f *fakeCommandStore) GetPending(_ context.Context, nodeID string) ([]*stor
 	var result []*store.NodeCommand
 	for _, cmd := range f.cmds {
 		if cmd.ManagedNodeID == nodeID && cmd.Phase == store.CommandPending {
-			result = append(result, cmd)
+			// Return a copy, not the stored pointer: real gorm GetPending
+			// materializes a fresh struct per query, so callers (e.g. concurrent
+			// polls in GetCommands) must each get their own object to mutate.
+			cp := *cmd
+			result = append(result, &cp)
 		}
 	}
 	return result, nil

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -243,19 +243,25 @@ func (h *NodeHandler) Decommission(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to queue unregister command"})
 	}
 
-	payload := struct {
-		ID      string            `json:"id"`
-		Command string            `json:"command"`
-		Args    map[string]string `json:"args,omitempty"`
-	}{
-		ID:      cmd.ID,
-		Command: cmd.Command,
+	// Claim the command Pending→Delivered before pushing so the agent's next
+	// REST poll won't re-deliver this same unregister command. If another path
+	// already claimed it (a poll racing this push) we skip the push: it will be
+	// delivered exactly once by whichever path won.
+	if claimed, err := h.commands.ClaimForDelivery(ctx, cmd.ID); err == nil && claimed {
+		payload := struct {
+			ID      string            `json:"id"`
+			Command string            `json:"command"`
+			Args    map[string]string `json:"args,omitempty"`
+		}{
+			ID:      cmd.ID,
+			Command: cmd.Command,
+		}
+		// Errors from SendCommand are best-effort — the command is already
+		// persisted (and now Delivered), and the WS layer will surface it on
+		// the next reconnect if the agent happens to drop between IsOnline and
+		// the write. The UI has the ExpiresAt to decide when to give up.
+		_ = h.hub.SendCommand(nodeID, payload)
 	}
-	// Errors from SendCommand are best-effort — the command is already
-	// persisted, and the WS layer will pick it up on the next reconnect if
-	// the agent happens to drop between IsOnline and the write. The UI has
-	// the ExpiresAt to decide when to give up.
-	_ = h.hub.SendCommand(nodeID, payload)
 
 	return c.JSON(http.StatusOK, decommissionResponse{CommandID: cmd.ID, NodeOnline: true})
 }
@@ -369,29 +375,33 @@ func (h *NodeHandler) GetCommands(c echo.Context) error {
 			return c.JSON(http.StatusForbidden, map[string]string{"error": "forbidden"})
 		}
 
-		cmds, err := h.commands.GetPending(c.Request().Context(), nodeID)
+		ctx := c.Request().Context()
+		cmds, err := h.commands.GetPending(ctx, nodeID)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to get commands"})
 		}
-		if cmds == nil {
-			cmds = []*store.NodeCommand{}
-		}
 
-		// Mark them as delivered
-		ids := make([]string, len(cmds))
-		for i, cmd := range cmds {
-			ids[i] = cmd.ID
-		}
-		if len(ids) > 0 {
-			now := time.Now()
-			_ = h.commands.MarkDelivered(c.Request().Context(), ids)
-			for _, cmd := range cmds {
-				cmd.Phase = store.CommandDelivered
-				cmd.DeliveredAt = &now
+		// Atomically claim each pending command Pending→Delivered and return only
+		// the ones THIS poll actually claimed. Claiming per command (instead of a
+		// bulk MarkDelivered) makes delivery exactly-once: if a concurrent poll or
+		// a WS push already claimed a command, our claim returns false and we skip
+		// it, so the same command is never handed to two deliveries.
+		now := time.Now()
+		claimed := make([]*store.NodeCommand, 0, len(cmds))
+		for _, cmd := range cmds {
+			ok, err := h.commands.ClaimForDelivery(ctx, cmd.ID)
+			if err != nil {
+				return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to get commands"})
 			}
+			if !ok {
+				continue
+			}
+			cmd.Phase = store.CommandDelivered
+			cmd.DeliveredAt = &now
+			claimed = append(claimed, cmd)
 		}
 
-		return c.JSON(http.StatusOK, cmds)
+		return c.JSON(http.StatusOK, claimed)
 	}
 
 	// Admin request: return all commands for the node

--- a/pkg/handlers/nodes_test.go
+++ b/pkg/handlers/nodes_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -312,6 +313,71 @@ var _ = Describe("NodeHandler", func() {
 			Expect(json.Unmarshal(rec.Body.Bytes(), &cmds)).To(Succeed())
 			Expect(cmds).To(HaveLen(1))
 			Expect(cmds[0].ID).To(Equal("cmd-1"))
+		})
+
+		It("does not re-deliver a command already claimed (e.g. pushed over WS)", func() {
+			ns.nodes = []*store.ManagedNode{{ID: "node-1"}}
+			// Simulate a command that was already delivered via the WS push path:
+			// pushCommand claims it Pending->Delivered before sending.
+			cs.cmds = []*store.NodeCommand{
+				{ID: "cmd-1", ManagedNodeID: "node-1", Command: "upgrade", Phase: store.CommandDelivered},
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/nodes/node-1/commands", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("nodeID")
+			c.SetParamValues("node-1")
+			c.Set(auth.ContextKeyNodeID, "node-1")
+
+			Expect(handler.GetCommands(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var cmds []*store.NodeCommand
+			Expect(json.Unmarshal(rec.Body.Bytes(), &cmds)).To(Succeed())
+			Expect(cmds).To(BeEmpty())
+		})
+
+		It("delivers a command to exactly one of two concurrent agent polls", func() {
+			ns.nodes = []*store.ManagedNode{{ID: "node-1"}}
+			cs.cmds = []*store.NodeCommand{
+				{ID: "cmd-1", ManagedNodeID: "node-1", Command: "upgrade", Phase: store.CommandPending},
+			}
+
+			// poll runs on a worker goroutine, so it returns its result instead of
+			// asserting (Ginkgo assertions must run on the spec goroutine).
+			poll := func() (int, error) {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/nodes/node-1/commands", nil)
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+				c.SetParamNames("nodeID")
+				c.SetParamValues("node-1")
+				c.Set(auth.ContextKeyNodeID, "node-1")
+				if err := handler.GetCommands(c); err != nil {
+					return 0, err
+				}
+				var cmds []*store.NodeCommand
+				if err := json.Unmarshal(rec.Body.Bytes(), &cmds); err != nil {
+					return 0, err
+				}
+				return len(cmds), nil
+			}
+
+			var wg sync.WaitGroup
+			counts := make([]int, 2)
+			errs := make([]error, 2)
+			for i := 0; i < 2; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					counts[i], errs[i] = poll()
+				}(i)
+			}
+			wg.Wait()
+
+			Expect(errs[0]).NotTo(HaveOccurred())
+			Expect(errs[1]).NotTo(HaveOccurred())
+			Expect(counts[0] + counts[1]).To(Equal(1))
 		})
 
 		It("should return all commands for admin", func() {

--- a/pkg/ops/inject_iso_test.go
+++ b/pkg/ops/inject_iso_test.go
@@ -1,0 +1,81 @@
+package ops
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kairos-io/AuroraBoot/pkg/schema"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InjectISO", Label("iso"), func() {
+	// InjectISO must not mutate the process working directory: builds run as
+	// concurrent goroutines in `web` mode and a global os.Chdir would corrupt
+	// sibling builds. This spec drives the cloud-config injection branch (a
+	// non-empty config.yaml in dst) and asserts the cwd is identical before and
+	// after, and that the injected config is present in the ISO.
+	It("injects cloud-config without changing the process working directory", func() {
+		if _, err := exec.LookPath("xorriso"); err != nil {
+			Skip("xorriso not installed")
+		}
+
+		dst := GinkgoT().TempDir()
+
+		// A non-empty config.yaml in dst triggers the injection branch.
+		Expect(os.WriteFile(filepath.Join(dst, "config.yaml"),
+			[]byte("#cloud-config\nhostname: injected\n"), 0o644)).To(Succeed())
+
+		// Build a minimal source ISO from a payload dir so xorriso has a real
+		// -indev/-outdev to replay against.
+		payload := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(payload, "placeholder"), []byte("x"), 0o644)).To(Succeed())
+		isoFile := filepath.Join(GinkgoT().TempDir(), "source.iso")
+		mk := exec.Command("xorriso", "-as", "mkisofs", "-o", isoFile, payload)
+		out, err := mk.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), string(out))
+
+		beforeWD, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+
+		fn := InjectISO(
+			func() string { return dst },
+			func() string { return isoFile },
+			schema.ISO{},
+		)
+		Expect(fn(context.Background())).To(Succeed())
+
+		afterWD, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(afterWD).To(Equal(beforeWD), "InjectISO must not change the process cwd")
+
+		// The injected config.yaml must now be present inside the ISO.
+		ls := exec.Command("xorriso", "-indev", isoFile, "-find", "/config.yaml")
+		lsOut, lsErr := ls.CombinedOutput()
+		Expect(lsErr).NotTo(HaveOccurred(), string(lsOut))
+		Expect(string(lsOut)).To(ContainSubstring("config.yaml"))
+	})
+
+	It("does not change the process working directory when xorriso fails", func() {
+		dst := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(dst, "config.yaml"),
+			[]byte("#cloud-config\nhostname: injected\n"), 0o644)).To(Succeed())
+
+		beforeWD, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+
+		// A bogus iso path makes xorriso fail; cwd must still be preserved.
+		fn := InjectISO(
+			func() string { return dst },
+			func() string { return filepath.Join(GinkgoT().TempDir(), "does-not-exist.iso") },
+			schema.ISO{},
+		)
+		_ = fn(context.Background())
+
+		afterWD, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(afterWD).To(Equal(beforeWD), "InjectISO must not change the process cwd even on failure")
+	})
+})

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -198,23 +198,11 @@ func InjectISO(dstFunc, isoFunc valueGetOnCall, i schema.ISO) func(ctx context.C
 		if _, err := os.Stat(filepath.Join(dst, "config.yaml")); err == nil {
 			f, err := os.ReadFile(filepath.Join(dst, "config.yaml"))
 			if err == nil && f != nil && len(f) > 0 {
-				currentCWD, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("failed to get current working directory: %w", err)
-				}
-				// Go back to the original working directory after we are done
-				defer func() {
-					if err := os.Chdir(currentCWD); err != nil {
-						internal.Log.Logger.Error().Err(err).Msg("failed to change back to original working directory")
-					}
-				}()
-
-				// Change to the destination directory so we can run xorriso from there
-				err = os.Chdir(dst)
-				if err != nil {
-					return fmt.Errorf("failed to change to destination directory '%s': %w", dst, err)
-				}
-
+				// No os.Chdir here: every path below (isoFile, tmp, and the
+				// config.yaml source) is already absolute, and xorriso is given
+				// absolute -indev/-outdev/-map paths. Builds run as concurrent
+				// goroutines in `web` mode, where a process-global chdir would
+				// corrupt sibling builds — so we must not mutate the cwd.
 				internal.Log.Logger.Info().Msgf("Adding cloud config file to '%s'", isoFile)
 				err = copy.Copy(filepath.Join(dst, "config.yaml"), filepath.Join(tmp, "config.yaml"))
 				if err != nil {

--- a/pkg/ops/network.go
+++ b/pkg/ops/network.go
@@ -21,10 +21,14 @@ func ServeArtifacts(listenAddr string, dirFunc valueGetOnCall) func(ctx context.
 	return func(ctx context.Context) error {
 		dir := dirFunc()
 		fs := http.FileServer(http.Dir(dir))
-		http.Handle("/", fs)
+		// Use a private mux instead of http.DefaultServeMux: registering "/" on
+		// the global mux panics ("multiple registrations for /") if this runs
+		// more than once in a process and leaks the handler across servers.
+		mux := http.NewServeMux()
+		mux.Handle("/", fs)
 		serverOne := &http.Server{
 			Addr:    listenAddr,
-			Handler: nil,
+			Handler: mux,
 		}
 		go func() {
 			<-ctx.Done()

--- a/pkg/ops/serve_artifacts_test.go
+++ b/pkg/ops/serve_artifacts_test.go
@@ -1,0 +1,80 @@
+package ops
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// freeAddr asks the OS for a currently-free TCP port and returns it as a
+// host:port string, so two ServeArtifacts instances can bind distinct ports.
+func freeAddr() string {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	Expect(err).NotTo(HaveOccurred())
+	addr := l.Addr().String()
+	Expect(l.Close()).To(Succeed())
+	return addr
+}
+
+var _ = Describe("ServeArtifacts", Label("network"), func() {
+	// ServeArtifacts must register its file handler on a private mux, not the
+	// global http.DefaultServeMux: registering "/" globally panics on the second
+	// call. Starting two instances proves no global state is shared.
+	It("starts two instances without panicking and serves the configured dir", func() {
+		dirA := GinkgoT().TempDir()
+		dirB := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(dirA, "a.txt"), []byte("from-A"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dirB, "b.txt"), []byte("from-B"), 0o644)).To(Succeed())
+
+		addrA := freeAddr()
+		addrB := freeAddr()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+
+		start := func(addr, dir string) {
+			fn := ServeArtifacts(addr, func() string { return dir })
+			go func() {
+				defer GinkgoRecover()
+				// ListenAndServe returns ErrServerClosed on Shutdown; both
+				// instances registering "/" must NOT panic on a shared mux.
+				_ = fn(ctx)
+			}()
+		}
+		start(addrA, dirA)
+		start(addrB, dirB)
+
+		get := func(addr, path string) (int, string) {
+			var code int
+			var body string
+			Eventually(func() error {
+				resp, err := http.Get(fmt.Sprintf("http://%s/%s", addr, path))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				b, _ := io.ReadAll(resp.Body)
+				code = resp.StatusCode
+				body = string(b)
+				return nil
+			}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+			return code, body
+		}
+
+		codeA, bodyA := get(addrA, "a.txt")
+		Expect(codeA).To(Equal(http.StatusOK))
+		Expect(bodyA).To(Equal("from-A"))
+
+		codeB, bodyB := get(addrB, "b.txt")
+		Expect(codeB).To(Equal(http.StatusOK))
+		Expect(bodyB).To(Equal("from-B"))
+	})
+})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -102,6 +102,17 @@ func (f *fakeCommandStore) GetPending(_ context.Context, nodeID string) ([]*stor
 	return out, nil
 }
 func (f *fakeCommandStore) MarkDelivered(_ context.Context, _ []string) error { return nil }
+func (f *fakeCommandStore) ClaimForDelivery(_ context.Context, id string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.cmds {
+		if c.ID == id && c.Phase == store.CommandPending {
+			c.Phase = store.CommandDelivered
+			return true, nil
+		}
+	}
+	return false, nil
+}
 func (f *fakeCommandStore) UpdateStatus(_ context.Context, _ string, _ string, _ string) error {
 	return nil
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -120,6 +120,12 @@ type CommandStore interface {
 	GetByID(ctx context.Context, id string) (*NodeCommand, error)
 	GetPending(ctx context.Context, nodeID string) ([]*NodeCommand, error)
 	MarkDelivered(ctx context.Context, ids []string) error
+	// ClaimForDelivery atomically transitions a single command from Pending to
+	// Delivered. It returns true only if this call performed the transition, so
+	// exactly one of several concurrent claimants (a WS push and an agent poll,
+	// or two concurrent polls) wins. A command that is missing or no longer
+	// Pending yields (false, nil).
+	ClaimForDelivery(ctx context.Context, id string) (bool, error)
 	UpdateStatus(ctx context.Context, id string, phase string, result string) error
 	// UpdateStatusForNode updates a command's status only if it belongs to
 	// nodeID. It returns ErrCommandNotFound when no command matches both the

--- a/pkg/uki/uki.go
+++ b/pkg/uki/uki.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
 	"github.com/kairos-io/AuroraBoot/pkg/ops"
@@ -34,6 +35,16 @@ import (
 	"github.com/u-root/u-root/pkg/cpio"
 	"golang.org/x/exp/maps"
 )
+
+// buildCWDMu serializes the portion of Build that mutates the process working
+// directory. os.Chdir is process-global, and in `web` mode builds run as
+// concurrent goroutines, so two overlapping Build calls would clobber each
+// other's cwd. Eliminating the chdir here is not cleanly possible: the
+// go-ukify Builder writes its UKI to a cwd-relative OutUKIPath and the
+// downstream cpio packing walks the cwd ("."), so both depend on cwd ==
+// sourceDir. Until those are made cwd-independent, we serialize the
+// chdir->Build->restore critical section instead.
+var buildCWDMu sync.Mutex
 
 // Options configures a UKI build.
 type Options struct {
@@ -172,6 +183,14 @@ func Build(opts Options) (err error) {
 	if secureBootEnroll == "" {
 		secureBootEnroll = "if-safe"
 	}
+
+	// Serialize the cwd-mutating region: we Chdir into the rootfs during the
+	// build, and a concurrent Build in `web` mode would otherwise clobber our
+	// cwd (and vice versa). Lock before capturing origWD and unlock after the
+	// restore defer below (defers run LIFO, so this Unlock runs after the
+	// Chdir-restore), keeping the whole chdir window mutually exclusive.
+	buildCWDMu.Lock()
+	defer buildCWDMu.Unlock()
 
 	// Preserve cwd — we Chdir into the rootfs during the build and must restore
 	// it so callers using this as a library don't observe the side effect.

--- a/pkg/utils/pxeUki.go
+++ b/pkg/utils/pxeUki.go
@@ -162,16 +162,25 @@ func offerDhcpPackage(pkt *dhcp4.Packet, serverIP net.IP, log logger.KairosLogge
 	return resp, nil
 }
 
-// serveHTTP starts an HTTP server that serves the specified ISO file for all requests.
-func serveHTTP(isoFile string, log logger.KairosLogger) error {
+// isoServeMux returns a private mux that serves isoFile for all requests. It is
+// deliberately a fresh http.NewServeMux per call rather than the global
+// http.DefaultServeMux: registering "/" on the global mux panics on a second
+// call ("multiple registrations for /") and leaks the handler across servers.
+func isoServeMux(isoFile string, log logger.KairosLogger) *http.ServeMux {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Logger.Info().Str("method", r.Method).Str("url", r.URL.Path).Msg("Serving kairos.iso for all requests")
 		http.ServeFile(w, r, isoFile)
 	})
+	mux := http.NewServeMux()
+	mux.Handle("/", handler)
+	return mux
+}
 
-	http.Handle("/", handler)
+// serveHTTP starts an HTTP server that serves the specified ISO file for all requests.
+func serveHTTP(isoFile string, log logger.KairosLogger) error {
+	srv := &http.Server{Addr: ":80", Handler: isoServeMux(isoFile, log)}
 	log.Logger.Info().Str("subsystem", "HTTP").Msg("Listening for requests on :80")
-	err := http.ListenAndServe(":80", nil)
+	err := srv.ListenAndServe()
 	if err != nil {
 		log.Logger.Error().Err(err).Msg("Error starting HTTP server")
 	}

--- a/pkg/utils/pxeUki_internal_test.go
+++ b/pkg/utils/pxeUki_internal_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kairos-io/kairos-sdk/types/logger"
+)
+
+// isoServeMux must build a fresh, private mux each call so it can be constructed
+// repeatedly without panicking on the global http.DefaultServeMux ("multiple
+// registrations for /"), and must serve the configured ISO file for any path.
+func TestISOServeMuxNoGlobalState(t *testing.T) {
+	log := logger.NewKairosLogger("test", "fatal", false)
+
+	dir := t.TempDir()
+	isoFile := filepath.Join(dir, "kairos.iso")
+	want := []byte("iso-bytes")
+	if err := os.WriteFile(isoFile, want, 0o644); err != nil {
+		t.Fatalf("writing iso file: %v", err)
+	}
+
+	// Constructing the mux twice must not panic (it would on DefaultServeMux).
+	mux1 := isoServeMux(isoFile, log)
+	mux2 := isoServeMux(isoFile, log)
+	if mux1 == nil || mux2 == nil {
+		t.Fatal("isoServeMux returned nil")
+	}
+
+	// Both muxes serve the ISO content for an arbitrary path.
+	for i, mux := range []*http.ServeMux{mux1, mux2} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("mux %d: status = %d, want 200", i, rec.Code)
+		}
+		if rec.Body.String() != string(want) {
+			t.Fatalf("mux %d: body = %q, want %q", i, rec.Body.String(), string(want))
+		}
+	}
+}

--- a/pkg/ws/concurrency_test.go
+++ b/pkg/ws/concurrency_test.go
@@ -1,0 +1,164 @@
+package ws_test
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/kairos-io/AuroraBoot/pkg/ws"
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These specs exercise the per-connection write lock added to defend against
+// gorilla/websocket's "concurrent write to websocket connection" panic. They are
+// meaningful under `go test -race`: without serialized writes the race detector
+// fires (or gorilla panics) when several goroutines write to one conn.
+var _ = Describe("WebSocket concurrent writers", func() {
+	var (
+		hub      *ws.Hub
+		gormDB   *gormstore.Store
+		nodes    store.NodeStore
+		commands store.CommandStore
+		server   *httptest.Server
+		nodeID   string
+		apiKey   string
+	)
+
+	BeforeEach(func() {
+		var err error
+		machineNum := testCounter.Add(1)
+		dbName := fmt.Sprintf("%s/ws_conc_%d.db", GinkgoT().TempDir(), machineNum)
+		gormDB, err = gormstore.New(dbName)
+		Expect(err).NotTo(HaveOccurred())
+
+		nodes = &gormstore.NodeStoreAdapter{S: gormDB}
+		commands = &gormstore.CommandStoreAdapter{S: gormDB}
+		hub = ws.NewHub()
+
+		testNode := &store.ManagedNode{
+			MachineID: fmt.Sprintf("machine-conc-%d", machineNum),
+			Hostname:  "conc-host",
+			Labels:    map[string]string{},
+		}
+		Expect(nodes.Register(context.Background(), testNode)).To(Succeed())
+		nodeID = testNode.ID
+		apiKey = testNode.APIKey
+
+		agentHandler := &ws.AgentHandler{Hub: hub, Nodes: nodes, Commands: commands}
+		uiHandler := &ws.UIHandler{Hub: hub}
+
+		e := echo.New()
+		e.GET("/api/v1/ws", agentHandler.HandleAgentWS)
+		e.GET("/api/v1/ws/ui", uiHandler.HandleUIWS)
+		server = httptest.NewServer(e)
+
+		DeferCleanup(func() {
+			server.Close()
+			_ = gormDB.Close()
+		})
+	})
+
+	It("serializes many concurrent SendCommand to one node without racing", func() {
+		conn, _, err := dialWS(server, "/api/v1/ws?token="+apiKey)
+		Expect(err).NotTo(HaveOccurred())
+		defer conn.Close()
+
+		Eventually(func() bool { return hub.IsOnline(nodeID) },
+			10*time.Second, 50*time.Millisecond).Should(BeTrue())
+
+		const n = 200
+
+		// Drain the reader so writes don't block on a full buffer; count the
+		// command frames we receive back.
+		received := make(chan struct{}, n)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			conn.SetReadDeadline(time.Now().Add(15 * time.Second))
+			for i := 0; i < n; i++ {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+				received <- struct{}{}
+			}
+		}()
+
+		var wg sync.WaitGroup
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				Expect(hub.SendCommand(nodeID, commandData{
+					ID:      fmt.Sprintf("cmd-%d", i),
+					Command: "exec",
+				})).To(Succeed())
+			}(i)
+		}
+		wg.Wait()
+
+		got := 0
+		for got < n {
+			select {
+			case <-received:
+				got++
+			case <-time.After(10 * time.Second):
+				Fail(fmt.Sprintf("only received %d/%d command frames", got, n))
+			}
+		}
+		Expect(got).To(Equal(n))
+	})
+
+	It("serializes concurrent UI Broadcasts to one connection without racing", func() {
+		uiURL := "ws" + server.URL[len("http"):] + "/api/v1/ws/ui"
+		conn, _, err := websocket.DefaultDialer.Dial(uiURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		defer conn.Close()
+
+		Eventually(func() int { return hub.UI.Count() },
+			5*time.Second, 50*time.Millisecond).Should(Equal(1))
+
+		const n = 200
+		received := make(chan struct{}, n)
+		go func() {
+			conn.SetReadDeadline(time.Now().Add(15 * time.Second))
+			for {
+				mt, _, err := conn.ReadMessage()
+				if err != nil {
+					return
+				}
+				// Ignore control frames; count text broadcasts only.
+				if mt == websocket.TextMessage {
+					received <- struct{}{}
+				}
+			}
+		}()
+
+		var wg sync.WaitGroup
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				hub.UI.Broadcast(map[string]any{"type": "test", "seq": i})
+			}(i)
+		}
+		wg.Wait()
+
+		got := 0
+		for got < n {
+			select {
+			case <-received:
+				got++
+			case <-time.After(10 * time.Second):
+				Fail(fmt.Sprintf("only received %d/%d broadcast frames", got, n))
+			}
+		}
+		Expect(got).To(Equal(n))
+	})
+})

--- a/pkg/ws/conn.go
+++ b/pkg/ws/conn.go
@@ -1,0 +1,41 @@
+package ws
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// wsConn wraps a *websocket.Conn with a per-connection write mutex.
+//
+// gorilla/websocket permits at most one concurrent writer per connection: it is
+// the caller's responsibility to serialize writes. In this server several
+// goroutines write to the same connection — the hub's SendCommand/Broadcast, the
+// agent read-loop's response writes, and the UI ping ticker — so every write
+// must go through writeMessage/writeControl to take this lock. The hub's map
+// mutex (Hub.mu / UIHub.mu) guards map access only and is intentionally separate
+// from this per-connection write lock.
+type wsConn struct {
+	*websocket.Conn
+	writeMu sync.Mutex
+}
+
+// newConn wraps a raw gorilla connection so all writes are serialized.
+func newConn(c *websocket.Conn) *wsConn {
+	return &wsConn{Conn: c}
+}
+
+// writeMessage serializes a data-frame write to the connection.
+func (c *wsConn) writeMessage(messageType int, data []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.Conn.WriteMessage(messageType, data)
+}
+
+// writeControl serializes a control-frame write (e.g. ping) to the connection.
+func (c *wsConn) writeControl(messageType int, data []byte, deadline time.Time) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.Conn.WriteControl(messageType, data, deadline)
+}

--- a/pkg/ws/handler.go
+++ b/pkg/ws/handler.go
@@ -70,8 +70,10 @@ func (h *AgentHandler) HandleAgentWS(c echo.Context) error {
 	}
 	defer conn.Close()
 
-	// Register in hub and mark node online.
-	h.Hub.Register(node.ID, conn)
+	// Register in hub and mark node online. wc wraps conn with a per-connection
+	// write lock; all writes to this connection (here and from the hub) must go
+	// through it so they don't race.
+	wc := h.Hub.Register(node.ID, conn)
 	if err := h.Nodes.UpdatePhase(ctx, node.ID, store.PhaseOnline); err != nil {
 		log.Printf("ws: failed to update node phase: %v", err)
 	}
@@ -87,7 +89,7 @@ func (h *AgentHandler) HandleAgentWS(c echo.Context) error {
 	}()
 
 	// Send pending commands on connect.
-	h.sendPendingCommands(node.ID, conn)
+	h.sendPendingCommands(node.ID, wc)
 
 	// Read loop.
 	for {
@@ -165,7 +167,7 @@ func (h *AgentHandler) handleCommandStatus(nodeID string, data json.RawMessage) 
 	}
 }
 
-func (h *AgentHandler) sendPendingCommands(nodeID string, conn *websocket.Conn) {
+func (h *AgentHandler) sendPendingCommands(nodeID string, conn *wsConn) {
 	ctx := context.Background()
 	cmds, err := h.Commands.GetPending(ctx, nodeID)
 	if err != nil || len(cmds) == 0 {
@@ -191,7 +193,7 @@ func (h *AgentHandler) sendPendingCommands(nodeID string, conn *websocket.Conn) 
 			continue
 		}
 
-		if err := conn.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+		if err := conn.writeMessage(websocket.TextMessage, msgBytes); err != nil {
 			log.Printf("ws: failed to send pending command %s to node %s: %v", cmd.ID, nodeID, err)
 			break
 		}
@@ -218,11 +220,16 @@ func (h *UIHandler) HandleUIWS(c echo.Context) error {
 	}
 	defer conn.Close()
 
-	// Register with UIHub for broadcast support.
-	var uiID string
+	// Register with UIHub for broadcast support. wc wraps conn with a
+	// per-connection write lock; the ping ticker below writes through it so it
+	// never races a concurrent Broadcast on the same conn.
+	var wc *wsConn
 	if h.Hub != nil && h.Hub.UI != nil {
-		uiID = h.Hub.UI.Register(conn)
+		var uiID string
+		uiID, wc = h.Hub.UI.Register(conn)
 		defer h.Hub.UI.Unregister(uiID)
+	} else {
+		wc = newConn(conn)
 	}
 
 	// Keep connection alive with ping/pong.
@@ -251,7 +258,7 @@ func (h *UIHandler) HandleUIWS(c echo.Context) error {
 		case <-done:
 			return nil
 		case <-ticker.C:
-			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+			if err := wc.writeControl(websocket.PingMessage, nil, time.Now().Add(10*time.Second)); err != nil {
 				return nil
 			}
 		}

--- a/pkg/ws/handler.go
+++ b/pkg/ws/handler.go
@@ -174,8 +174,20 @@ func (h *AgentHandler) sendPendingCommands(nodeID string, conn *wsConn) {
 		return
 	}
 
-	var delivered []string
 	for _, cmd := range cmds {
+		// Atomically claim Pending→Delivered before sending so a concurrent REST
+		// poll or WS push can't also deliver the same command. If another path
+		// already claimed it, our claim returns false and we skip it — exactly-once
+		// delivery, consistent with the poll path in NodeHandler.GetCommands.
+		claimed, err := h.Commands.ClaimForDelivery(ctx, cmd.ID)
+		if err != nil {
+			log.Printf("ws: failed to claim pending command %s for node %s: %v", cmd.ID, nodeID, err)
+			continue
+		}
+		if !claimed {
+			continue
+		}
+
 		cmdMsg := commandData{
 			ID:      cmd.ID,
 			Command: cmd.Command,
@@ -196,13 +208,6 @@ func (h *AgentHandler) sendPendingCommands(nodeID string, conn *wsConn) {
 		if err := conn.writeMessage(websocket.TextMessage, msgBytes); err != nil {
 			log.Printf("ws: failed to send pending command %s to node %s: %v", cmd.ID, nodeID, err)
 			break
-		}
-		delivered = append(delivered, cmd.ID)
-	}
-
-	if len(delivered) > 0 {
-		if err := h.Commands.MarkDelivered(ctx, delivered); err != nil {
-			log.Printf("ws: failed to mark commands as delivered: %v", err)
 		}
 	}
 }

--- a/pkg/ws/hub.go
+++ b/pkg/ws/hub.go
@@ -10,8 +10,13 @@ import (
 )
 
 // Hub tracks active WebSocket connections per node.
+//
+// mu guards the connections map only. Each stored *wsConn carries its own write
+// mutex, so concurrent SendCommand calls to the same node — and any other writer
+// to that connection — are serialized at the connection level, as gorilla
+// requires, without holding the map lock across a network write.
 type Hub struct {
-	connections map[string]*websocket.Conn
+	connections map[string]*wsConn
 	mu          sync.RWMutex
 	UI          *UIHub
 }
@@ -19,16 +24,21 @@ type Hub struct {
 // NewHub creates a new Hub with an embedded UIHub.
 func NewHub() *Hub {
 	return &Hub{
-		connections: make(map[string]*websocket.Conn),
+		connections: make(map[string]*wsConn),
 		UI:          NewUIHub(),
 	}
 }
 
-// Register stores the WebSocket connection for the given node ID.
-func (h *Hub) Register(nodeID string, conn *websocket.Conn) {
+// Register stores the WebSocket connection for the given node ID and returns the
+// wrapped connection whose writeMessage/writeControl methods serialize writes.
+// Callers (e.g. the agent read-loop) must route all of their own writes through
+// the returned wrapper so they don't race the hub's writes on the same conn.
+func (h *Hub) Register(nodeID string, conn *websocket.Conn) *wsConn {
+	wc := newConn(conn)
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.connections[nodeID] = conn
+	h.connections[nodeID] = wc
+	return wc
 }
 
 // Unregister removes the WebSocket connection for the given node ID.
@@ -41,9 +51,12 @@ func (h *Hub) Unregister(nodeID string) {
 // SendCommand sends a command message to the specified node via WebSocket.
 // Returns an error if the node is not connected.
 func (h *Hub) SendCommand(nodeID string, cmd any) error {
+	// Hold the map lock only long enough to look up the connection; the actual
+	// network write happens under the per-connection write lock so concurrent
+	// SendCommand calls to the same node are serialized without blocking the map.
 	h.mu.RLock()
-	defer h.mu.RUnlock()
 	conn, ok := h.connections[nodeID]
+	h.mu.RUnlock()
 
 	if !ok || conn == nil {
 		return fmt.Errorf("node %s is not connected", nodeID)
@@ -64,7 +77,7 @@ func (h *Hub) SendCommand(nodeID string, cmd any) error {
 		return fmt.Errorf("marshal ws message: %w", err)
 	}
 
-	if err := conn.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+	if err := conn.writeMessage(websocket.TextMessage, msgBytes); err != nil {
 		return fmt.Errorf("write message: %w", err)
 	}
 
@@ -72,24 +85,31 @@ func (h *Hub) SendCommand(nodeID string, cmd any) error {
 }
 
 // UIHub tracks active WebSocket connections from UI clients.
+//
+// As with Hub, mu guards the connections map only; each stored *wsConn carries
+// its own write mutex so concurrent Broadcasts (e.g. a build-log chunk and a
+// deploy-progress update) never race on the same UI connection.
 type UIHub struct {
-	connections map[string]*websocket.Conn
+	connections map[string]*wsConn
 	mu          sync.RWMutex
 	counter     atomic.Int64
 }
 
 // NewUIHub creates a new UIHub.
 func NewUIHub() *UIHub {
-	return &UIHub{connections: make(map[string]*websocket.Conn)}
+	return &UIHub{connections: make(map[string]*wsConn)}
 }
 
-// Register stores the WebSocket connection and returns its unique ID.
-func (h *UIHub) Register(conn *websocket.Conn) string {
+// Register stores the WebSocket connection and returns its unique ID and the
+// wrapped connection. The UI handler must route its own writes (the ping ticker)
+// through the returned wrapper so they don't race the hub's Broadcasts.
+func (h *UIHub) Register(conn *websocket.Conn) (string, *wsConn) {
 	id := fmt.Sprintf("ui-%d", h.counter.Add(1))
+	wc := newConn(conn)
 	h.mu.Lock()
-	h.connections[id] = conn
+	h.connections[id] = wc
 	h.mu.Unlock()
-	return id
+	return id, wc
 }
 
 // Unregister removes the WebSocket connection with the given ID.
@@ -99,16 +119,30 @@ func (h *UIHub) Unregister(id string) {
 	h.mu.Unlock()
 }
 
+// Count returns the number of currently connected UI clients.
+func (h *UIHub) Count() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.connections)
+}
+
 // Broadcast sends a message to all connected UI clients.
 func (h *UIHub) Broadcast(msg any) {
 	data, err := json.Marshal(msg)
 	if err != nil {
 		return
 	}
+	// Snapshot the connection set under the map lock, then write outside it so a
+	// slow client can't block other Broadcasts. Each write takes the per-conn
+	// write lock, serializing concurrent Broadcasts on the same connection.
 	h.mu.RLock()
-	defer h.mu.RUnlock()
+	conns := make([]*wsConn, 0, len(h.connections))
 	for _, conn := range h.connections {
-		_ = conn.WriteMessage(websocket.TextMessage, data)
+		conns = append(conns, conn)
+	}
+	h.mu.RUnlock()
+	for _, conn := range conns {
+		_ = conn.writeMessage(websocket.TextMessage, data)
 	}
 }
 


### PR DESCRIPTION
## What

Addresses the four #4117 **Medium** fleet-server concurrency/correctness items deferred from the security-hardening PR (#534), each as an independently reviewable commit, plus a follow-up that closes the last delivery-dedup window.

| Commit | Fix |
|---|---|
| `fix(ws): serialize all writes per WebSocket connection` | `gorilla/websocket` forbids concurrent writes to one `*Conn`, but `Hub.SendCommand` (under shared `RLock`), `UIHub.Broadcast`, the agent read-loop, and the UI ping ticker all wrote to the same conn. New `wsConn` wrapper (conn + per-conn write mutex); every write routes through it. Map locks are no longer held across network writes. |
| `fix(api): deliver each node command exactly once` | Admin-created commands were pushed over WS but left `Pending`, so the next REST poll re-delivered them. New atomic `ClaimForDelivery` (`UPDATE … WHERE phase=Pending`, RowsAffected); push and poll both claim-then-send. |
| `fix(ops): stop mutating process cwd in concurrent build paths` | `os.Chdir` corrupts cwd of concurrent goroutine builds in `web` mode. Eliminated in `InjectISO` (paths already absolute); serialized in `uki.Build` with a documented mutex (third-party go-ukify writes cwd-relative). |
| `fix(server): stop registering handlers on the global DefaultServeMux` | `ServeArtifacts` and the pxe-uki server used `http.Handle("/")` on `DefaultServeMux` → panic on a second registration. Each now uses a private `http.NewServeMux()`. |
| `fix(ws): claim pending commands on connect for exactly-once delivery` | `sendPendingCommands` switched from bulk `MarkDelivered` to per-command `ClaimForDelivery`, closing the last double-delivery window. |
| `test(handlers): return copies from fake GetPending to fix -race` | Test-fake aliasing defect surfaced by the new concurrent-poll test under `-race`; real gorm returns fresh structs per query. |

## Testing

- `go build ./...`, `go vet` (touched packages) — clean.
- `pkg/ws` and `pkg/handlers` green under **`-race`**; `internal/store/gorm`, `pkg/ops`, `pkg/uki`, `pkg/utils` green.
- New tests: 200 concurrent WS writers/conn; store-level + handler concurrent-claim "exactly one winner"; `InjectISO` leaves cwd unchanged; two mux instances without panic.
- Reviewed by an internal staff-engineer pass (production code sound; the one blocker it found — a test-fake `-race` defect — is fixed in the last commit).

## Known follow-ups (intentionally out of scope)

- `uki.Build` serializes concurrent UKI builds end-to-end (the mutex is taken before image extraction) — correctness is fine; throughput could be improved by acquiring it later.
- Claim-before-send is at-most-once on a write failure (command marked `Delivered` but the frame dropped → relies on `ExpiresAt`); consistent across all delivery paths.
- `MarkDelivered` is now unused in production (retained as an interface method).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Added: Redfish deploy ISO-path fix (`145b1a9`)

Bundled here (found while end-to-end testing the fleet server): `DeployRedfish` built the local ISO path as `filepath.Join(artifactsDir, artifactID, isoFile)`, but `ArtifactFiles` already stores each file's **full path** — so the prefix was doubled into a non-existent, relative path and `isoserve.Register` rejected it (`path ... is not absolute`). **Every local-artifact Redfish deploy failed; only explicit `--image-url` worked.** Fixed by resolving with `filepath.Abs`. The handler test modelled `ArtifactFiles` as a bare basename, masking the bug — corrected to the real full-path format, turning the "registers the on-disk ISO" spec into a regression guard. Closes a gap in #4111.