### PR TITLE
Fix uki builds through the web UI

### DIFF
--- a/pkg/uki/initramfs_test.go
+++ b/pkg/uki/initramfs_test.go
@@ -53,10 +53,10 @@ func readInitrd(initrdPath string) (map[string]cpio.Record, error) {
 
 // recordContent reads the bytes of a regular-file record.
 func recordContent(rec cpio.Record) ([]byte, error) {
-	buf := make([]byte, rec.FileSize)
 	if rec.FileSize == 0 {
-		return buf, nil
+		return []byte{}, nil
 	}
+	buf := make([]byte, int(rec.FileSize))
 	_, err := rec.ReadAt(buf, 0)
 	return buf, err
 }

--- a/pkg/uki/initramfs_test.go
+++ b/pkg/uki/initramfs_test.go
@@ -1,0 +1,204 @@
+package uki
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/u-root/u-root/pkg/cpio"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// readInitrd decompresses the zstd cpio "initrd" produced by createInitramfs
+// and returns its records keyed by name, so tests can assert on the layout.
+func readInitrd(initrdPath string) (map[string]cpio.Record, error) {
+	f, err := os.Open(initrdPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	zr, err := zstd.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer zr.Close()
+
+	raw, err := io.ReadAll(zr)
+	if err != nil {
+		return nil, err
+	}
+
+	archiver, err := cpio.Format("newc")
+	if err != nil {
+		return nil, err
+	}
+	records, err := cpio.ReadAllRecords(archiver.Reader(bytes.NewReader(raw)))
+	if err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]cpio.Record, len(records))
+	for _, rec := range records {
+		byName[rec.Name] = rec
+	}
+	return byName, nil
+}
+
+// recordContent reads the bytes of a regular-file record.
+func recordContent(rec cpio.Record) ([]byte, error) {
+	buf := make([]byte, rec.FileSize)
+	if rec.FileSize == 0 {
+		return buf, nil
+	}
+	_, err := rec.ReadAt(buf, 0)
+	return buf, err
+}
+
+var _ = Describe("createInitramfs", func() {
+	var sourceDir, artifactsDir string
+	var err error
+
+	BeforeEach(func() {
+		sourceDir, err = os.MkdirTemp("", "createInitramfs-src-")
+		Expect(err).ToNot(HaveOccurred())
+		artifactsDir, err = os.MkdirTemp("", "createInitramfs-art-")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(sourceDir)
+		os.RemoveAll(artifactsDir)
+	})
+
+	It("records every entry under a path relative to sourceDir, rooted at \".\"", func() {
+		Expect(os.MkdirAll(filepath.Join(sourceDir, "etc"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(sourceDir, "etc", "os-release"), []byte("ID=kairos\n"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(sourceDir, "init"), []byte("#!/bin/sh\n"), 0o755)).To(Succeed())
+
+		Expect(createInitramfs(sourceDir, artifactsDir)).To(Succeed())
+
+		records, err := readInitrd(filepath.Join(artifactsDir, "initrd"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Names are relative to sourceDir (no leading slash, no temp-dir prefix)
+		// and the rootfs root is recorded as ".".
+		Expect(records).To(HaveKey("."))
+		Expect(records).To(HaveKey("etc"))
+		Expect(records).To(HaveKey("etc/os-release"))
+		Expect(records).To(HaveKey("init"))
+		for name := range records {
+			Expect(name).ToNot(HavePrefix("/"), "record %q must not be absolute", name)
+			Expect(name).ToNot(ContainSubstring(sourceDir), "record %q leaked the temp sourceDir prefix", name)
+		}
+	})
+
+	It("round-trips regular file contents", func() {
+		want := []byte("ID=kairos\nVERSION=v3\n")
+		Expect(os.MkdirAll(filepath.Join(sourceDir, "etc"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(sourceDir, "etc", "os-release"), want, 0o644)).To(Succeed())
+
+		Expect(createInitramfs(sourceDir, artifactsDir)).To(Succeed())
+
+		records, err := readInitrd(filepath.Join(artifactsDir, "initrd"))
+		Expect(err).ToNot(HaveOccurred())
+
+		rec, ok := records["etc/os-release"]
+		Expect(ok).To(BeTrue())
+		got, err := recordContent(rec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(want))
+	})
+
+	It("excludes the top-level virtual filesystem directories", func() {
+		for _, dir := range []string{"sys", "run", "dev", "tmp", "proc"} {
+			Expect(os.MkdirAll(filepath.Join(sourceDir, dir), 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(sourceDir, dir, "marker"), []byte("x"), 0o644)).To(Succeed())
+		}
+		// A real file we expect to keep.
+		Expect(os.WriteFile(filepath.Join(sourceDir, "keep"), []byte("x"), 0o644)).To(Succeed())
+
+		Expect(createInitramfs(sourceDir, artifactsDir)).To(Succeed())
+
+		records, err := readInitrd(filepath.Join(artifactsDir, "initrd"))
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(records).To(HaveKey("keep"))
+		for _, dir := range []string{"sys", "run", "dev", "tmp", "proc"} {
+			Expect(records).ToNot(HaveKey(dir))
+			Expect(records).ToNot(HaveKey(dir+"/marker"))
+		}
+	})
+
+	It("only excludes those names at the top level, not nested ones", func() {
+		// "etc/sys" must survive: the exclude list matches the full relative
+		// path, not any path component.
+		Expect(os.MkdirAll(filepath.Join(sourceDir, "etc", "sys"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(sourceDir, "etc", "sys", "keep"), []byte("x"), 0o644)).To(Succeed())
+
+		Expect(createInitramfs(sourceDir, artifactsDir)).To(Succeed())
+
+		records, err := readInitrd(filepath.Join(artifactsDir, "initrd"))
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(records).To(HaveKey("etc/sys"))
+		Expect(records).To(HaveKey("etc/sys/keep"))
+	})
+
+	// Regression guard for the removed os.Chdir: createInitramfs must capture
+	// the sourceDir it is given, regardless of the process working directory
+	// and regardless of other builds running concurrently. The old
+	// chdir-into-sourceDir + Walk(".") approach raced on the process-global cwd
+	// and could pack the wrong rootfs under concurrency.
+	It("is independent of the process cwd and safe to run concurrently", func() {
+		const n = 8
+		srcDirs := make([]string, n)
+		artDirs := make([]string, n)
+		for i := 0; i < n; i++ {
+			srcDirs[i], err = os.MkdirTemp("", fmt.Sprintf("createInitramfs-conc-src-%d-", i))
+			Expect(err).ToNot(HaveOccurred())
+			artDirs[i], err = os.MkdirTemp("", fmt.Sprintf("createInitramfs-conc-art-%d-", i))
+			Expect(err).ToNot(HaveOccurred())
+			// Each rootfs gets a uniquely named marker file.
+			Expect(os.WriteFile(filepath.Join(srcDirs[i], fmt.Sprintf("marker-%d", i)), []byte("x"), 0o644)).To(Succeed())
+		}
+		defer func() {
+			for i := 0; i < n; i++ {
+				os.RemoveAll(srcDirs[i])
+				os.RemoveAll(artDirs[i])
+			}
+		}()
+
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				errs[i] = createInitramfs(srcDirs[i], artDirs[i])
+			}(i)
+		}
+		wg.Wait()
+
+		for i := 0; i < n; i++ {
+			Expect(errs[i]).ToNot(HaveOccurred())
+			records, err := readInitrd(filepath.Join(artDirs[i], "initrd"))
+			Expect(err).ToNot(HaveOccurred())
+			// Each initrd must contain exactly its own marker and none of the
+			// others — proving no cross-contamination via a shared cwd.
+			Expect(records).To(HaveKey(fmt.Sprintf("marker-%d", i)))
+			for j := 0; j < n; j++ {
+				if j == i {
+					continue
+				}
+				Expect(records).ToNot(HaveKey(fmt.Sprintf("marker-%d", j)))
+			}
+		}
+	})
+})

--- a/pkg/uki/uki.go
+++ b/pkg/uki/uki.go
@@ -136,6 +136,24 @@ type Options struct {
 	Logger *logger.KairosLogger
 }
 
+// absolutizeKeyPaths rewrites the key/cert/splash path options to absolute
+// paths. The build Chdir's into the rootfs partway through, so any relative
+// path must be resolved against the original working directory first.
+// pkcs11 URIs (valid for SBKey) and empty values are left untouched.
+func absolutizeKeyPaths(opts *Options) error {
+	for _, p := range []*string{&opts.TPMPCRPrivateKey, &opts.SBKey, &opts.SBCert, &opts.PublicKeysDir, &opts.Splash} {
+		if *p == "" || strings.Contains(*p, "pkcs11") {
+			continue
+		}
+		abs, err := filepath.Abs(*p)
+		if err != nil {
+			return fmt.Errorf("resolving path %q: %w", *p, err)
+		}
+		*p = abs
+	}
+	return nil
+}
+
 // Build runs the full UKI build pipeline as described by opts.
 //
 // It validates required fields, checks that the host binaries and bundled
@@ -146,6 +164,14 @@ type Options struct {
 // it before returning.
 func Build(opts Options) (err error) {
 	if err := opts.validate(); err != nil {
+		return err
+	}
+
+	// Resolve key/cert/splash paths to absolute before the build Chdir's into
+	// the rootfs. Relative paths (e.g. the web server passes paths relative to
+	// its working dir like "data/keys/...") would otherwise resolve against the
+	// wrong directory once os.Chdir runs and fail with "no such file".
+	if err := absolutizeKeyPaths(&opts); err != nil {
 		return err
 	}
 

--- a/pkg/uki/uki.go
+++ b/pkg/uki/uki.go
@@ -21,7 +21,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
 	"github.com/kairos-io/AuroraBoot/pkg/ops"
@@ -35,16 +34,6 @@ import (
 	"github.com/u-root/u-root/pkg/cpio"
 	"golang.org/x/exp/maps"
 )
-
-// buildCWDMu serializes the portion of Build that mutates the process working
-// directory. os.Chdir is process-global, and in `web` mode builds run as
-// concurrent goroutines, so two overlapping Build calls would clobber each
-// other's cwd. Eliminating the chdir here is not cleanly possible: the
-// go-ukify Builder writes its UKI to a cwd-relative OutUKIPath and the
-// downstream cpio packing walks the cwd ("."), so both depend on cwd ==
-// sourceDir. Until those are made cwd-independent, we serialize the
-// chdir->Build->restore critical section instead.
-var buildCWDMu sync.Mutex
 
 // Options configures a UKI build.
 type Options struct {
@@ -136,12 +125,17 @@ type Options struct {
 	Logger *logger.KairosLogger
 }
 
-// absolutizeKeyPaths rewrites the key/cert/splash path options to absolute
-// paths. The build Chdir's into the rootfs partway through, so any relative
-// path must be resolved against the original working directory first.
-// pkcs11 URIs (valid for SBKey) and empty values are left untouched.
-func absolutizeKeyPaths(opts *Options) error {
-	for _, p := range []*string{&opts.TPMPCRPrivateKey, &opts.SBKey, &opts.SBCert, &opts.PublicKeysDir, &opts.Splash} {
+// absolutizePaths rewrites every path option to an absolute path. These are
+// handed to go-ukify and to host subprocesses (mcopy, xorriso, ...) that run
+// with an unspecified working directory, so relative paths (e.g. the web
+// server passes paths relative to its working dir like "data/keys/...") must
+// be resolved against the caller's working directory up-front to resolve
+// reliably. pkcs11 URIs (valid for SBKey) and empty values are left untouched.
+func absolutizePaths(opts *Options) error {
+	for _, p := range []*string{
+		&opts.TPMPCRPrivateKey, &opts.SBKey, &opts.SBCert, &opts.PublicKeysDir, &opts.Splash,
+		&opts.OverlayRootfs, &opts.OverlayISO, &opts.OutputDir,
+	} {
 		if *p == "" || strings.Contains(*p, "pkcs11") {
 			continue
 		}
@@ -160,18 +154,19 @@ func absolutizeKeyPaths(opts *Options) error {
 // systemd-boot files are available, extracts the source image, generates the
 // EFI files via go-ukify and finally assembles the requested output type.
 //
-// Build changes the process working directory during the build and restores
-// it before returning.
+// Build does not mutate the process working directory: every artifact is
+// written under a per-build temporary sourceDir using absolute paths, so
+// concurrent Build calls (e.g. in `web` mode) are safe to run in parallel.
 func Build(opts Options) (err error) {
 	if err := opts.validate(); err != nil {
 		return err
 	}
 
-	// Resolve key/cert/splash paths to absolute before the build Chdir's into
-	// the rootfs. Relative paths (e.g. the web server passes paths relative to
-	// its working dir like "data/keys/...") would otherwise resolve against the
-	// wrong directory once os.Chdir runs and fail with "no such file".
-	if err := absolutizeKeyPaths(&opts); err != nil {
+	// Resolve all path options to absolute up-front so they resolve against the
+	// caller's working directory rather than wherever subprocesses happen to
+	// run (e.g. the web server passes paths relative to its working dir like
+	// "data/keys/...").
+	if err := absolutizePaths(&opts); err != nil {
 		return err
 	}
 
@@ -210,26 +205,6 @@ func Build(opts Options) (err error) {
 		secureBootEnroll = "if-safe"
 	}
 
-	// Serialize the cwd-mutating region: we Chdir into the rootfs during the
-	// build, and a concurrent Build in `web` mode would otherwise clobber our
-	// cwd (and vice versa). Lock before capturing origWD and unlock after the
-	// restore defer below (defers run LIFO, so this Unlock runs after the
-	// Chdir-restore), keeping the whole chdir window mutually exclusive.
-	buildCWDMu.Lock()
-	defer buildCWDMu.Unlock()
-
-	// Preserve cwd — we Chdir into the rootfs during the build and must restore
-	// it so callers using this as a library don't observe the side effect.
-	origWD, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("getting working directory: %w", err)
-	}
-	defer func() {
-		if cderr := os.Chdir(origWD); cderr != nil && err == nil {
-			err = fmt.Errorf("restoring working directory: %w", cderr)
-		}
-	}()
-
 	artifactsTempDir, err := os.MkdirTemp("", "auroraboot-build-uki-artifacts-")
 	if err != nil {
 		return err
@@ -259,12 +234,8 @@ func Build(opts Options) (err error) {
 	}
 
 	if opts.OverlayRootfs != "" {
-		absolutePath, err := filepath.Abs(opts.OverlayRootfs)
-		if err != nil {
-			return fmt.Errorf("converting overlay-rootfs to absolute path: %w", err)
-		}
-		log.Infof("Adding files from %s to rootfs", absolutePath)
-		overlay, err := sdkImages.NewSrcFromURI(fmt.Sprintf("dir:%s", absolutePath))
+		log.Infof("Adding files from %s to rootfs", opts.OverlayRootfs)
+		overlay, err := sdkImages.NewSrcFromURI(fmt.Sprintf("dir:%s", opts.OverlayRootfs))
 		if err != nil {
 			return fmt.Errorf("error creating overlay image: %s", err)
 		}
@@ -326,13 +297,13 @@ func Build(opts Options) (err error) {
 			InitrdPath:    filepath.Join(artifactsTempDir, "initrd"),
 			Cmdline:       entry.Cmdline,
 			OsRelease:     filepath.Join(sourceDir, "etc/os-release"),
-			OutUKIPath:    entry.FileName + ".efi",
+			OutUKIPath:    filepath.Join(sourceDir, entry.FileName+".efi"),
 			PCRKey:        opts.TPMPCRPrivateKey,
 			SBKey:         opts.SBKey,
 			SBCert:        opts.SBCert,
 			SdBootPath:    systemdBoot,
 			SdStubPath:    stub,
-			OutSdBootPath: outputSystemdBootEfi,
+			OutSdBootPath: filepath.Join(sourceDir, outputSystemdBootEfi),
 			Splash:        opts.Splash,
 		}
 
@@ -341,10 +312,6 @@ func Build(opts Options) (err error) {
 				slog.Debug("Expanding extra cmdline with base", "cmdline", cmd, "base", entry.Cmdline)
 				builder.ExtraCmdlines = append(builder.ExtraCmdlines, fmt.Sprintf("%s %s", entry.Cmdline, cmd))
 			}
-		}
-
-		if err := os.Chdir(sourceDir); err != nil {
-			return fmt.Errorf("changing to %s directory: %w", sourceDir, err)
 		}
 
 		if err := builder.Build(); err != nil {
@@ -375,14 +342,7 @@ func Build(opts Options) (err error) {
 
 	switch outputType {
 	case string(constants.IsoOutput):
-		var absolutePathIso string
-		if opts.OverlayISO != "" {
-			absolutePathIso, err = filepath.Abs(opts.OverlayISO)
-			if err != nil {
-				return fmt.Errorf("converting overlay-iso to absolute path: %w", err)
-			}
-		}
-		if err := createISO(e, sourceDir, outputDir, absolutePathIso, opts.PublicKeysDir, outputName, opts.Name, entries, *log, config.Arch); err != nil {
+		if err := createISO(e, sourceDir, outputDir, opts.OverlayISO, opts.PublicKeysDir, outputName, opts.Name, entries, *log, config.Arch); err != nil {
 			return err
 		}
 	case string(constants.ContainerOutput):
@@ -679,18 +639,21 @@ func createInitramfs(sourceDir, artifactsTempDir string) error {
 		"proc": true,
 	}
 
-	if err := os.Chdir(sourceDir); err != nil {
-		return fmt.Errorf("changing to %s directory: %w", sourceDir, err)
-	}
-
-	err = filepath.Walk(".", func(filePath string, fileInfo os.FileInfo, err error) error {
+	// Walk sourceDir with absolute paths (no os.Chdir) and record each entry
+	// under a path relative to sourceDir, so the initramfs layout is rooted at
+	// "." regardless of the process working directory.
+	err = filepath.Walk(sourceDir, func(filePath string, fileInfo os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if fileInfo.IsDir() && excludeDirs[filePath] {
+		relPath, err := filepath.Rel(sourceDir, filePath)
+		if err != nil {
+			return fmt.Errorf("resolving %q relative to %q: %w", filePath, sourceDir, err)
+		}
+		if fileInfo.IsDir() && excludeDirs[relPath] {
 			return filepath.SkipDir
 		}
-		if strings.Contains(filePath, "initramfs.cpio") {
+		if strings.Contains(relPath, "initramfs.cpio") {
 			return nil
 		}
 
@@ -699,7 +662,7 @@ func createInitramfs(sourceDir, artifactsTempDir string) error {
 			return fmt.Errorf("getting record of %q failed: %w", filePath, err)
 		}
 
-		rec.Name = strings.TrimPrefix(rec.Name, sourceDir)
+		rec.Name = relPath
 
 		// MakeReproducible currently breaks hardlinks
 		// (https://github.com/u-root/u-root/issues/3031); zero out the metadata

--- a/pkg/uki/uki.go
+++ b/pkg/uki/uki.go
@@ -130,20 +130,36 @@ type Options struct {
 // with an unspecified working directory, so relative paths (e.g. the web
 // server passes paths relative to its working dir like "data/keys/...") must
 // be resolved against the caller's working directory up-front to resolve
-// reliably. pkcs11 URIs (valid for SBKey) and empty values are left untouched.
+// reliably. pkcs11 URIs (valid for SBKey and TPMPCRPrivateKey) and empty values are left untouched.
 func absolutizePaths(opts *Options) error {
-	for _, p := range []*string{
-		&opts.TPMPCRPrivateKey, &opts.SBKey, &opts.SBCert, &opts.PublicKeysDir, &opts.Splash,
-		&opts.OverlayRootfs, &opts.OverlayISO, &opts.OutputDir,
-	} {
-		if *p == "" || strings.Contains(*p, "pkcs11") {
-			continue
+	absIfNeeded := func(p *string) error {
+		if *p == "" || filepath.IsAbs(*p) {
+			return nil
 		}
 		abs, err := filepath.Abs(*p)
 		if err != nil {
 			return fmt.Errorf("resolving path %q: %w", *p, err)
 		}
 		*p = abs
+		return nil
+	}
+
+	// Only these options can be PKCS#11 URIs.
+	if opts.TPMPCRPrivateKey != "" && !strings.HasPrefix(opts.TPMPCRPrivateKey, "pkcs11:") {
+		if err := absIfNeeded(&opts.TPMPCRPrivateKey); err != nil {
+			return err
+		}
+	}
+	if opts.SBKey != "" && !strings.HasPrefix(opts.SBKey, "pkcs11:") {
+		if err := absIfNeeded(&opts.SBKey); err != nil {
+			return err
+		}
+	}
+
+	for _, p := range []*string{&opts.SBCert, &opts.PublicKeysDir, &opts.Splash, &opts.OverlayRootfs, &opts.OverlayISO, &opts.OutputDir} {
+		if err := absIfNeeded(p); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/uki/uki_test.go
+++ b/pkg/uki/uki_test.go
@@ -101,3 +101,39 @@ var _ = Describe("sumFileSizes", func() {
 		Expect(err.Error()).To(ContainSubstring("finding file info"))
 	})
 })
+
+var _ = Describe("absolutizeKeyPaths", func() {
+	It("rewrites relative key/cert/splash paths to absolute", func() {
+		opts := &Options{
+			TPMPCRPrivateKey: "data/keys/production/tpm2-pcr-private.pem",
+			SBKey:            "data/keys/db.key",
+			SBCert:           "data/keys/db.pem",
+			PublicKeysDir:    "data/keys",
+			Splash:           "data/splash.bmp",
+		}
+		Expect(absolutizeKeyPaths(opts)).To(Succeed())
+
+		Expect(filepath.IsAbs(opts.TPMPCRPrivateKey)).To(BeTrue())
+		Expect(filepath.IsAbs(opts.SBKey)).To(BeTrue())
+		Expect(filepath.IsAbs(opts.SBCert)).To(BeTrue())
+		Expect(filepath.IsAbs(opts.PublicKeysDir)).To(BeTrue())
+		Expect(filepath.IsAbs(opts.Splash)).To(BeTrue())
+		Expect(opts.TPMPCRPrivateKey).To(HaveSuffix("/data/keys/production/tpm2-pcr-private.pem"))
+	})
+
+	It("leaves empty values and pkcs11 URIs untouched", func() {
+		opts := &Options{
+			SBKey:            "pkcs11:token=mytoken;object=mykey",
+			TPMPCRPrivateKey: "",
+		}
+		Expect(absolutizeKeyPaths(opts)).To(Succeed())
+		Expect(opts.SBKey).To(Equal("pkcs11:token=mytoken;object=mykey"))
+		Expect(opts.TPMPCRPrivateKey).To(BeEmpty())
+	})
+
+	It("leaves already-absolute paths unchanged", func() {
+		opts := &Options{TPMPCRPrivateKey: "/data/keys/production/tpm2-pcr-private.pem"}
+		Expect(absolutizeKeyPaths(opts)).To(Succeed())
+		Expect(opts.TPMPCRPrivateKey).To(Equal("/data/keys/production/tpm2-pcr-private.pem"))
+	})
+})

--- a/pkg/uki/uki_test.go
+++ b/pkg/uki/uki_test.go
@@ -102,7 +102,7 @@ var _ = Describe("sumFileSizes", func() {
 	})
 })
 
-var _ = Describe("absolutizeKeyPaths", func() {
+var _ = Describe("absolutizePaths", func() {
 	It("rewrites relative key/cert/splash paths to absolute", func() {
 		opts := &Options{
 			TPMPCRPrivateKey: "data/keys/production/tpm2-pcr-private.pem",
@@ -111,7 +111,7 @@ var _ = Describe("absolutizeKeyPaths", func() {
 			PublicKeysDir:    "data/keys",
 			Splash:           "data/splash.bmp",
 		}
-		Expect(absolutizeKeyPaths(opts)).To(Succeed())
+		Expect(absolutizePaths(opts)).To(Succeed())
 
 		Expect(filepath.IsAbs(opts.TPMPCRPrivateKey)).To(BeTrue())
 		Expect(filepath.IsAbs(opts.SBKey)).To(BeTrue())
@@ -121,19 +121,37 @@ var _ = Describe("absolutizeKeyPaths", func() {
 		Expect(opts.TPMPCRPrivateKey).To(HaveSuffix("/data/keys/production/tpm2-pcr-private.pem"))
 	})
 
+	It("rewrites relative overlay and output paths to absolute", func() {
+		opts := &Options{
+			OverlayRootfs: "data/overlay-rootfs",
+			OverlayISO:    "data/overlay-iso",
+			OutputDir:     "build/out",
+		}
+		Expect(absolutizePaths(opts)).To(Succeed())
+
+		Expect(filepath.IsAbs(opts.OverlayRootfs)).To(BeTrue())
+		Expect(filepath.IsAbs(opts.OverlayISO)).To(BeTrue())
+		Expect(filepath.IsAbs(opts.OutputDir)).To(BeTrue())
+		Expect(opts.OutputDir).To(HaveSuffix("/build/out"))
+	})
+
 	It("leaves empty values and pkcs11 URIs untouched", func() {
 		opts := &Options{
 			SBKey:            "pkcs11:token=mytoken;object=mykey",
 			TPMPCRPrivateKey: "",
+			OverlayISO:       "",
+			OutputDir:        "",
 		}
-		Expect(absolutizeKeyPaths(opts)).To(Succeed())
+		Expect(absolutizePaths(opts)).To(Succeed())
 		Expect(opts.SBKey).To(Equal("pkcs11:token=mytoken;object=mykey"))
 		Expect(opts.TPMPCRPrivateKey).To(BeEmpty())
+		Expect(opts.OverlayISO).To(BeEmpty())
+		Expect(opts.OutputDir).To(BeEmpty())
 	})
 
 	It("leaves already-absolute paths unchanged", func() {
 		opts := &Options{TPMPCRPrivateKey: "/data/keys/production/tpm2-pcr-private.pem"}
-		Expect(absolutizeKeyPaths(opts)).To(Succeed())
+		Expect(absolutizePaths(opts)).To(Succeed())
 		Expect(opts.TPMPCRPrivateKey).To(Equal("/data/keys/production/tpm2-pcr-private.pem"))
 	})
 })


### PR DESCRIPTION
Failed with: `UKI build failed: open data/keys/production/tpm2-pcr-private.pem: no such file or directory`

because the paths were relative but the code had switch working directory.