### PR TITLE
feat: Redfish fleet management — BMC Registration + declarative vendor quirk profiles (RFC 0001)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/vendor-profile.md
+++ b/.github/PULL_REQUEST_TEMPLATE/vendor-profile.md
@@ -1,0 +1,36 @@
+<!--
+Use this template for a Redfish vendor quirk-profile contribution.
+See docs/CONTRIBUTING-vendor-profiles.md for the full guide.
+-->
+
+## Vendor quirk profile
+
+**Vendor / model:**
+**Profile name (`name:` field):**
+**Firmware validated against (`validatedFirmware:`):**
+
+### What this profile changes vs. the spec-default (`generic`) flow
+
+<!-- e.g. "prefers Manager-hosted virtual media (iLO hosts media under the Manager)". -->
+
+### How it was validated
+
+<!-- e.g. "deployed successfully against <model> running <firmware> in my lab". -->
+
+### Checklist
+
+- [ ] Profile is **schema-valid** — parses with `auroraboot redfish probe --quirks-dir`
+      (or `LoadProfileDir`); no unknown keys, valid enums, no non-allowlisted
+      `tuneInsertParams` fields (the `Image` field is rejected by design).
+- [ ] `validatedFirmware` is **labeled** with the exact firmware revision tested.
+- [ ] The profile **does not** attempt to set the `Image` URL, force an unsupported
+      `ResetType`, or otherwise reach past the documented allowlist.
+- [ ] **(once P4 lands)** A sanitized, recorded DMTF **mockup** of the BMC resource
+      tree is included under `pkg/redfish/testdata/mockups/<vendor>/<firmware>/`,
+      and I attest it has been **sanitized** (serials, MACs, IPs, asset tags redacted).
+- [ ] **(once P4 lands)** A **golden test** replays the mockup against the deploy
+      flow and is green, so this profile reaches **tier B**.
+
+> New operator-supplied / in-tree-without-mockup profiles ship as **tier C
+> (UNVERIFIED)**. Adding a sanitized mockup + golden test (P4) promotes the profile
+> to **tier B (community-validated)**.

--- a/docs/CONTRIBUTING-vendor-profiles.md
+++ b/docs/CONTRIBUTING-vendor-profiles.md
@@ -153,14 +153,18 @@ own. The tier is surfaced in a load-time log line, e.g.
 | Tier | What it means | Where it comes from |
 |---|---|---|
 | **A — core-tested** | The spec-default path the project exercises in CI. | The built-in `generic` profile. |
-| **B — community-validated** | A profile **with a recorded, sanitized hardware mockup** that CI replays, so regressions are caught. | An in-tree profile + its mockup *(the mockup replay harness lands in **P4**; until then no profile reaches B).* |
+| **B — community-validated** | A profile **with a recorded, sanitized hardware mockup** that CI replays on every PR, so regressions are caught. | An in-tree profile + its mockup under `pkg/redfish/testdata/mockups/<vendor>/` (the built-in `ilo` is tier B today). |
 | **C — unverified** | A bare profile with no recorded mockup, in-tree or operator-supplied. Loaded fine, logged as UNVERIFIED. | Operator-dir profiles (always C) and in-tree profiles without a mockup. |
 
 **Operator-supplied profiles are always tier C.** To reach **tier B**, contribute
 the profile in-tree together with a recorded, sanitized DMTF mockup of your BMC's
-resource tree, which CI will replay against the deploy flow. *(The mockup format,
-location, sanitization guidance, and golden-test harness arrive in **P4** — this is
-the entire promotion incentive: add evidence, get a guarantee.)*
+resource tree, which CI replays against the deploy flow on every PR. The mockup
+format, location, prune list, sanitization expectation, and the golden-test harness
+are documented in
+[`pkg/redfish/testdata/mockups/README.md`](../pkg/redfish/testdata/mockups/README.md).
+Promotion is one step: add the sanitized mockup tree, list the built-in in
+`pkg/redfish/mockups.manifest`, and add a golden-test row — add evidence, get a
+guarantee.
 
 ---
 
@@ -178,9 +182,11 @@ what your profile was proven against.
 
 Open a PR using the **vendor-profile PR template**
 (`.github/PULL_REQUEST_TEMPLATE/vendor-profile.md`). The checklist covers:
-schema-valid profile, `validatedFirmware` labeled, and — once **P4** lands — a
-sanitized mockup and a golden test so your profile reaches tier B.
+schema-valid profile, `validatedFirmware` labeled, and — for tier B — a sanitized
+mockup tree under `pkg/redfish/testdata/mockups/<vendor>/` plus a golden-test row
+that replays it (see
+[`pkg/redfish/testdata/mockups/README.md`](../pkg/redfish/testdata/mockups/README.md)).
 
 Put the profile under `examples/redfish/quirks/` if it is an example/template, or
 in-tree alongside the built-ins if you are submitting it as a supported vendor
-profile (it ships as tier C until a mockup promotes it to B in P4).
+profile (it ships as tier C until a recorded mockup + golden test promote it to B).

--- a/docs/CONTRIBUTING-vendor-profiles.md
+++ b/docs/CONTRIBUTING-vendor-profiles.md
@@ -1,0 +1,186 @@
+# Contributing Redfish vendor quirk profiles
+
+AuroraBoot deploys an OS image to a server over Redfish virtual media: it discovers
+the system, inserts the media by URL (`VirtualMedia.InsertMedia`), sets a one-time
+boot override, resets with an explicit `ResetType`, and polls the returned Task to
+completion. The flow is spec-compliant, but BMC vendors implement Redfish
+differently — sometimes non-compliantly. A **quirk profile** is a small piece of
+declarative YAML that nudges the genuine per-vendor deltas (mostly "where is the
+virtual media" and "which `ResetType`") without changing the core flow.
+
+A profile is **inert data, never code.** The worst a broken or malicious profile
+can do is cause a failed deploy with a clear error. That safety boundary is exactly
+what lets us accept a profile from someone whose hardware we will never see.
+
+This guide covers: getting a starter profile from your BMC, the schema, where
+profiles live and how they are selected, the precedence rules, support tiers, and
+how to contribute a profile back.
+
+---
+
+## 1. Get a starter profile from your BMC: `redfish probe`
+
+`auroraboot redfish probe` is read-only — it issues GETs only (no InsertMedia, no
+boot change, no reset) — so it is safe to run against any BMC. It reports what the
+BMC actually exposes and emits a **tier-C starter profile** you can tweak.
+
+```bash
+auroraboot redfish probe \
+  --endpoint https://bmc.example.com \
+  --username admin \
+  --password-file ./bmc-pass \
+  --output yaml > my-vendor.yaml
+```
+
+`--output text` prints the human report only; `--output yaml` prints only the
+starter profile (pipe it to a file); `--output both` (default) prints both. The
+probe stamps `match.vendor` from the BMC manufacturer, suggests a
+`mediaSearch.order` when the only CD/DVD media is Manager-hosted (the HPE iLO
+signal), and lists the allowable `ResetType`s as comments.
+
+Then iterate: drop the file in a directory, point `--quirks-dir` at it, and run a
+real `redfish deploy --vendor <name>` until it works on your hardware.
+
+---
+
+## 2. Write / tweak a profile: the schema
+
+Start from `examples/redfish/quirks/template.yaml` (every field documented) or the
+worked `examples/redfish/quirks/ilo.yaml`. Every section is **optional except
+`name`**; an omitted section means "use the spec-default behaviour", so a profile
+with only a name behaves exactly like the built-in `generic` (spec-default) profile.
+
+```yaml
+name: my-vendor                  # REQUIRED — the selection key (see §3)
+match:                           # optional, informational hint only
+  vendor: ExampleVendor          #   does NOT drive selection (selection is by name)
+mediaSearch:                     # optional — reorder/filter VirtualMedia members
+  order: [manager, system]       #   entries: "system" | "manager" | "manager:<id>"
+mediaType: CD                    # optional — CD | DVD | USBStick | Floppy (default CD)
+resetType:                       # optional — ordered, first-match-wins rules
+  - when: { powerState: "Off" }  #   powerState: "On" | "Off" | "*"
+    then: "On"                   #   then: a Redfish ResetType, re-validated by the core
+  - when: { powerState: "*" }
+    then: "ForceRestart"
+tuneInsertParams:                # optional — sparse patch over an ALLOWLISTED field set
+  clear: [TransferProtocolType]  #   allowlist: MediaType, TransferProtocolType,
+  set:                           #              Inserted, WriteProtected
+    WriteProtected: true
+validatedFirmware: "fw 1.23"     # optional — see §6 (firmware labeling)
+```
+
+Field reference:
+
+- **`name`** (string, required) — the profile's identity and selection key.
+- **`match.vendor`** (string, optional) — an informational hint. Selection is by
+  `name`, not by `match`; `match` is documentation the probe fills in for you.
+- **`mediaSearch.order`** (list, optional) — reorders/filters candidate
+  `VirtualMedia` members. Each entry is one of `system`, `manager`, or
+  `manager:<id>`. Matching members are emitted in the listed order; members
+  matching no entry are **dropped**. Omit to keep the core's default order. (HPE
+  iLO hosts media under the Manager, so its profile uses `[manager, system]`.)
+- **`mediaType`** (enum, optional) — the `MediaType` sent on InsertMedia. One of
+  `CD`, `DVD`, `USBStick`, `Floppy`. Omit for the spec default (`CD`).
+- **`resetType`** (list of rules, optional) — first-match-wins. `when.powerState`
+  is `On`, `Off`, or `*` (any); `then` is a Redfish `ResetType` (`On`,
+  `ForceRestart`, `GracefulRestart`, `ForceOff`, `PowerCycle`, …). The chosen type
+  is **re-validated by the core** against the BMC's advertised allowable values — a
+  rule can prefer, but never force, an unsupported type. Omit for the core default.
+- **`tuneInsertParams`** (optional) — a sparse patch over the InsertMedia
+  parameters. `clear` drops fields, `set` sets them. **The allowlist is exactly
+  `MediaType`, `TransferProtocolType`, `Inserted`, `WriteProtected`.**
+- **`validatedFirmware`** (string, optional) — see §6.
+
+### The safety boundary (what a profile can never do)
+
+Validation is strict and happens **at load** (unknown keys, bad enums, and
+non-allowlisted fields are rejected before any hook runs). A profile can **never**:
+
+- **Set or clear the `Image` URL.** `Image` is rejected anywhere it appears
+  (`tuneInsertParams.set`/`clear`, any casing) with a dedicated error. The image
+  URL is core-owned and SSRF-validated; letting a profile set it would reopen a
+  confused-deputy / SSRF hole.
+- **Force an unsupported `ResetType`.** Every chosen type flows back through the
+  core's allowable-values check.
+- **Touch sessions, TLS verification, or system selection** — a profile has no
+  client handle and sees only read-only value copies of the relevant data.
+
+A malformed profile is a **load-time error that disables only that profile**; it
+never fails the rest of the load or the deploy.
+
+---
+
+## 3. Where profiles live, and how `--quirks-dir` works
+
+Built-in profiles (`generic`, `ilo`, `supermicro`) ship in the binary. Operator
+profiles are loaded from a directory of `*.yaml` / `*.yml` files at **start**
+(load-at-start, never hot-reloaded — an in-flight deploy must not have its profile
+swapped):
+
+- **CLI** — `auroraboot redfish deploy --quirks-dir ./quirks --vendor my-vendor …`
+  (and `auroraboot redfish probe --quirks-dir ./quirks` to load+validate them).
+  Env: `AURORABOOT_REDFISH_QUIRKS_DIR`.
+- **Fleet server** — `auroraboot web --redfish-quirks-dir ./quirks …`. A
+  `BMCTarget`'s `vendor` selects a profile by name. Env:
+  `AURORABOOT_REDFISH_QUIRKS_DIR`.
+
+Each loaded profile and each skipped (malformed) file is logged at start.
+
+---
+
+## 4. Selection & precedence
+
+- **Selection is by name.** `--vendor <name>` (CLI) or a `BMCTarget.vendor`
+  (server) resolves, in order: an operator/built-in profile **by name**, then the
+  built-in **vendor mapping**, then **`generic`**. A typo or unknown name resolves
+  to `generic` — never a silent wrong workaround.
+- **Precedence: operator overrides built-in.** An operator profile whose `name`
+  collides with a built-in (e.g. `ilo`) **overrides** the built-in. Operator intent
+  wins, and the override is logged loudly, e.g.:
+
+  ```
+  redfish: operator quirk profile "ilo" overrides the built-in [tier C: UNVERIFIED — no recorded mockup]
+  ```
+
+---
+
+## 5. Support tiers (and how to reach tier B)
+
+The **project derives** a profile's support tier; a profile can never assert its
+own. The tier is surfaced in a load-time log line, e.g.
+`redfish: loaded quirk profile "ilo" [tier C: UNVERIFIED — no recorded mockup]`.
+
+| Tier | What it means | Where it comes from |
+|---|---|---|
+| **A — core-tested** | The spec-default path the project exercises in CI. | The built-in `generic` profile. |
+| **B — community-validated** | A profile **with a recorded, sanitized hardware mockup** that CI replays, so regressions are caught. | An in-tree profile + its mockup *(the mockup replay harness lands in **P4**; until then no profile reaches B).* |
+| **C — unverified** | A bare profile with no recorded mockup, in-tree or operator-supplied. Loaded fine, logged as UNVERIFIED. | Operator-dir profiles (always C) and in-tree profiles without a mockup. |
+
+**Operator-supplied profiles are always tier C.** To reach **tier B**, contribute
+the profile in-tree together with a recorded, sanitized DMTF mockup of your BMC's
+resource tree, which CI will replay against the deploy flow. *(The mockup format,
+location, sanitization guidance, and golden-test harness arrive in **P4** — this is
+the entire promotion incentive: add evidence, get a guarantee.)*
+
+---
+
+## 6. Firmware labeling (`validatedFirmware`)
+
+A profile is validated against a **specific firmware revision** — Redfish behaviour
+changes across firmware. Record the revision you tested against in
+`validatedFirmware`, e.g. `"iLO 5 2.44"` or `"Supermicro X12 1.04"`. A different
+firmware revision is a different evidence pair; label honestly so operators know
+what your profile was proven against.
+
+---
+
+## 7. Contributing back
+
+Open a PR using the **vendor-profile PR template**
+(`.github/PULL_REQUEST_TEMPLATE/vendor-profile.md`). The checklist covers:
+schema-valid profile, `validatedFirmware` labeled, and — once **P4** lands — a
+sanitized mockup and a golden test so your profile reaches tier B.
+
+Put the profile under `examples/redfish/quirks/` if it is an example/template, or
+in-tree alongside the built-ins if you are submitting it as a supported vendor
+profile (it ships as tier C until a mockup promotes it to B in P4).

--- a/docs/rfc/0001-redfish-vendor-quirk-profiles.md
+++ b/docs/rfc/0001-redfish-vendor-quirk-profiles.md
@@ -1,0 +1,202 @@
+# RFC 0001: Redfish vendor-support ecosystem — declarative quirk profiles + recorded-evidence CI
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Author** | William Rizzo (@wrkode) |
+| **Created** | 2026-06-09 |
+| **Area** | `pkg/redfish` (virtual-media deployment) |
+
+## Summary
+
+Make AuroraBoot's Redfish vendor support **community-scalable**: replace the compiled-in vendor
+quirk profiles with **declarative YAML profiles** that operators can write, share, and contribute —
+validated in CI against **recorded evidence** of real hardware (DMTF Redfish mockups) — so vendor
+coverage can grow without the maintainers owning or testing every BMC.
+
+This RFC deliberately does **not** introduce a scripting engine (Lua/CEL/WASM). Profiles are inert
+data with a bounded blast radius; that property is what makes contributions safe to accept from
+people whose hardware we have never seen.
+
+## Motivation
+
+Every BMC vendor implements DMTF Redfish a little differently — and frequently not compliantly.
+AuroraBoot's deploy flow (session → discovery → `VirtualMedia.InsertMedia` URL-pull → one-time boot
+override → `ComputerSystem.Reset` → Task polling → session teardown) is spec-correct and tested
+against emulators, but the *deltas* between BMCs are encoded as compiled-in Go "quirk" hooks
+(`pkg/redfish/quirks.go`, `quirks_vendor.go`). Today:
+
+- Adding or fixing a vendor quirk requires a Go change and a release from the maintainers.
+- The existing iLO/Supermicro profiles are reasoned from public documentation, not confirmed on
+  metal — and the project has no scalable way to confirm them.
+- An operator who hits a quirky BMC in the field has no self-service path at all.
+
+The maintainers cannot own a hardware lab covering every vendor × model × firmware. The design must
+therefore change *who maintains vendor knowledge* and *how it is validated*.
+
+## The ecosystem contract
+
+| Layer | Maintained by | Tested by | How |
+|---|---|---|---|
+| Spec-correct core flow + safety boundary | Project | Project CI | Existing fake-BMC unit suite (+ optional live emulator job) |
+| Vendor knowledge (quirk profiles) | Community / affected operators | The contributor, on their hardware | Declarative YAML profile + recorded mockup, PR'd together |
+| Evidence replay | Project CI | Automatic, every PR | The recorded mockup is replayed through the fake-BMC harness; a per-vendor golden test asserts the request sequence |
+
+The enabling property is **bounded blast radius**: a profile is data, never code. The worst a wrong
+or malicious profile can do is cause a failed deploy with a clear error. It structurally cannot:
+
+- set or alter the ISO **image URL** (core-owned, SSRF-validated via the media-URL allowlist);
+- force an unsupported **ResetType** (re-validated against the BMC's advertised allowable values);
+- touch **sessions, TLS verification, or system selection** (core-owned; profiles hold no client).
+
+That is what lets a maintainer merge a profile for hardware they cannot test.
+
+## Design
+
+### 1. Declarative quirk profiles
+
+The existing quirks seam stays exactly as it is: a `quirks` struct of optional hook functions
+(`mediaSearch`, `mediaType`, `resetType`, `tuneInsertParams`), where a nil hook means spec-default
+and the `generic` profile is the zero value (guarded by an existing regression test). The only new
+thing is a second *producer* of that struct: a loader that compiles a YAML profile into hook
+closures.
+
+```yaml
+# Example: the equivalent of the current built-in iLO profile
+name: ilo
+match: { vendor: HPE }
+mediaSearch: { order: [manager, system] }   # iLO hosts virtual media under the Manager
+mediaType: CD                                # optional; omitted = spec default
+resetType:                                   # optional rules, first match wins
+  - { when: { powerState: "Off" }, then: "On" }
+  - { when: { powerState: "*" },   then: "ForceRestart" }
+tuneInsertParams:                            # sparse patch over an allowlist
+  clear: [TransferProtocolType]              # e.g. for firmware that rejects it
+validatedFirmware: ""                        # filled when evidence is recorded (see tiers)
+```
+
+Profiles cross a narrow, safe boundary: the core hands each hook **plain, read-only view structs**
+(media members with their location/types, the system's power state and allowable reset types, the
+insert parameters minus the image URL) and accepts back **constrained answers** (an ordering of
+indices, an enum pick, a sparse patch over an allowlisted field set). Profiles never see the live
+Redfish client, the deploy request, or any credential. An omitted section means spec-default; an
+empty profile is byte-for-byte the `generic` behaviour.
+
+Validation happens at load: unknown keys, bad enums, attempts to patch non-allowlisted fields
+(including `Image`), and duplicate names are rejected. A malformed profile disables only itself.
+
+### 2. Support tiers
+
+Support levels are explicit and derived by the project — a profile cannot assert its own tier:
+
+| Tier | Meaning | Guarantee |
+|---|---|---|
+| **A — Core-tested** | `generic` + whatever the fake-BMC suite / emulator CI exercises | Project guarantee; breakage blocks merge |
+| **B — Community-validated** | In-tree profile **with** a recorded, sanitized mockup, replayed in CI | "Works against the recorded firmware; regressions are caught automatically" |
+| **C — Unverified** | Bare profile (in-tree without evidence, or operator-local) | Loaded fine, loudly logged as unverified; no promises |
+
+Promotion C → B = contribute a mockup. The tier is surfaced in a load-time log line (e.g.
+`redfish: loaded quirk profile "ilo" [tier B: validated against iLO 5 fw 2.44]`).
+
+### 3. Recorded-evidence CI (the mockup loop)
+
+The contribution unit is **a profile + a recorded mockup of the contributor's BMC**, PR'd together:
+
+1. A deploy fails; AuroraBoot already surfaces the BMC's `@Message.ExtendedInfo` so the operator
+   sees what the BMC objected to.
+2. The operator runs `auroraboot redfish probe` (below), gets a pre-filled starter profile, tweaks
+   it in their local profile directory until the deploy works on their hardware.
+3. They record their BMC's resource tree with DMTF's `redfish-mockup-creator` (a read-only walk),
+   sanitize it (serials/MACs/IPs/asset tags redacted — documented procedure + PR-template
+   attestation), prune it to the deploy-relevant subtree, and open a PR with profile + mockup +
+   firmware label.
+4. CI loads the mockup tree into the existing fake-BMC test harness (recorded GETs; the harness's
+   existing synthesized handlers cover the POST actions a static mockup cannot record) and runs a
+   **per-vendor request-sequence golden test**: discovery resolves the expected system and media
+   member, the InsertMedia body matches and its `Image` equals the test's served URL (proving the
+   profile never rewrote it), boot/reset match the profile rules after allowable-values
+   re-validation, and the session DELETE fires on success and error paths.
+
+A regression in a profile, the profile compiler, or the core flow then fails that vendor's test *by
+name* — loudly, attributably, with no hardware in the loop. This is also the scalable path for the
+long-open real-hardware-validation work: vendor support stops being "reasoned from docs" and becomes
+"confirmed on a contributor's metal, frozen as evidence, regression-tested forever."
+
+**Honest limitation:** mockup replay validates AuroraBoot's request sequence against recorded GET
+responses; it cannot catch a BMC that would reject a request at runtime (action responses are
+synthesized). That residual gap is exactly what the tier-B "validated against firmware X on real
+hardware" claim and the optional live-emulator CI job cover. The tiers are honest because they name
+this boundary.
+
+### 4. The probe command
+
+`auroraboot redfish probe --endpoint <url> [credentials]` — a read-only diagnostic that prints what
+a BMC actually exposes, and emits a **starter profile**. Everything it reports comes from discovery
+code that already exists: SessionService presence/auth mode, the Systems members and their IDs
+(feeds system selection), where VirtualMedia lives (System vs Manager) and its MediaTypes (feeds
+`mediaSearch`/`mediaType`), the allowable ResetTypes, and model/manufacturer/firmware strings. It
+performs no writes and is CLI-only in v1. This turns "my BMC doesn't work" into an afternoon of
+self-service instead of an upstream issue.
+
+### 5. Future, explicitly gated: constrained OEM actions
+
+Some vendors require OEM actions instead of the spec InsertMedia/Reset. A possible later extension
+is a declarative `oemAction` block under hard constraints: it may only invoke an action **present in
+the BMC's own `Actions` advertisement** (never a free-form URI); the image URL is only referenceable
+through a placeholder the core substitutes **after** SSRF validation (a raw URL literal in a profile
+is a load error); body fields and values come from a fixed allowlist; flow points are a fixed enum.
+
+This lands **last, behind a dedicated security review**. If the discovered-actions constraint cannot
+be made airtight, OEM actions go to a reviewed in-tree Go hook instead — the declarative surface's
+entire value is that it is safe to accept from strangers, and an escape hatch that breaks that
+property defeats the design.
+
+## Alternatives considered
+
+- **Embedded scripting (Lua via gopher-lua, Starlark):** pure-Go and feasible, but rejected. An
+  inventory of the real quirks shows they are all *selection and field-override*, never computation
+  — so a scripting engine adds no reachable capability while adding a permanent, hand-maintained
+  sandbox (CPU/memory/time limits, stdlib stripping) on a path that drives BMCs with admin
+  credentials, and it breaks the "safe to accept from strangers" property that the ecosystem model
+  depends on. If a future quirk genuinely requires computation, it should be a reviewed Go change.
+- **CEL expressions:** safer than Lua (non-Turing-complete, bounded), but still solves the wrong
+  problem: the quirks need data, not expressions, and CEL cannot express the mutating hook cleanly.
+- **WASM (wazero):** strongest sandbox, but the contributor experience ("set up a toolchain and
+  compile a module to drop a field") is wrong for the audience, and marshalling across the ABI is
+  heavy for what is usually a two-line tweak.
+- **Go `plugin` packages / out-of-process driver binaries:** `plugin` is incompatible with the
+  project's static, cross-platform (amd64/arm64/riscv64, no cgo) builds. Out-of-process drivers
+  (gRPC, Terraform-provider-style) are the honest answer for *radically* divergent vendors, but they
+  are a driver SDK with a much larger trust and maintenance footprint — deferred unless real demand
+  for tier-2 vendors materialises; the in-tree Go hook path covers those until then.
+
+## Rollout
+
+Each phase is independently shippable; none changes the core deploy flow.
+
+| Phase | Scope |
+|---|---|
+| **1** | Profile schema + loader + safe view/boundary types, in-tree only. Bundled iLO/Supermicro profiles expressed against it. **Zero behaviour change** (the generic-zero-value regression test proves it). |
+| **2** | `auroraboot redfish probe` (read-only report + starter profile). |
+| **3** | Operator profile directory (load-at-start), named selection with typo-safe fallback to `generic`, tier surfacing, `CONTRIBUTING` guide + PR template for vendor profiles. |
+| **4** | Mockup replay harness in CI + per-vendor golden tests + sanitization/pruning policy. This makes tier B real. |
+| **5** | *(conditional)* the constrained `oemAction` block, behind its own security review. |
+
+## Open questions
+
+1. Mockup sanitization: documented redaction script + contributor attestation, or a maintained
+   `sanitize-mockup` helper command? What is the exact redaction field list?
+2. Mockup location and size policy (proposed: `pkg/redfish/testdata/mockups/<vendor>/<firmware>/`,
+   pruned to the deploy-relevant subtree, a few hundred KB cap).
+3. Tier surfacing beyond the load-time log line (CLI listing? a badge in the web UI's BMC page?).
+4. `oemAction` ship/no-ship criteria and its placeholder/field allowlists.
+5. Should `probe` ever get a server/UI endpoint, or stay CLI-only?
+
+## Security considerations
+
+Summarised throughout; the load-bearing invariants are: profiles are inert data; the image URL is
+never profile-settable and is always SSRF-validated by the core; ResetType is re-validated against
+the BMC's advertised allowable values; sessions/TLS/system-selection are core-owned; operator-dir
+profiles are always tier C and logged; tier is derived by the project, never asserted by a profile;
+the (future) OEM-action block may only target actions the BMC itself advertises and is gated on a
+dedicated security review.

--- a/examples/redfish/quirks/ilo.yaml
+++ b/examples/redfish/quirks/ilo.yaml
@@ -1,0 +1,40 @@
+# examples/redfish/quirks/ilo.yaml
+#
+# A worked example: an operator quirk profile equivalent to AuroraBoot's built-in
+# HPE iLO profile. Drop a directory of files like this one and pass it with
+# `--quirks-dir` (CLI) or `--redfish-quirks-dir` (fleet server), then select it by
+# name with `--vendor ilo` (CLI) or by setting a BMCTarget's vendor to "ilo".
+#
+# Because its name is "ilo", placing this file in the quirks dir OVERRIDES the
+# built-in iLO profile (the override is logged loudly at load). Operator intent
+# wins — useful when you have tweaked the profile for your firmware.
+#
+# Support tier: an operator-supplied profile is ALWAYS tier C (UNVERIFIED). To
+# reach tier B (community-validated) the profile must ship in-tree together with a
+# recorded, sanitized hardware mockup that CI replays — see
+# docs/CONTRIBUTING-vendor-profiles.md (and P4, which adds the mockup harness).
+
+# name (required): how the profile is selected. `--vendor <name>` / BMCTarget.Vendor.
+name: ilo
+
+# match (optional): an informational selection hint. The probe command stamps the
+# BMC manufacturer here; it does not change selection (selection is by `name`).
+match:
+  vendor: HPE
+
+# mediaSearch (optional): reorder/filter the candidate VirtualMedia members. Each
+# `order` entry is one of "system", "manager", or "manager:<id>"; matching members
+# are emitted in that order and unmatched members are dropped. HPE iLO hosts
+# virtual media under the Manager (the BMC), not the ComputerSystem, so prefer
+# Manager-hosted media first, then fall back to System-hosted.
+mediaSearch:
+  order: [manager, system]
+
+# The remaining sections are omitted here because iLO accepts the spec defaults.
+# An omitted section compiles to a nil hook (= spec-default behaviour), so this
+# profile diverges from generic ONLY in media search order. See template.yaml for
+# every field documented.
+
+# validatedFirmware (optional): the firmware this profile was validated against.
+# Informational, used for tier labelling. Label it honestly, e.g. "iLO 5 2.44".
+validatedFirmware: ""

--- a/examples/redfish/quirks/template.yaml
+++ b/examples/redfish/quirks/template.yaml
@@ -1,0 +1,72 @@
+# examples/redfish/quirks/template.yaml
+#
+# A fully-commented template for an operator quirk profile. Copy it, rename it,
+# delete the sections you do not need, and drop it in your `--quirks-dir` /
+# `--redfish-quirks-dir`. Every section is OPTIONAL except `name`; an omitted
+# section compiles to "use the spec-default behaviour", so a profile with only a
+# name behaves exactly like the generic (spec-default) profile.
+#
+# A profile is INERT DATA, not code. The hard safety boundary (enforced at load
+# and by the core deploy flow) means a profile can NEVER:
+#   - set or clear the InsertMedia `Image` URL (core-owned and SSRF-validated),
+#   - force an unsupported ResetType (the core re-validates against the BMC's
+#     advertised allowable values),
+#   - touch sessions, TLS verification, or system selection.
+# A malformed profile is rejected at load and disables ONLY itself; it never fails
+# the whole load or the deploy.
+#
+# Support tier: operator-supplied profiles are ALWAYS tier C (UNVERIFIED). See
+# docs/CONTRIBUTING-vendor-profiles.md for how to reach tier B.
+
+# name (REQUIRED): the profile's identity. Select it with `--vendor <name>` (CLI)
+# or by setting a BMCTarget's vendor to this name (fleet server). A name that
+# collides with a built-in (generic, ilo, supermicro) OVERRIDES the built-in, and
+# the override is logged loudly at load. An unknown `--vendor` falls back to
+# generic — a typo never silently enables the wrong workaround.
+name: my-vendor
+
+# match (optional): an informational selection hint only. It does NOT drive
+# selection (selection is purely by `name`). The probe command records the BMC
+# manufacturer here as a documentation aid.
+match:
+  vendor: ExampleVendor
+
+# mediaSearch (optional): reorder/filter the candidate VirtualMedia members. Each
+# entry in `order` is one of:
+#   - "system"        — media hosted under the ComputerSystem
+#   - "manager"       — media hosted under any Manager (the BMC)
+#   - "manager:<id>"  — media hosted under one specific Manager, by Id
+# Matching members are emitted in the listed order; members matching no entry are
+# DROPPED. Omit this section to keep the core's default search order.
+mediaSearch:
+  order: [manager, system]
+
+# mediaType (optional): the VirtualMedia MediaType sent on InsertMedia. One of:
+#   CD | DVD | USBStick | Floppy
+# Omit to use the spec default (CD).
+mediaType: CD
+
+# resetType (optional): an ordered, first-match-wins rule set for the ResetType
+# sent when the system is reset to boot the media. `when.powerState` is one of
+# "On", "Off", or "*" (any). `then` is a Redfish ResetType (e.g. On, ForceRestart,
+# GracefulRestart, ForceOff, PowerCycle). The chosen type is STILL re-validated by
+# the core against the BMC's advertised allowable values — a rule can prefer but
+# never force an unsupported type. Omit to keep the core default.
+resetType:
+  - when: { powerState: "Off" }
+    then: "On"
+  - when: { powerState: "*" }
+    then: "ForceRestart"
+
+# tuneInsertParams (optional): a sparse patch over an ALLOWLISTED set of InsertMedia
+# fields. Allowed fields: MediaType, TransferProtocolType, Inserted, WriteProtected.
+# The `Image` field is REJECTED at load (any casing) — the image URL is core-owned
+# and SSRF-validated. Use `clear` to drop a field the BMC rejects, `set` to set one.
+tuneInsertParams:
+  clear: [TransferProtocolType]   # e.g. some BMCs reject an explicit transfer protocol
+  set:
+    WriteProtected: true
+
+# validatedFirmware (optional): the firmware revision this profile was validated
+# against. Informational, used for tier labelling. Label it honestly.
+validatedFirmware: "ExampleVendor BMC fw 1.23"

--- a/internal/cmd/redfish.go
+++ b/internal/cmd/redfish.go
@@ -20,6 +20,33 @@ import (
 // password when neither --password nor --password-file is set.
 const redfishPasswordEnv = "AURORABOOT_REDFISH_PASSWORD"
 
+// redfishQuirksDirEnv is the environment variable consulted for the operator
+// quirk-profile directory when --quirks-dir is not set.
+const redfishQuirksDirEnv = "AURORABOOT_REDFISH_QUIRKS_DIR"
+
+// loadRedfishQuirksDir loads operator-supplied quirk profiles from dir (if any)
+// and installs the resulting registry as the process-wide default so subsequent
+// redfish.NewDeployer calls resolve --vendor against the loaded profiles. It is
+// load-at-start: profiles are read once here, never hot-reloaded mid-deploy. Each
+// loaded profile and each malformed-and-skipped file is logged by the registry; a
+// single bad profile disables only itself and never fails the command. An empty
+// dir is a no-op (built-in profiles only). Only a directory-read failure is fatal.
+func loadRedfishQuirksDir(dir string) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		dir = os.Getenv(redfishQuirksDirEnv)
+	}
+	if strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	registry, _, err := redfish.LoadProfileDir(dir)
+	if err != nil {
+		return fmt.Errorf("loading quirk profiles: %w", err)
+	}
+	redfish.SetDefaultRegistry(registry)
+	return nil
+}
+
 // resolveRedfishPassword resolves the RedFish password from, in precedence order:
 // the explicit --password flag, --password-file, the AURORABOOT_REDFISH_PASSWORD
 // environment variable, then --password-stdin. It errors if none is provided.
@@ -134,8 +161,13 @@ var RedFishDeployCmd = cli.Command{
 				},
 				&cli.StringFlag{
 					Name:  "vendor",
-					Usage: "Hardware vendor (generic, supermicro, ilo, dmtf)",
+					Usage: "Quirk profile to select: a built-in vendor (generic, supermicro, ilo, dmtf) OR the name of an operator profile loaded from --quirks-dir. An unknown name falls back to generic",
 					Value: "generic",
+				},
+				&cli.StringFlag{
+					Name:    "quirks-dir",
+					Usage:   "Directory of operator-supplied *.yaml/*.yml quirk profiles loaded at start. Selected by name via --vendor; a profile named the same as a built-in overrides it (logged). A malformed profile is skipped, not fatal",
+					EnvVars: []string{redfishQuirksDirEnv},
 				},
 				&cli.StringFlag{
 					Name:  "boot-mode",
@@ -195,6 +227,12 @@ var RedFishDeployCmd = cli.Command{
 			},
 			Action: func(c *cli.Context) error {
 				ctx := c.Context
+
+				// Load operator quirk profiles (if any) BEFORE NewDeployer so --vendor
+				// can select one by name. Load-at-start, not hot-reload.
+				if err := loadRedfishQuirksDir(c.String("quirks-dir")); err != nil {
+					return err
+				}
 
 				endpoint := c.String("endpoint")
 				username := c.String("username")

--- a/internal/cmd/redfish.go
+++ b/internal/cmd/redfish.go
@@ -97,6 +97,7 @@ var RedFishDeployCmd = cli.Command{
 	Name:  "redfish",
 	Usage: "Deploy ISO to server via RedFish (EXPERIMENTAL)",
 	Subcommands: []*cli.Command{
+		redfishProbeCmd(),
 		{
 			Name:  "deploy",
 			Usage: "Deploy ISO to server via RedFish",

--- a/internal/cmd/redfish_probe.go
+++ b/internal/cmd/redfish_probe.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/kairos-io/AuroraBoot/pkg/isoserve"
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+	"github.com/urfave/cli/v2"
+)
+
+// redfishProbeCmd builds the read-only `auroraboot redfish probe` subcommand. It
+// connects to a BMC, prints what it actually exposes, and emits a starter quirk
+// profile (tier C) the operator can tweak. It performs NO writes — no InsertMedia,
+// no boot PATCH, no Reset — so it is safe to run against any BMC. Credential and TLS
+// handling mirror `redfish deploy` exactly.
+func redfishProbeCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "probe",
+		Usage: "Read-only diagnostic: report what a RedFish BMC exposes and emit a starter quirk profile",
+		Description: "Connects to a BMC and prints its SessionService/auth mode, ComputerSystem Ids, " +
+			"hardware summary, virtual-media layout, and allowable ResetTypes, then emits a starter " +
+			"quirk-profile YAML (tier C: UNVERIFIED). It makes no writes (no InsertMedia, boot change, " +
+			"or reset) and turns an unsupported BMC into self-service.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "endpoint",
+				Usage:    "RedFish endpoint URL",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "username",
+				Usage:    "RedFish username",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "password",
+				Usage: "RedFish password (INSECURE: visible in the process list/argv; prefer --password-file, AURORABOOT_REDFISH_PASSWORD, or --password-stdin)",
+			},
+			&cli.StringFlag{
+				Name:  "password-file",
+				Usage: "Read the RedFish password from this file (trailing newline trimmed)",
+			},
+			&cli.BoolFlag{
+				Name:  "password-stdin",
+				Usage: "Read the RedFish password from standard input (trailing newline trimmed)",
+			},
+			&cli.StringFlag{
+				Name:  "system-id",
+				Usage: "Redfish ComputerSystem Id to describe; when the BMC exposes more than one system and this is unset, the probe reports all Ids and describes the first",
+			},
+			&cli.StringFlag{
+				Name:  "auth-mode",
+				Usage: "Redfish authentication mode: session, basic, or auto (detect from the ServiceRoot and fall back to basic when no SessionService is advertised)",
+				Value: "auto",
+			},
+			&cli.BoolFlag{
+				Name:  "verify-ssl",
+				Usage: "Verify SSL certificates",
+				Value: true,
+			},
+			&cli.StringFlag{
+				Name:  "output",
+				Usage: "Output format: text (human report only), yaml (starter profile only, pipeable to a file), or both",
+				Value: "both",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			return runRedfishProbe(c, os.Stdin, c.App.Writer)
+		},
+	}
+}
+
+// runRedfishProbe executes the probe. stdin is injected for password-stdin testing;
+// out is the writer the report/YAML are emitted to (c.App.Writer in production).
+func runRedfishProbe(c *cli.Context, stdin io.Reader, out io.Writer) error {
+	ctx := c.Context
+
+	output, err := resolveProbeOutput(c.String("output"))
+	if err != nil {
+		return err
+	}
+
+	endpoint := c.String("endpoint")
+	username := c.String("username")
+	password, err := resolveRedfishPassword(
+		c.String("password"),
+		c.String("password-file"),
+		c.Bool("password-stdin"),
+		stdin,
+	)
+	if err != nil {
+		return err
+	}
+
+	// SSRF-guard the operator-supplied BMC endpoint, mirroring `redfish deploy`.
+	if err := isoserve.ValidateMediaURL(endpoint); err != nil {
+		return fmt.Errorf("validating endpoint: %w", err)
+	}
+
+	deployer := redfish.NewDeployer(redfish.Config{
+		Endpoint:  endpoint,
+		Username:  username,
+		Password:  password,
+		VerifySSL: c.Bool("verify-ssl"),
+		SystemID:  c.String("system-id"),
+		AuthMode:  redfish.AuthMode(c.String("auth-mode")),
+	})
+
+	if err := deployer.Connect(ctx); err != nil {
+		return fmt.Errorf("connecting to RedFish endpoint: %w", err)
+	}
+	// Always tear the session down (DELETE) on both success and error.
+	defer func() { _ = deployer.Close() }()
+
+	report, err := deployer.Probe(ctx)
+	if err != nil {
+		return fmt.Errorf("probing RedFish endpoint: %w", err)
+	}
+
+	renderProbeReport(out, report, output)
+	return nil
+}
+
+// resolveProbeOutput validates and normalises the --output flag. The empty string
+// defaults to "both". Any other value than text/yaml/both is rejected.
+func resolveProbeOutput(flag string) (string, error) {
+	switch out := strings.ToLower(strings.TrimSpace(flag)); out {
+	case "":
+		return "both", nil
+	case "text", "yaml", "both":
+		return out, nil
+	default:
+		return "", fmt.Errorf("invalid --output %q (valid: text, yaml, both)", flag)
+	}
+}
+
+// renderProbeReport writes the probe report to out in the requested format
+// ("text", "yaml", or "both"). It is the rendering seam, separated from the
+// connect/probe machinery so it can be unit-tested without a live BMC.
+func renderProbeReport(out io.Writer, report *redfish.ProbeReport, output string) {
+	var b strings.Builder
+	if output == "text" || output == "both" {
+		writeProbeText(&b, report)
+	}
+	if output == "both" {
+		b.WriteString("\n")
+	}
+	if output == "yaml" || output == "both" {
+		if output == "both" {
+			b.WriteString(redfish.StarterProfileHeader + "\n")
+		}
+		b.WriteString(report.StarterProfile())
+	}
+	// strings.Builder never errors; the single sink write is guarded for the rare
+	// io.Writer that does (a closed pipe), matching the cmd house style.
+	_, _ = io.WriteString(out, b.String())
+}
+
+// writeProbeText renders the human-readable, labelled probe report into b.
+func writeProbeText(b *strings.Builder, r *redfish.ProbeReport) {
+	p := func(format string, args ...any) { _, _ = fmt.Fprintf(b, format, args...) }
+
+	p("RedFish probe: %s\n", r.Endpoint)
+
+	p("\nService:\n")
+	p("  SessionService advertised: %s\n", yesNo(r.HasSessionService))
+	if r.HasSessionService {
+		p("    auth modes available: session, basic\n")
+	} else {
+		p("    auth modes available: basic only (no SessionService advertised)\n")
+	}
+	p("  auth mode used: %s\n", r.AuthModeUsed)
+
+	p("\nSystems:\n")
+	p("  member Ids: %s\n", strings.Join(r.SystemIDs, ", "))
+	if r.MultipleSystems {
+		p("  multiple systems — set --system-id (BMCTarget.SystemID); showing %s\n", r.SelectedSystemID)
+	} else {
+		p("  describing: %s\n", r.SelectedSystemID)
+	}
+
+	p("\nInspect:\n")
+	p("  manufacturer: %s\n", orDash(r.System.Manufacturer))
+	p("  model:        %s\n", orDash(r.System.Model))
+	p("  serial:       %s\n", orDash(r.System.SerialNumber))
+	p("  memory (GiB): %d\n", r.System.MemoryGiB)
+	p("  CPUs:         %d\n", r.System.ProcessorCount)
+	p("  features:     %s\n", orDash(strings.Join(sortedFeatures(r.System.Features), ", ")))
+	p("  firmware:     %s\n", orDash(r.FirmwareVersion))
+
+	p("\nVirtual media:\n")
+	if len(r.Media) == 0 {
+		p("  (none exposed)\n")
+	}
+	for i, m := range r.Media {
+		marker := "  "
+		if i == r.DefaultCDIndex {
+			marker = "* " // the default search would pick this member
+		}
+		types := orDash(strings.Join(m.MediaTypes, ","))
+		p("%sID=%s location=%s mediaTypes=[%s] inserted=%s\n",
+			marker, m.ID, m.Location, types, yesNo(m.Inserted))
+	}
+	if r.DefaultCDIndex >= 0 {
+		p("  (* = the default CD/DVD search would pick this member)\n")
+	} else {
+		p("  no CD/DVD-capable media found — a deploy would fail to find media\n")
+	}
+	if r.ManagerHostedCDOnly {
+		p("  NOTE: the only CD/DVD media is Manager-hosted (the HPE iLO signal);\n")
+		p("        the starter profile suggests a manager-first mediaSearch order.\n")
+	}
+
+	p("\nReset:\n")
+	p("  power state:           %s\n", orDash(r.PowerState))
+	p("  allowable ResetTypes:  %s\n", orDash(strings.Join(r.AllowableResetTypes, ", ")))
+	p("  core default for state: %s\n", orDash(r.DefaultResetType))
+}
+
+// sortedFeatures returns the detected feature names sorted for stable output.
+func sortedFeatures(features map[string]bool) []string {
+	out := make([]string, 0, len(features))
+	for f, ok := range features {
+		if ok {
+			out = append(out, f)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/cmd/redfish_probe.go
+++ b/internal/cmd/redfish_probe.go
@@ -67,6 +67,11 @@ func redfishProbeCmd() *cli.Command {
 				Usage: "Output format: text (human report only), yaml (starter profile only, pipeable to a file), or both",
 				Value: "both",
 			},
+			&cli.StringFlag{
+				Name:    "quirks-dir",
+				Usage:   "Directory of operator-supplied *.yaml/*.yml quirk profiles to load and validate at start. The probe is read-only and does not apply a profile; loading here surfaces malformed-profile errors and the support tier of each",
+				EnvVars: []string{redfishQuirksDirEnv},
+			},
 		},
 		Action: func(c *cli.Context) error {
 			return runRedfishProbe(c, os.Stdin, c.App.Writer)
@@ -81,6 +86,13 @@ func runRedfishProbe(c *cli.Context, stdin io.Reader, out io.Writer) error {
 
 	output, err := resolveProbeOutput(c.String("output"))
 	if err != nil {
+		return err
+	}
+
+	// Load (and so validate) any operator quirk profiles at start. The probe is
+	// read-only and applies no profile; loading surfaces malformed-profile errors
+	// and each profile's support tier via the registry's load-time log lines.
+	if err := loadRedfishQuirksDir(c.String("quirks-dir")); err != nil {
 		return err
 	}
 

--- a/internal/cmd/redfish_probe_internal_test.go
+++ b/internal/cmd/redfish_probe_internal_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+)
+
+func TestResolveProbeOutput(t *testing.T) {
+	tests := []struct {
+		flag    string
+		want    string
+		wantErr bool
+	}{
+		{"", "both", false},
+		{"both", "both", false},
+		{"text", "text", false},
+		{"yaml", "yaml", false},
+		{"YAML", "yaml", false},
+		{"  text  ", "text", false},
+		{"json", "", true},
+	}
+	for _, tt := range tests {
+		got, err := resolveProbeOutput(tt.flag)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("resolveProbeOutput(%q): expected error, got nil", tt.flag)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("resolveProbeOutput(%q): unexpected error %v", tt.flag, err)
+		}
+		if got != tt.want {
+			t.Errorf("resolveProbeOutput(%q) = %q, want %q", tt.flag, got, tt.want)
+		}
+	}
+}
+
+// sampleReport is a manager-hosted-CD probe report (the iLO shape) used to exercise
+// the rendering seam: it yields a starter profile WITH a mediaSearch order.
+func sampleReport() *redfish.ProbeReport {
+	return &redfish.ProbeReport{
+		Endpoint:          "https://bmc.example",
+		HasSessionService: true,
+		AuthModeUsed:      "session",
+		SystemIDs:         []string{"sys-1"},
+		SelectedSystemID:  "sys-1",
+		System: redfish.SystemInfo{
+			ID:             "sys-1",
+			Manufacturer:   "HPE",
+			Model:          "ProLiant DL360",
+			SerialNumber:   "SN-1",
+			MemoryGiB:      64,
+			ProcessorCount: 8,
+			Features:       map[string]bool{redfish.FeatureUEFI: true},
+		},
+		FirmwareVersion: "iLO 5 v2.44",
+		Media: []redfish.MediaView{
+			{Index: 0, ID: "Cd", Location: "manager:mgr-1", MediaTypes: []string{"CD", "DVD"}},
+		},
+		DefaultCDIndex:      0,
+		ManagerHostedCDOnly: true,
+		PowerState:          "On",
+		AllowableResetTypes: []string{"On", "ForceRestart", "GracefulRestart"},
+		DefaultResetType:    "ForceRestart",
+	}
+}
+
+func TestRenderProbeReportYAMLOnlyParses(t *testing.T) {
+	var buf bytes.Buffer
+	renderProbeReport(&buf, sampleReport(), "yaml")
+
+	out := buf.String()
+	if strings.Contains(out, "RedFish probe:") {
+		t.Fatalf("yaml-only output must not contain the human report header:\n%s", out)
+	}
+
+	profile, err := redfish.ParseProfile(buf.Bytes())
+	if err != nil {
+		t.Fatalf("yaml-only output must parse as a profile: %v\n---\n%s", err, out)
+	}
+	if profile.Name != "hpe" {
+		t.Errorf("profile name = %q, want %q", profile.Name, "hpe")
+	}
+	if profile.MediaSearch == nil {
+		t.Fatalf("manager-hosted media must yield a mediaSearch")
+	}
+	if got := strings.Join(profile.MediaSearch.Order, ","); got != "manager,system" {
+		t.Errorf("mediaSearch.order = %q, want %q", got, "manager,system")
+	}
+	if profile.ValidatedFirmware != "iLO 5 v2.44" {
+		t.Errorf("validatedFirmware = %q, want %q", profile.ValidatedFirmware, "iLO 5 v2.44")
+	}
+}
+
+func TestRenderProbeReportBothHasTextAndProfile(t *testing.T) {
+	var buf bytes.Buffer
+	renderProbeReport(&buf, sampleReport(), "both")
+
+	out := buf.String()
+	for _, want := range []string{
+		"RedFish probe: https://bmc.example",
+		"member Ids: sys-1",
+		"manufacturer: HPE",
+		"firmware:     iLO 5 v2.44",
+		"only CD/DVD media is Manager-hosted",
+		"suggested profile (tier C",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("both output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderProbeReportTextOnlyHasNoProfile(t *testing.T) {
+	var buf bytes.Buffer
+	renderProbeReport(&buf, sampleReport(), "text")
+
+	out := buf.String()
+	if !strings.Contains(out, "RedFish probe:") {
+		t.Errorf("text output must contain the human report")
+	}
+	if strings.Contains(out, "name: hpe") {
+		t.Errorf("text-only output must not contain the starter profile body")
+	}
+}

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -193,6 +193,7 @@ func runWeb(c *cli.Context) error {
 	secureBootKeySetStore := &gormstore.SecureBootKeySetStoreAdapter{S: store}
 	deploymentStore := &gormstore.DeploymentStoreAdapter{S: store}
 	bmcTargetStore := &gormstore.BMCTargetStoreAdapter{S: store}
+	settingsStore := &gormstore.SettingsStoreAdapter{S: store}
 
 	netbootManager := netbootmgr.NewManager()
 
@@ -202,11 +203,14 @@ func runWeb(c *cli.Context) error {
 	// advertised base defaults to --url but can differ (the BMC management network
 	// is often not the UI network).
 	var isoServe *isoserve.Server
+	// serveURL is the advertised base URL a BMC fetches the served ISO from. It is
+	// hoisted out of the start block so it can seed the runtime image-source
+	// settings' advertised URL even before an operator overrides it.
+	serveURL := redfishServeURL
+	if serveURL == "" {
+		serveURL = externalURL
+	}
 	if redfishServeAddr != "" {
-		serveURL := redfishServeURL
-		if serveURL == "" {
-			serveURL = externalURL
-		}
 		isoServe = isoserve.New(isoserve.Config{
 			BaseURL:  serveURL,
 			BindAddr: redfishServeAddr,
@@ -239,6 +243,7 @@ func runWeb(c *cli.Context) error {
 		NetbootManager:        netbootManager,
 		DeploymentStore:       deploymentStore,
 		BMCTargetStore:        bmcTargetStore,
+		SettingsStore:         settingsStore,
 		Builder:               artifactBuilder,
 		AdminPassword:         adminPassword,
 		RegToken:              regToken,
@@ -248,6 +253,7 @@ func runWeb(c *cli.Context) error {
 		KeysDir:               keysDir,
 		Hub:                   wsHub,
 		ISOServe:              isoServe,
+		RedfishServeURL:       redfishServeURLSeed(isoServe, serveURL),
 	})
 
 	fmt.Fprintf(os.Stderr, "AuroraBoot fleet server starting on %s\n", listenAddr)
@@ -314,6 +320,17 @@ func loadOrGenerateSecret(path, label string) string {
 	}
 	fmt.Fprintf(os.Stderr, "Generated %s: %s (saved to %s)\n", label, secret, path)
 	return secret
+}
+
+// redfishServeURLSeed returns the advertised URL to seed the image-source
+// settings with, but only when a local ISO-serve listener was actually
+// configured. With no listener the advertised URL is irrelevant (local serving
+// cannot be enabled), so seeding it would be misleading.
+func redfishServeURLSeed(isoServe *isoserve.Server, serveURL string) string {
+	if isoServe == nil {
+		return ""
+	}
+	return serveURL
 }
 
 func generateToken(bytes int) string {

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -98,6 +98,7 @@ var WebCMD = cli.Command{
 		&cli.StringFlag{Name: "redfish-serve-addr", Usage: "Bind address for the Redfish ISO-serve (e.g. 10.0.0.5:8090). Required to enable serving local artifact ISOs to a BMC", EnvVars: []string{"AURORABOOT_REDFISH_SERVE_ADDR"}},
 		&cli.StringFlag{Name: "redfish-serve-tls-cert", Usage: "TLS certificate for the Redfish ISO-serve (opt-in HTTPS; requires a BMC-trusted cert)"},
 		&cli.StringFlag{Name: "redfish-serve-tls-key", Usage: "TLS key for the Redfish ISO-serve"},
+		&cli.StringFlag{Name: "redfish-quirks-dir", Usage: "Directory of operator-supplied *.yaml/*.yml Redfish quirk profiles, loaded once at server start (not hot-reloaded). A BMCTarget's vendor resolves to a profile by name; an operator profile named the same as a built-in overrides it (logged). A malformed profile is skipped, not fatal", EnvVars: []string{redfishQuirksDirEnv}},
 	},
 	Action: runWeb,
 }
@@ -116,6 +117,7 @@ func runWeb(c *cli.Context) error {
 	redfishServeAddr := c.String("redfish-serve-addr")
 	redfishServeTLSCert := c.String("redfish-serve-tls-cert")
 	redfishServeTLSKey := c.String("redfish-serve-tls-key")
+	redfishQuirksDir := c.String("redfish-quirks-dir")
 
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		return fmt.Errorf("create data directory: %w", err)
@@ -222,6 +224,16 @@ func runWeb(c *cli.Context) error {
 			_ = isoServe.Shutdown(shutdownCtx)
 		}()
 		fmt.Fprintf(os.Stderr, "  ISO-serve: %s (bind %s)\n", serveURL, redfishServeAddr)
+	}
+
+	// Load operator-supplied Redfish quirk profiles once at start (not
+	// hot-reloaded: an in-flight deploy must never have its profile swapped). The
+	// loaded registry becomes the process-wide default, so the Redfish deploy path
+	// resolves a BMCTarget's vendor to a profile by name — operator profiles
+	// included — inside redfish.NewDeployer. Each profile and each skipped file is
+	// logged by the loader.
+	if err := loadRedfishQuirksDir(redfishQuirksDir); err != nil {
+		return err
 	}
 
 	// Root context for background deploy goroutines, cancelled when runWeb

--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -194,6 +194,9 @@ func (a *DeploymentStoreAdapter) Update(ctx context.Context, dep *store.Deployme
 func (a *DeploymentStoreAdapter) Delete(ctx context.Context, id string) error {
 	return a.S.DeploymentDelete(ctx, id)
 }
+func (a *DeploymentStoreAdapter) CASEjectState(ctx context.Context, id, from, to string) (bool, error) {
+	return a.S.DeploymentCASEjectState(ctx, id, from, to)
+}
 
 // SettingsStoreAdapter adapts Store to the store.SettingsStore interface.
 type SettingsStoreAdapter struct{ S *Store }

--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -194,3 +194,16 @@ func (a *DeploymentStoreAdapter) Update(ctx context.Context, dep *store.Deployme
 func (a *DeploymentStoreAdapter) Delete(ctx context.Context, id string) error {
 	return a.S.DeploymentDelete(ctx, id)
 }
+
+// SettingsStoreAdapter adapts Store to the store.SettingsStore interface.
+type SettingsStoreAdapter struct{ S *Store }
+
+func (a *SettingsStoreAdapter) Get(ctx context.Context, key string) (string, bool, error) {
+	return a.S.SettingGet(ctx, key)
+}
+func (a *SettingsStoreAdapter) Set(ctx context.Context, key, value string) error {
+	return a.S.SettingSet(ctx, key, value)
+}
+func (a *SettingsStoreAdapter) GetAll(ctx context.Context) (map[string]string, error) {
+	return a.S.SettingGetAll(ctx)
+}

--- a/internal/store/gorm/bmc_imageurl_test.go
+++ b/internal/store/gorm/bmc_imageurl_test.go
@@ -1,0 +1,56 @@
+package gorm_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+)
+
+var _ = Describe("BMCTarget ImageURL persistence", func() {
+	var (
+		ctx context.Context
+		s   *gormstore.Store
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		s, err = gormstore.New(":memory:")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("persists ImageURL on Create and round-trips it on read", func() {
+		t := &store.BMCTarget{Name: "host", Endpoint: "https://10.0.0.9", ImageURL: "https://10.0.0.5/os.iso"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.ImageURL).To(Equal("https://10.0.0.5/os.iso"))
+	})
+
+	It("persists an updated ImageURL", func() {
+		t := &store.BMCTarget{Name: "host", Endpoint: "https://10.0.0.9"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+		Expect(t.ImageURL).To(BeEmpty())
+
+		t.ImageURL = "https://10.0.0.6/os.iso"
+		Expect(s.BMCTargetUpdate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.ImageURL).To(Equal("https://10.0.0.6/os.iso"))
+	})
+
+	It("defaults to an empty ImageURL", func() {
+		t := &store.BMCTarget{Name: "host", Endpoint: "https://10.0.0.1"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.ImageURL).To(BeEmpty())
+	})
+})

--- a/internal/store/gorm/bmc_status_test.go
+++ b/internal/store/gorm/bmc_status_test.go
@@ -1,0 +1,89 @@
+package gorm_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+)
+
+var _ = Describe("BMCTarget status-cache persistence", func() {
+	var (
+		ctx context.Context
+		s   *gormstore.Store
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		s, err = gormstore.New(":memory:")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("persists every status-cache field on Update and round-trips it on read", func() {
+		t := &store.BMCTarget{Name: "h", Endpoint: "https://10.0.0.9"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+
+		inspectAt := time.Now().UTC().Truncate(time.Second)
+		pingAt := inspectAt.Add(time.Minute)
+		t.LastStatus = "reachable"
+		t.LastError = ""
+		t.LastInspectAt = &inspectAt
+		t.LastPingAt = &pingAt
+		t.LastModel = "PowerEdge R760"
+		t.LastManufacturer = "Dell"
+		t.LastSerial = "SN-123"
+		t.LastMemoryGiB = 256
+		t.LastCPUCount = 64
+		t.LastFeatures = []string{"SecureBoot", "UEFI"}
+		Expect(s.BMCTargetUpdate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.LastStatus).To(Equal("reachable"))
+		Expect(got.LastError).To(BeEmpty())
+		Expect(got.LastInspectAt).NotTo(BeNil())
+		Expect(got.LastInspectAt.UTC()).To(Equal(inspectAt))
+		Expect(got.LastPingAt).NotTo(BeNil())
+		Expect(got.LastPingAt.UTC()).To(Equal(pingAt))
+		Expect(got.LastModel).To(Equal("PowerEdge R760"))
+		Expect(got.LastManufacturer).To(Equal("Dell"))
+		Expect(got.LastSerial).To(Equal("SN-123"))
+		Expect(got.LastMemoryGiB).To(Equal(256))
+		Expect(got.LastCPUCount).To(Equal(64))
+	})
+
+	It("round-trips LastFeatures through the json serializer", func() {
+		t := &store.BMCTarget{Name: "h", Endpoint: "https://10.0.0.9"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+
+		t.LastFeatures = []string{"SecureBoot", "UEFI"}
+		Expect(s.BMCTargetUpdate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.LastFeatures).To(Equal([]string{"SecureBoot", "UEFI"}))
+
+		// And the list path decodes it too.
+		all, err := s.BMCTargetList(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(all).To(HaveLen(1))
+		Expect(all[0].LastFeatures).To(Equal([]string{"SecureBoot", "UEFI"}))
+	})
+
+	It("defaults status-cache fields to zero for a fresh target", func() {
+		t := &store.BMCTarget{Name: "fresh", Endpoint: "https://10.0.0.1"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.LastStatus).To(BeEmpty())
+		Expect(got.LastInspectAt).To(BeNil())
+		Expect(got.LastPingAt).To(BeNil())
+		Expect(got.LastFeatures).To(BeEmpty())
+	})
+})

--- a/internal/store/gorm/bmc_systemid_test.go
+++ b/internal/store/gorm/bmc_systemid_test.go
@@ -1,0 +1,56 @@
+package gorm_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+)
+
+var _ = Describe("BMCTarget SystemID persistence", func() {
+	var (
+		ctx context.Context
+		s   *gormstore.Store
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		s, err = gormstore.New(":memory:")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("persists SystemID on Create and round-trips it on read", func() {
+		t := &store.BMCTarget{Name: "multi", Endpoint: "https://10.0.0.9", SystemID: "node-b"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.SystemID).To(Equal("node-b"))
+	})
+
+	It("persists an updated SystemID", func() {
+		t := &store.BMCTarget{Name: "multi", Endpoint: "https://10.0.0.9"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+		Expect(t.SystemID).To(BeEmpty())
+
+		t.SystemID = "node-a"
+		Expect(s.BMCTargetUpdate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.SystemID).To(Equal("node-a"))
+	})
+
+	It("defaults to an empty SystemID for single-system BMCs", func() {
+		t := &store.BMCTarget{Name: "single", Endpoint: "https://10.0.0.1"}
+		Expect(s.BMCTargetCreate(ctx, t)).To(Succeed())
+
+		got, err := s.BMCTargetGetByID(ctx, t.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.SystemID).To(BeEmpty())
+	})
+})

--- a/internal/store/gorm/deployment_eject_test.go
+++ b/internal/store/gorm/deployment_eject_test.go
@@ -1,0 +1,114 @@
+package gorm_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+)
+
+var _ = Describe("Deployment eject fields + CAS", func() {
+	var (
+		ctx context.Context
+		s   *gormstore.Store
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		s, err = gormstore.New(":memory:")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("persists the eject fields and round-trips them on read", func() {
+		ejectedAt := time.Now().UTC().Truncate(time.Second)
+		dep := &store.Deployment{
+			ArtifactID:  "art-1",
+			Method:      "redfish",
+			Status:      store.DeployCompleted,
+			BMCTargetID: "bmc-1",
+			NodeID:      "node-1",
+			EjectPolicy: store.EjectPolicyOnPhoneHome,
+			EjectState:  store.EjectStateEjected,
+			EjectError:  "",
+			EjectedAt:   &ejectedAt,
+		}
+		Expect(s.DeploymentCreate(ctx, dep)).To(Succeed())
+
+		got, err := s.DeploymentGetByID(ctx, dep.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.NodeID).To(Equal("node-1"))
+		Expect(got.EjectPolicy).To(Equal(store.EjectPolicyOnPhoneHome))
+		Expect(got.EjectState).To(Equal(store.EjectStateEjected))
+		Expect(got.EjectedAt).NotTo(BeNil())
+		Expect(got.EjectedAt.Unix()).To(Equal(ejectedAt.Unix()))
+	})
+
+	It("defaults the eject fields to empty for a plain deployment", func() {
+		dep := &store.Deployment{ArtifactID: "art-1", Method: "redfish", Status: store.DeployActive}
+		Expect(s.DeploymentCreate(ctx, dep)).To(Succeed())
+
+		got, err := s.DeploymentGetByID(ctx, dep.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.EjectPolicy).To(BeEmpty())
+		Expect(got.EjectState).To(BeEmpty())
+		Expect(got.EjectedAt).To(BeNil())
+	})
+
+	Describe("CASEjectState", func() {
+		var depID string
+
+		BeforeEach(func() {
+			dep := &store.Deployment{
+				ArtifactID: "art-1",
+				Method:     "redfish",
+				Status:     store.DeployCompleted,
+				EjectState: store.EjectStatePending,
+			}
+			Expect(s.DeploymentCreate(ctx, dep)).To(Succeed())
+			depID = dep.ID
+		})
+
+		It("transitions when the current state matches `from`", func() {
+			ok, err := s.DeploymentCASEjectState(ctx, depID, store.EjectStatePending, store.EjectStateEjecting)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+
+			got, err := s.DeploymentGetByID(ctx, depID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.EjectState).To(Equal(store.EjectStateEjecting))
+		})
+
+		It("refuses when the current state does not match `from`", func() {
+			ok, err := s.DeploymentCASEjectState(ctx, depID, store.EjectStateEjecting, store.EjectStateEjected)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+
+			got, err := s.DeploymentGetByID(ctx, depID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.EjectState).To(Equal(store.EjectStatePending))
+		})
+
+		It("lets exactly one of two concurrent claimants win", func() {
+			// Two attempts race the same pending->ejecting transition; exactly one
+			// must win (the compare-and-set idempotency guarantee the finalize path
+			// relies on).
+			first, err := s.DeploymentCASEjectState(ctx, depID, store.EjectStatePending, store.EjectStateEjecting)
+			Expect(err).NotTo(HaveOccurred())
+			second, err := s.DeploymentCASEjectState(ctx, depID, store.EjectStatePending, store.EjectStateEjecting)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(first).To(BeTrue())
+			Expect(second).To(BeFalse())
+		})
+
+		It("returns false for a missing deployment", func() {
+			ok, err := s.DeploymentCASEjectState(ctx, "does-not-exist", store.EjectStatePending, store.EjectStateEjecting)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+})

--- a/internal/store/gorm/settings_test.go
+++ b/internal/store/gorm/settings_test.go
@@ -1,0 +1,66 @@
+package gorm_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+)
+
+var _ = Describe("settingStore", func() {
+	var (
+		ctx context.Context
+		s   *gormstore.Store
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		s, err = gormstore.New(":memory:")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("reports a missing key as not-found without erroring", func() {
+		v, found, err := s.SettingGet(ctx, "imageSource.defaultImageURL")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeFalse())
+		Expect(v).To(BeEmpty())
+	})
+
+	It("sets and reads back a value", func() {
+		Expect(s.SettingSet(ctx, "imageSource.defaultImageURL", "https://10.0.0.5/os.iso")).To(Succeed())
+
+		v, found, err := s.SettingGet(ctx, "imageSource.defaultImageURL")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(v).To(Equal("https://10.0.0.5/os.iso"))
+	})
+
+	It("upserts on a repeated Set (last write wins)", func() {
+		Expect(s.SettingSet(ctx, "imageSource.localServeEnabled", "false")).To(Succeed())
+		Expect(s.SettingSet(ctx, "imageSource.localServeEnabled", "true")).To(Succeed())
+
+		v, found, err := s.SettingGet(ctx, "imageSource.localServeEnabled")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(v).To(Equal("true"))
+	})
+
+	It("returns every setting from GetAll", func() {
+		Expect(s.SettingSet(ctx, "a", "1")).To(Succeed())
+		Expect(s.SettingSet(ctx, "b", "2")).To(Succeed())
+
+		all, err := s.SettingGetAll(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(all).To(HaveKeyWithValue("a", "1"))
+		Expect(all).To(HaveKeyWithValue("b", "2"))
+	})
+
+	It("returns an empty map when no settings exist", func() {
+		all, err := s.SettingGetAll(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(all).To(BeEmpty())
+	})
+})

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -610,6 +610,21 @@ func (s *Store) DeploymentDelete(ctx context.Context, id string) error {
 	return s.db.WithContext(ctx).Delete(&store.Deployment{}, "id = ?", id).Error
 }
 
+// DeploymentCASEjectState atomically transitions eject_state from `from` to `to`.
+// The conditional WHERE (id = ? AND eject_state = from) plus a RowsAffected check
+// makes the claim a race-free compare-and-set: when an auto eject-on-phone-home and
+// a manual finalize both target the same deployment, exactly one UPDATE matches the
+// still-`from` row and the loser sees RowsAffected == 0. Mirrors ClaimForDelivery.
+func (s *Store) DeploymentCASEjectState(ctx context.Context, id, from, to string) (bool, error) {
+	res := s.db.WithContext(ctx).Model(&store.Deployment{}).
+		Where("id = ? AND eject_state = ?", id, from).
+		Update("eject_state", to)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
 // --- SettingsStore ---
 
 func (s *Store) SettingGet(ctx context.Context, key string) (string, bool, error) {

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Store implements GroupStore, NodeStore, and CommandStore using GORM.
@@ -65,7 +67,7 @@ func New(dsn string) (*Store, error) {
 		}
 	}
 
-	if err := db.AutoMigrate(&store.NodeGroup{}, &store.ManagedNode{}, &store.NodeCommand{}, &store.ArtifactRecord{}, &store.SecureBootKeySet{}, &store.BMCTarget{}, &store.Deployment{}); err != nil {
+	if err := db.AutoMigrate(&store.NodeGroup{}, &store.ManagedNode{}, &store.NodeCommand{}, &store.ArtifactRecord{}, &store.SecureBootKeySet{}, &store.BMCTarget{}, &store.Deployment{}, &store.Setting{}); err != nil {
 		return nil, fmt.Errorf("auto-migrating: %w", err)
 	}
 
@@ -606,6 +608,43 @@ func (s *Store) DeploymentUpdate(ctx context.Context, dep *store.Deployment) err
 
 func (s *Store) DeploymentDelete(ctx context.Context, id string) error {
 	return s.db.WithContext(ctx).Delete(&store.Deployment{}, "id = ?", id).Error
+}
+
+// --- SettingsStore ---
+
+func (s *Store) SettingGet(ctx context.Context, key string) (string, bool, error) {
+	var setting store.Setting
+	err := s.db.WithContext(ctx).First(&setting, "key = ?", key).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return setting.Value, true, nil
+}
+
+// SettingSet upserts key→value. The OnConflict clause updates the existing row in
+// place (rather than failing on the primary-key collision), so callers get
+// last-write-wins semantics on a repeated Set.
+func (s *Store) SettingSet(ctx context.Context, key, value string) error {
+	setting := store.Setting{Key: key, Value: value, UpdatedAt: time.Now()}
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		UpdateAll: true,
+	}).Create(&setting).Error
+}
+
+func (s *Store) SettingGetAll(ctx context.Context) (map[string]string, error) {
+	var settings []store.Setting
+	if err := s.db.WithContext(ctx).Find(&settings).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(settings))
+	for _, setting := range settings {
+		out[setting.Key] = setting.Value
+	}
+	return out, nil
 }
 
 // Close closes the underlying database connection.

--- a/pkg/handlers/bmc_crud_test.go
+++ b/pkg/handlers/bmc_crud_test.go
@@ -76,6 +76,13 @@ var _ = Describe("BMC target CRUD ImageURL validation", func() {
 		Expect(bmcTargets.targets[0].ImageURL).To(Equal("https://10.0.0.5/os.iso"))
 	})
 
+	It("persists the EjectPowerCycle flag on update", func() {
+		bmcTargets.targets = []*store.BMCTarget{{ID: "bmc-1", Endpoint: "https://10.0.0.9"}}
+		rec := update("bmc-1", `{"name":"h","endpoint":"https://10.0.0.9","ejectPowerCycle":true}`)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(bmcTargets.targets[0].EjectPowerCycle).To(BeTrue())
+	})
+
 	It("accepts a normal RFC1918 endpoint on create", func() {
 		rec := create(`{"name":"h","endpoint":"https://192.168.1.50"}`)
 		Expect(rec.Code).To(Equal(http.StatusCreated))

--- a/pkg/handlers/bmc_crud_test.go
+++ b/pkg/handlers/bmc_crud_test.go
@@ -1,0 +1,78 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/labstack/echo/v4"
+)
+
+var _ = Describe("BMC target CRUD ImageURL validation", func() {
+	var (
+		e          *echo.Echo
+		bmcTargets *fakeBMCTargetStore
+		h          *handlers.DeployHandler
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		bmcTargets = &fakeBMCTargetStore{}
+		h = handlers.NewDeployHandler(&fakeArtifactStore{}, &fakeDeploymentStore{}, bmcTargets, nil, "", nil, nil)
+	})
+
+	create := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/bmc-targets", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		Expect(h.CreateBMCTarget(c)).To(Succeed())
+		return rec
+	}
+
+	update := func(id, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/bmc-targets/"+id, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(id)
+		Expect(h.UpdateBMCTarget(c)).To(Succeed())
+		return rec
+	}
+
+	It("accepts and persists a valid per-BMC ImageURL on create", func() {
+		rec := create(`{"name":"h","endpoint":"https://10.0.0.9","imageUrl":"https://10.0.0.5/os.iso"}`)
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+		Expect(bmcTargets.targets).To(HaveLen(1))
+		Expect(bmcTargets.targets[0].ImageURL).To(Equal("https://10.0.0.5/os.iso"))
+	})
+
+	It("rejects an SSRF-blocked ImageURL on create with 400", func() {
+		rec := create(`{"name":"h","endpoint":"https://10.0.0.9","imageUrl":"http://169.254.169.254/x.iso"}`)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		Expect(rec.Body.String()).To(ContainSubstring("invalid imageUrl"))
+		Expect(bmcTargets.targets).To(BeEmpty())
+	})
+
+	It("rejects an SSRF-blocked ImageURL on update with 400", func() {
+		bmcTargets.targets = []*store.BMCTarget{{ID: "bmc-1", Endpoint: "https://10.0.0.9"}}
+		rec := update("bmc-1", `{"name":"h","endpoint":"https://10.0.0.9","imageUrl":"http://169.254.169.254/x.iso"}`)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		Expect(rec.Body.String()).To(ContainSubstring("invalid imageUrl"))
+		// The stored target is unchanged.
+		Expect(bmcTargets.targets[0].ImageURL).To(BeEmpty())
+	})
+
+	It("persists an updated ImageURL on update", func() {
+		bmcTargets.targets = []*store.BMCTarget{{ID: "bmc-1", Endpoint: "https://10.0.0.9"}}
+		rec := update("bmc-1", `{"name":"h","endpoint":"https://10.0.0.9","imageUrl":"https://10.0.0.5/os.iso"}`)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(bmcTargets.targets[0].ImageURL).To(Equal("https://10.0.0.5/os.iso"))
+	})
+})

--- a/pkg/handlers/bmc_crud_test.go
+++ b/pkg/handlers/bmc_crud_test.go
@@ -75,4 +75,25 @@ var _ = Describe("BMC target CRUD ImageURL validation", func() {
 		Expect(rec.Code).To(Equal(http.StatusOK))
 		Expect(bmcTargets.targets[0].ImageURL).To(Equal("https://10.0.0.5/os.iso"))
 	})
+
+	It("ignores client-supplied status-cache fields on create (server-owned)", func() {
+		rec := create(`{"name":"h","endpoint":"https://10.0.0.9","lastStatus":"reachable","lastModel":"FAKE","lastFeatures":["UEFI"]}`)
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+		Expect(bmcTargets.targets).To(HaveLen(1))
+		// A client cannot fabricate a cached status without an actual check.
+		Expect(bmcTargets.targets[0].LastStatus).To(BeEmpty())
+		Expect(bmcTargets.targets[0].LastModel).To(BeEmpty())
+		Expect(bmcTargets.targets[0].LastFeatures).To(BeEmpty())
+	})
+
+	It("does not let an update overwrite the server-owned status cache", func() {
+		bmcTargets.targets = []*store.BMCTarget{{
+			ID: "bmc-1", Endpoint: "https://10.0.0.9", LastStatus: "reachable", LastModel: "REAL",
+		}}
+		rec := update("bmc-1", `{"name":"h","endpoint":"https://10.0.0.9","lastStatus":"unreachable","lastModel":"FAKE"}`)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		// The fixed-field copy never touches the status cache: it is preserved.
+		Expect(bmcTargets.targets[0].LastStatus).To(Equal("reachable"))
+		Expect(bmcTargets.targets[0].LastModel).To(Equal("REAL"))
+	})
 })

--- a/pkg/handlers/bmc_crud_test.go
+++ b/pkg/handlers/bmc_crud_test.go
@@ -76,6 +76,43 @@ var _ = Describe("BMC target CRUD ImageURL validation", func() {
 		Expect(bmcTargets.targets[0].ImageURL).To(Equal("https://10.0.0.5/os.iso"))
 	})
 
+	It("accepts a normal RFC1918 endpoint on create", func() {
+		rec := create(`{"name":"h","endpoint":"https://192.168.1.50"}`)
+		Expect(rec.Code).To(Equal(http.StatusCreated))
+		Expect(bmcTargets.targets).To(HaveLen(1))
+		Expect(bmcTargets.targets[0].Endpoint).To(Equal("https://192.168.1.50"))
+	})
+
+	It("rejects an SSRF-blocked metadata-IP endpoint on create with 400", func() {
+		rec := create(`{"name":"h","endpoint":"https://169.254.169.254"}`)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		Expect(rec.Body.String()).To(ContainSubstring("invalid endpoint"))
+		Expect(bmcTargets.targets).To(BeEmpty())
+	})
+
+	It("rejects a loopback endpoint on create with 400", func() {
+		rec := create(`{"name":"h","endpoint":"https://127.0.0.1"}`)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		Expect(rec.Body.String()).To(ContainSubstring("invalid endpoint"))
+		Expect(bmcTargets.targets).To(BeEmpty())
+	})
+
+	It("rejects an SSRF-blocked metadata-IP endpoint on update with 400", func() {
+		bmcTargets.targets = []*store.BMCTarget{{ID: "bmc-1", Endpoint: "https://10.0.0.9"}}
+		rec := update("bmc-1", `{"name":"h","endpoint":"https://169.254.169.254"}`)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		Expect(rec.Body.String()).To(ContainSubstring("invalid endpoint"))
+		// The stored target is unchanged.
+		Expect(bmcTargets.targets[0].Endpoint).To(Equal("https://10.0.0.9"))
+	})
+
+	It("accepts a normal RFC1918 endpoint on update", func() {
+		bmcTargets.targets = []*store.BMCTarget{{ID: "bmc-1", Endpoint: "https://10.0.0.9"}}
+		rec := update("bmc-1", `{"name":"h","endpoint":"https://192.168.1.50"}`)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(bmcTargets.targets[0].Endpoint).To(Equal("https://192.168.1.50"))
+	})
+
 	It("ignores client-supplied status-cache fields on create (server-owned)", func() {
 		rec := create(`{"name":"h","endpoint":"https://10.0.0.9","lastStatus":"reachable","lastModel":"FAKE","lastFeatures":["UEFI"]}`)
 		Expect(rec.Code).To(Equal(http.StatusCreated))

--- a/pkg/handlers/bmc_status.go
+++ b/pkg/handlers/bmc_status.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/labstack/echo/v4"
+)
+
+// BMC status-cache values. These mirror store.BMCTarget.LastStatus; "" (unknown)
+// is the third, implicit state for a target that has never been pinged/inspected.
+const (
+	bmcStatusReachable   = "reachable"
+	bmcStatusUnreachable = "unreachable"
+)
+
+// refreshAllInterTargetDelay paces a sequential refresh-all so a single BMC (or a
+// shared sushy service fronting many systems) is not hit back-to-back.
+const refreshAllInterTargetDelay = 250 * time.Millisecond
+
+// refreshAllPerTargetTimeout bounds each individual reachability ping during a
+// refresh-all so one unresponsive BMC cannot stall the whole sweep.
+const refreshAllPerTargetTimeout = 5 * time.Second
+
+// bmcStatusResponse is the per-target status payload returned by the ping and
+// refresh-all endpoints.
+type bmcStatusResponse struct {
+	ID         string     `json:"id,omitempty"`
+	Status     string     `json:"status"`
+	LastPingAt *time.Time `json:"lastPingAt,omitempty"`
+	Error      string     `json:"error,omitempty"`
+}
+
+// clearBMCStatusCache zeroes the server-owned status-cache fields on a target.
+// CreateBMCTarget calls it after binding the request body so a client cannot
+// fabricate a cached status: these fields are populated only by the inspect, ping,
+// and refresh-all handlers.
+func clearBMCStatusCache(t *store.BMCTarget) {
+	t.LastStatus = ""
+	t.LastError = ""
+	t.LastInspectAt = nil
+	t.LastPingAt = nil
+	t.LastModel = ""
+	t.LastManufacturer = ""
+	t.LastSerial = ""
+	t.LastMemoryGiB = 0
+	t.LastCPUCount = 0
+	t.LastFeatures = nil
+}
+
+// scrubBMCError renders an error for storage/return in the status cache. The
+// redfish package already scrubs credentials at the source; this is a thin,
+// nil-safe accessor kept as a single choke point so any future defensive
+// redaction lives in one place.
+func scrubBMCError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// pingTarget performs the session-free reachability ping for one target and
+// persists the outcome (LastStatus / LastError / LastPingAt) into its status
+// cache. It never creates a Redfish session, so it adds nothing to the BMC's
+// capped concurrent-session count. It returns the status payload (mutated target's
+// LastPingAt is reused) so callers can include it in a response without re-reading
+// the store. A store-write failure is best-effort and swallowed.
+func (h *DeployHandler) pingTarget(ctx context.Context, target *store.BMCTarget) bmcStatusResponse {
+	now := time.Now()
+	err := redfish.Reachable(ctx, target.Endpoint, !target.VerifySSL)
+
+	target.LastPingAt = &now
+	if err != nil {
+		target.LastStatus = bmcStatusUnreachable
+		target.LastError = pingErrorMessage(err)
+	} else {
+		target.LastStatus = bmcStatusReachable
+		target.LastError = ""
+	}
+	_ = h.bmcTargets.Update(ctx, target)
+
+	return bmcStatusResponse{
+		ID:         target.ID,
+		Status:     target.LastStatus,
+		LastPingAt: target.LastPingAt,
+		Error:      target.LastError,
+	}
+}
+
+// pingErrorMessage maps a session-free ping failure to an operator-facing message.
+// A ServiceRoot gated behind authentication (401/403) is a common posture on
+// hardened BMCs; the ping cannot authenticate by design, so we steer the operator
+// to an authenticated Inspect rather than reporting a misleading hard failure.
+func pingErrorMessage(err error) string {
+	msg := scrubBMCError(err)
+	if strings.Contains(msg, "status 401") || strings.Contains(msg, "status 403") {
+		return "ServiceRoot requires authentication; use Inspect for an authenticated check"
+	}
+	return msg
+}
+
+// PingBMCTarget handles GET /api/v1/bmc-targets/:id/status. It runs a session-free
+// reachability ping against the target's ServiceRoot, persists the outcome into
+// the status cache, and returns it. No Redfish session is created, so this is safe
+// to call without burning a BMC session.
+func (h *DeployHandler) PingBMCTarget(c echo.Context) error {
+	id := c.Param("id")
+	ctx := c.Request().Context()
+
+	target, err := h.bmcTargets.GetByID(ctx, id)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "BMC target not found"})
+	}
+
+	resp := h.pingTarget(ctx, target)
+	// The per-target id is implicit in the URL for this endpoint; omit it from the
+	// single-target body to keep the shape minimal.
+	resp.ID = ""
+	return c.JSON(http.StatusOK, resp)
+}
+
+// RefreshAllBMCTargets handles POST /api/v1/bmc-targets/refresh-all. It pings every
+// saved BMC sequentially (concurrency = 1) with a small inter-target delay and a
+// per-target timeout, persisting each outcome into the status cache, and returns
+// the per-target results.
+//
+// Only one refresh may run at a time: a concurrent call returns 409. Sequential,
+// session-free pings avoid a thundering herd against a shared sushy service
+// fronting many systems and never consume BMC sessions.
+func (h *DeployHandler) RefreshAllBMCTargets(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	if !h.refreshAll.tryAcquire() {
+		return c.JSON(http.StatusConflict, map[string]string{"error": "a refresh is already in progress"})
+	}
+	defer h.refreshAll.release()
+
+	targets, err := h.bmcTargets.List(ctx)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to list BMC targets"})
+	}
+
+	results := make([]bmcStatusResponse, 0, len(targets))
+	for i, target := range targets {
+		if err := ctx.Err(); err != nil {
+			// The client went away (or the request was cancelled). Stop early rather
+			// than continue hammering BMCs for a response nobody will read.
+			break
+		}
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return c.JSON(http.StatusOK, results)
+			case <-time.After(refreshAllInterTargetDelay):
+			}
+		}
+
+		pingCtx, cancel := context.WithTimeout(ctx, refreshAllPerTargetTimeout)
+		results = append(results, h.pingTarget(pingCtx, target))
+		cancel()
+	}
+
+	return c.JSON(http.StatusOK, results)
+}
+
+// refreshGuard enforces a single in-flight refresh-all. tryAcquire reports whether
+// the caller won the slot; a loser must NOT release. The winner releases on return.
+type refreshGuard struct {
+	mu       sync.Mutex
+	inflight bool
+}
+
+func (g *refreshGuard) tryAcquire() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.inflight {
+		return false
+	}
+	g.inflight = true
+	return true
+}
+
+func (g *refreshGuard) release() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.inflight = false
+}

--- a/pkg/handlers/bmc_status_test.go
+++ b/pkg/handlers/bmc_status_test.go
@@ -1,0 +1,287 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// newServiceRootServer stands up a plain-HTTP server that answers the Redfish
+// ServiceRoot with a 200 + parseable body, so a session-free reachability ping
+// succeeds. It records whether any POST (a session-create) was ever attempted.
+func newServiceRootServer(posts *int32) *httptest.Server {
+	var mu sync.Mutex
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && posts != nil {
+			mu.Lock()
+			*posts++
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/","Id":"RootService"}`))
+	}))
+}
+
+// closedEndpoint returns a URL whose listener has been closed, so a connection to
+// it is refused — modelling an unreachable BMC.
+func closedEndpoint() string {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	Expect(err).NotTo(HaveOccurred())
+	url := "http://" + l.Addr().String()
+	Expect(l.Close()).To(Succeed())
+	return url
+}
+
+var _ = Describe("DeployHandler inspect persistence", func() {
+	var (
+		e          *echo.Echo
+		bmcTargets *fakeBMCTargetStore
+		bmc        *multiSystemBMC
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		bmcTargets = &fakeBMCTargetStore{}
+		// Single-system BMC so inspect succeeds without a SystemID.
+		bmc = newMultiSystemBMC("node-a")
+	})
+
+	AfterEach(func() { bmc.Close() })
+
+	inspect := func(targetID string) *httptest.ResponseRecorder {
+		h := handlers.NewDeployHandler(nil, nil, bmcTargets, nil, "", nil, nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/bmc-targets/"+targetID+"/inspect", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(targetID)
+		Expect(h.InspectHardware(c)).To(Succeed())
+		return rec
+	}
+
+	It("persists reachable facts into the status cache on a successful inspect", func() {
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID: "t-1", Name: "h", Endpoint: bmc.URL(), Username: "admin", Password: "p", VerifySSL: false,
+		})).To(Succeed())
+
+		rec := inspect("t-1")
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		got, err := bmcTargets.GetByID(context.Background(), "t-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.LastStatus).To(Equal("reachable"))
+		Expect(got.LastError).To(BeEmpty())
+		Expect(got.LastInspectAt).NotTo(BeNil())
+		Expect(got.LastModel).To(Equal("ProLiant-node-a"))
+		Expect(got.LastManufacturer).To(Equal("ACME"))
+		Expect(got.LastSerial).To(Equal("SN-node-a"))
+		Expect(got.LastMemoryGiB).To(Equal(64))
+		Expect(got.LastCPUCount).To(Equal(8))
+	})
+
+	It("persists an unreachable status + scrubbed error when the connect fails", func() {
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID: "t-bad", Name: "bad", Endpoint: closedEndpoint(), Username: "admin", Password: "p", VerifySSL: false,
+		})).To(Succeed())
+
+		rec := inspect("t-bad")
+		Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+
+		got, err := bmcTargets.GetByID(context.Background(), "t-bad")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.LastStatus).To(Equal("unreachable"))
+		Expect(got.LastError).NotTo(BeEmpty())
+		Expect(got.LastInspectAt).NotTo(BeNil())
+		// Credentials never leak into the cached error.
+		Expect(got.LastError).NotTo(ContainSubstring("admin"))
+	})
+})
+
+var _ = Describe("DeployHandler.PingBMCTarget", func() {
+	var (
+		e          *echo.Echo
+		bmcTargets *fakeBMCTargetStore
+		h          *handlers.DeployHandler
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		bmcTargets = &fakeBMCTargetStore{}
+		h = handlers.NewDeployHandler(nil, nil, bmcTargets, nil, "", nil, nil)
+	})
+
+	ping := func(id string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/bmc-targets/"+id+"/status", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(id)
+		Expect(h.PingBMCTarget(c)).To(Succeed())
+		return rec
+	}
+
+	It("reports reachable and persists LastPingAt for a live ServiceRoot", func() {
+		var posts int32
+		srv := newServiceRootServer(&posts)
+		defer srv.Close()
+
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID: "t-up", Name: "up", Endpoint: srv.URL, Username: "admin", Password: "p", VerifySSL: false,
+		})).To(Succeed())
+
+		rec := ping("t-up")
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		var resp struct {
+			Status     string     `json:"status"`
+			LastPingAt *time.Time `json:"lastPingAt"`
+			Error      string     `json:"error"`
+		}
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		Expect(resp.Status).To(Equal("reachable"))
+		Expect(resp.LastPingAt).NotTo(BeNil())
+		Expect(resp.Error).To(BeEmpty())
+
+		// Session-free: the ping must never have POSTed a session-create.
+		Expect(posts).To(Equal(int32(0)))
+
+		got, err := bmcTargets.GetByID(context.Background(), "t-up")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.LastStatus).To(Equal("reachable"))
+		Expect(got.LastPingAt).NotTo(BeNil())
+	})
+
+	It("reports unreachable for a refused endpoint", func() {
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID: "t-down", Name: "down", Endpoint: closedEndpoint(), Username: "admin", Password: "p", VerifySSL: false,
+		})).To(Succeed())
+
+		rec := ping("t-down")
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		var resp struct {
+			Status string `json:"status"`
+			Error  string `json:"error"`
+		}
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		Expect(resp.Status).To(Equal("unreachable"))
+		Expect(resp.Error).NotTo(BeEmpty())
+
+		got, err := bmcTargets.GetByID(context.Background(), "t-down")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.LastStatus).To(Equal("unreachable"))
+	})
+
+	It("returns 404 for an unknown target", func() {
+		rec := ping("nope")
+		Expect(rec.Code).To(Equal(http.StatusNotFound))
+	})
+})
+
+var _ = Describe("DeployHandler.RefreshAllBMCTargets", func() {
+	var (
+		e          *echo.Echo
+		bmcTargets *fakeBMCTargetStore
+		h          *handlers.DeployHandler
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		bmcTargets = &fakeBMCTargetStore{}
+		h = handlers.NewDeployHandler(nil, nil, bmcTargets, nil, "", nil, nil)
+	})
+
+	refresh := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/bmc-targets/refresh-all", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		Expect(h.RefreshAllBMCTargets(c)).To(Succeed())
+		return rec
+	}
+
+	It("pings every target and returns the per-target results", func() {
+		srv := newServiceRootServer(nil)
+		defer srv.Close()
+
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "a", Endpoint: srv.URL})).To(Succeed())
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "b", Endpoint: closedEndpoint()})).To(Succeed())
+
+		rec := refresh()
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		var results []struct {
+			ID         string     `json:"id"`
+			Status     string     `json:"status"`
+			LastPingAt *time.Time `json:"lastPingAt"`
+		}
+		Expect(json.Unmarshal(rec.Body.Bytes(), &results)).To(Succeed())
+		Expect(results).To(HaveLen(2))
+
+		byID := map[string]string{}
+		for _, r := range results {
+			byID[r.ID] = r.Status
+		}
+		Expect(byID["a"]).To(Equal("reachable"))
+		Expect(byID["b"]).To(Equal("unreachable"))
+
+		// Both outcomes were persisted into the cache.
+		got, err := bmcTargets.GetByID(context.Background(), "a")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.LastStatus).To(Equal("reachable"))
+		Expect(got.LastPingAt).NotTo(BeNil())
+	})
+
+	It("returns 409 when a refresh is already in progress", func() {
+		// A BMC whose ServiceRoot blocks until released holds the first refresh
+		// in-flight; a second concurrent call must get 409.
+		release := make(chan struct{})
+		entered := make(chan struct{}, 1)
+		var once sync.Once
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			once.Do(func() { entered <- struct{}{} })
+			<-release
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/"}`))
+		}))
+		defer srv.Close()
+
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "slow", Endpoint: srv.URL})).To(Succeed())
+
+		// Drive the first refresh in a goroutine; it blocks inside the ping.
+		firstDone := make(chan int, 1)
+		go func() {
+			defer GinkgoRecover()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/bmc-targets/refresh-all", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			Expect(h.RefreshAllBMCTargets(c)).To(Succeed())
+			firstDone <- rec.Code
+		}()
+
+		// Wait until the first refresh is actually inside the ping (mutex held).
+		Eventually(entered, 5*time.Second).Should(Receive())
+
+		// A concurrent refresh must be rejected with 409.
+		rec := refresh()
+		Expect(rec.Code).To(Equal(http.StatusConflict))
+		Expect(rec.Body.String()).To(ContainSubstring("already in progress"))
+
+		// Let the first refresh finish; it succeeds with 200.
+		close(release)
+		Eventually(firstDone, 5*time.Second).Should(Receive(Equal(http.StatusOK)))
+
+		// After it completes the guard is released: a fresh refresh works again.
+		rec2 := refresh()
+		Expect(rec2.Code).To(Equal(http.StatusOK))
+	})
+})

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -57,6 +57,11 @@ type DeployHandler struct {
 	// can abort it. Guarded by runsMu.
 	runsMu sync.Mutex
 	runs   map[string]context.CancelFunc
+
+	// refreshAll enforces a single in-flight "refresh all" BMC-status sweep: a
+	// concurrent RefreshAllBMCTargets call returns 409 rather than launching a
+	// second parallel sweep that would double the BMC-ping load.
+	refreshAll refreshGuard
 }
 
 // NewDeployHandler creates a new DeployHandler.
@@ -588,6 +593,7 @@ func (h *DeployHandler) InspectHardware(c echo.Context) error {
 		Timeout:   30 * time.Second,
 	})
 	if err := deployer.Connect(ctx); err != nil {
+		h.persistInspectFailure(ctx, target, err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to connect to redfish endpoint: %v", err)})
 	}
 	// Always tear the session down (DELETE) on both success and error.
@@ -596,8 +602,12 @@ func (h *DeployHandler) InspectHardware(c echo.Context) error {
 	inspector := hardware.NewInspector(deployer)
 	info, err := inspector.InspectSystem(ctx)
 	if err != nil {
+		h.persistInspectFailure(ctx, target, err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to inspect hardware: %v", err)})
 	}
+
+	features := sortedFeatures(info.Features)
+	h.persistInspectSuccess(ctx, target, info, features)
 
 	return c.JSON(http.StatusOK, inspectResponse{
 		MemoryGiB:         info.MemoryGiB,
@@ -605,8 +615,40 @@ func (h *DeployHandler) InspectHardware(c echo.Context) error {
 		Model:             info.Model,
 		Manufacturer:      info.Manufacturer,
 		SerialNumber:      info.SerialNumber,
-		SupportedFeatures: sortedFeatures(info.Features),
+		SupportedFeatures: features,
 	})
+}
+
+// persistInspectSuccess writes a successful inspect result into the BMC target's
+// server-owned status cache so the BMC page can render details without contacting
+// the BMC again. It sets LastStatus="reachable", the hardware facts, LastInspectAt,
+// and clears LastError. A store failure is best-effort and swallowed: the inspect
+// response itself is authoritative and must not fail because the cache write did.
+func (h *DeployHandler) persistInspectSuccess(ctx context.Context, target *store.BMCTarget, info *hardware.SystemInfo, features []string) {
+	now := time.Now()
+	target.LastStatus = bmcStatusReachable
+	target.LastError = ""
+	target.LastInspectAt = &now
+	target.LastModel = info.Model
+	target.LastManufacturer = info.Manufacturer
+	target.LastSerial = info.SerialNumber
+	target.LastMemoryGiB = info.MemoryGiB
+	target.LastCPUCount = info.ProcessorCount
+	target.LastFeatures = features
+	_ = h.bmcTargets.Update(ctx, target)
+}
+
+// persistInspectFailure records an unreachable/inspect-error outcome into the
+// status cache: LastStatus="unreachable", a scrubbed LastError, LastInspectAt=now.
+// The error text is scrubbed of credentials at its source (the redfish package),
+// but is re-scrubbed defensively here in case a future error path is not. A store
+// failure is best-effort and swallowed.
+func (h *DeployHandler) persistInspectFailure(ctx context.Context, target *store.BMCTarget, cause error) {
+	now := time.Now()
+	target.LastStatus = bmcStatusUnreachable
+	target.LastError = scrubBMCError(cause)
+	target.LastInspectAt = &now
+	_ = h.bmcTargets.Update(ctx, target)
 }
 
 // sortedFeatures returns the detected feature names as a stable, sorted slice for
@@ -639,6 +681,10 @@ func (h *DeployHandler) CreateBMCTarget(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid imageUrl: %v", err)})
 		}
 	}
+	// Status-cache fields are server-owned (populated only by inspect/ping/refresh).
+	// Drop anything a client may have smuggled in via the bound body so it cannot
+	// fabricate a "reachable" status without an actual check.
+	clearBMCStatusCache(&target)
 
 	if err := h.bmcTargets.Create(c.Request().Context(), &target); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create BMC target"})

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -187,6 +187,10 @@ type deployRedfishRequest struct {
 	Password  string `json:"password"`
 	Vendor    string `json:"vendor"`
 	VerifySSL *bool  `json:"verifySSL"`
+	// SystemID optionally pins the target ComputerSystem by its Redfish Id. When
+	// set it takes precedence over a saved target's SystemID; required when the BMC
+	// exposes more than one system. Mirrors the CLI's --system-id.
+	SystemID string `json:"systemId"`
 }
 
 // imageURLUsesHTTPS reports whether an operator-supplied media URL is fetched
@@ -221,6 +225,7 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 		password  string
 		vendor    string
 		verifySSL bool
+		systemID  string
 		bmcID     string
 	)
 
@@ -234,6 +239,7 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 		password = target.Password
 		vendor = target.Vendor
 		verifySSL = target.VerifySSL
+		systemID = target.SystemID
 		bmcID = target.ID
 	} else {
 		if req.Endpoint == "" || req.Username == "" || req.Password == "" {
@@ -251,6 +257,13 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 		} else {
 			verifySSL = true
 		}
+	}
+
+	// An explicit request SystemID overrides the saved target's (and is the only
+	// way to select a system for an inline-credentials deploy). When empty, fall
+	// back to whatever the saved target carries.
+	if req.SystemID != "" {
+		systemID = req.SystemID
 	}
 
 	// Locate the artifact's on-disk ISO. InsertMedia is URL-pull (no byte
@@ -335,7 +348,7 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 	runCtx, cancel := context.WithTimeout(h.baseCtx, redfishDeployTimeout)
 	h.registerRun(dep.ID, cancel)
 
-	go h.runRedfishDeploy(runCtx, cancel, dep.ID, imageURL, serveToken, endpoint, username, password, vendor, verifySSL, useHTTPS)
+	go h.runRedfishDeploy(runCtx, cancel, dep.ID, imageURL, serveToken, endpoint, username, password, vendor, systemID, verifySSL, useHTTPS)
 
 	return c.JSON(http.StatusAccepted, dep)
 }
@@ -346,7 +359,7 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 // deploy timeout; cancel is its cancel func, deregistered and called on return so
 // the run-registry never retains a finished deploy. useHTTPS sets the InsertMedia
 // TransferProtocolType so it matches the scheme the BMC actually fetches over.
-func (h *DeployHandler) runRedfishDeploy(ctx context.Context, cancel context.CancelFunc, deploymentID, imageURL, serveToken, endpoint, username, password, vendor string, verifySSL, useHTTPS bool) {
+func (h *DeployHandler) runRedfishDeploy(ctx context.Context, cancel context.CancelFunc, deploymentID, imageURL, serveToken, endpoint, username, password, vendor, systemID string, verifySSL, useHTTPS bool) {
 	logPrefix := fmt.Sprintf("deployment %s", deploymentID)
 
 	defer cancel()
@@ -365,6 +378,7 @@ func (h *DeployHandler) runRedfishDeploy(ctx context.Context, cancel context.Can
 		Password:  password,
 		Vendor:    redfish.VendorType(vendor),
 		VerifySSL: verifySSL,
+		SystemID:  systemID,
 		Timeout:   redfishDeployTimeout,
 	})
 
@@ -500,6 +514,7 @@ func (h *DeployHandler) InspectHardware(c echo.Context) error {
 		Password:  target.Password,
 		Vendor:    redfish.VendorType(target.Vendor),
 		VerifySSL: target.VerifySSL,
+		SystemID:  target.SystemID,
 		Timeout:   30 * time.Second,
 	})
 	if err := deployer.Connect(ctx); err != nil {
@@ -587,6 +602,7 @@ func (h *DeployHandler) UpdateBMCTarget(c echo.Context) error {
 		existing.Password = updated.Password
 	}
 	existing.VerifySSL = updated.VerifySSL
+	existing.SystemID = updated.SystemID
 	existing.NodeID = updated.NodeID
 
 	if err := h.bmcTargets.Update(ctx, existing); err != nil {

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -37,6 +37,12 @@ type DeployHandler struct {
 	// May be nil, in which case a Redfish deploy must supply an explicit imageUrl.
 	isoServe *isoserve.Server
 
+	// settings exposes the runtime image-source settings (global default image URL,
+	// local-serve enable flag, advertised URL). May be nil (e.g. in tests or when
+	// no settings store is wired), in which case the deploy falls back to the
+	// request/per-BMC imageUrl or the configured local-serve.
+	settings store.SettingsStore
+
 	// hub is the WebSocket hub used to broadcast live deploy-step progress to UI
 	// clients. May be nil (e.g. in tests or when no hub is wired), in which case
 	// progress is only persisted to the Deployment row and surfaced via polling.
@@ -83,6 +89,15 @@ func (h *DeployHandler) WithBaseContext(ctx context.Context) *DeployHandler {
 	if ctx != nil {
 		h.baseCtx = ctx
 	}
+	return h
+}
+
+// WithSettings wires the runtime settings store so DeployRedfish can resolve the
+// global default image URL and the local-serve enable flag. Passing nil leaves
+// the handler using only the request/per-BMC imageUrl and the launch-configured
+// local-serve. Returns the handler for chaining.
+func (h *DeployHandler) WithSettings(s store.SettingsStore) *DeployHandler {
+	h.settings = s
 	return h
 }
 
@@ -204,6 +219,48 @@ func imageURLUsesHTTPS(imageURL string) (bool, error) {
 	return strings.EqualFold(parsed.Scheme, "https"), nil
 }
 
+// resolveOperatorImageURL applies the operator-supplied image-URL precedence
+// (per-deploy > per-BMC > global default), all model (a). It returns "" when no
+// tier supplies a URL, signalling the caller to fall back to local serving
+// (model b). It does not validate; the caller SSRF-validates the chosen URL.
+func resolveOperatorImageURL(reqURL, bmcURL, defaultURL string) string {
+	switch {
+	case reqURL != "":
+		return reqURL
+	case bmcURL != "":
+		return bmcURL
+	default:
+		return defaultURL
+	}
+}
+
+// defaultImageURL returns the global default image URL setting, or "" when no
+// settings store is wired or the key is unset. A read error is surfaced so the
+// caller can fail closed rather than silently treating it as unset.
+func (h *DeployHandler) defaultImageURL(ctx context.Context) (string, error) {
+	if h.settings == nil {
+		return "", nil
+	}
+	v, _, err := h.settings.Get(ctx, SettingDefaultImageURL)
+	return v, err
+}
+
+// localServeEnabled reports whether the runtime local-serve enable flag is set.
+// It is the gate (alongside a launch-configured listener) for serving the
+// artifact ISO locally. Defaults to false: missing setting, no settings store, or
+// a read error all yield false so deploys never silently serve without an
+// explicit opt-in.
+func (h *DeployHandler) localServeEnabled(ctx context.Context) bool {
+	if h.settings == nil {
+		return false
+	}
+	v, _, err := h.settings.Get(ctx, SettingLocalServeEnabled)
+	if err != nil {
+		return false
+	}
+	return v == "true"
+}
+
 // DeployRedfish handles POST /api/v1/artifacts/:id/deploy/redfish.
 func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 	artifactID := c.Param("id")
@@ -220,13 +277,14 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 	}
 
 	var (
-		endpoint  string
-		username  string
-		password  string
-		vendor    string
-		verifySSL bool
-		systemID  string
-		bmcID     string
+		endpoint    string
+		username    string
+		password    string
+		vendor      string
+		verifySSL   bool
+		systemID    string
+		bmcImageURL string
+		bmcID       string
 	)
 
 	if req.BMCTargetID != "" {
@@ -240,6 +298,7 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 		vendor = target.Vendor
 		verifySSL = target.VerifySSL
 		systemID = target.SystemID
+		bmcImageURL = target.ImageURL
 		bmcID = target.ID
 	} else {
 		if req.Endpoint == "" || req.Username == "" || req.Password == "" {
@@ -281,13 +340,22 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 
 	// Resolve the image URL the BMC will fetch, and whether the BMC must fetch it
 	// over HTTPS. InsertMedia advertises a TransferProtocolType that must match the
-	// served URL's scheme, so derive useHTTPS alongside the URL:
-	//   1. an explicit imageUrl: SSRF-validate and use it; HTTPS iff its scheme is
-	//      "https".
-	//   2. otherwise serve the artifact's local ISO over a tokenized,
-	//      BMC-reachable URL via the ISO-serve helper; HTTPS iff the serve helper
-	//      is actually serving TLS.
-	imageURL := req.ImageURL
+	// served URL's scheme, so derive useHTTPS alongside the URL. Image-source
+	// precedence (highest to lowest), each operator-supplied URL SSRF-validated as
+	// defense in depth even when validated on write:
+	//   1. req.ImageURL  — per-deploy override (model a).
+	//   2. BMC ImageURL  — per-BMC override (model a).
+	//   3. global defaultImageURL setting (model a).
+	//   4. local serve: AuroraBoot serves the artifact's on-disk ISO over a
+	//      tokenized, BMC-reachable URL (model b), only when a listener was
+	//      configured at launch AND the runtime enable flag is set.
+	//   5. otherwise 503.
+	defaultURL, err := h.defaultImageURL(ctx)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to read image-source settings"})
+	}
+	imageURL := resolveOperatorImageURL(req.ImageURL, bmcImageURL, defaultURL)
+
 	serveToken := ""
 	useHTTPS := false
 	if imageURL != "" {
@@ -299,9 +367,11 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid imageUrl: %v", err)})
 		}
 	} else {
-		if h.isoServe == nil {
+		// No operator-supplied URL at any tier: fall back to local serving, which
+		// requires both a launch-configured listener and the runtime enable flag.
+		if h.isoServe == nil || !h.localServeEnabled(ctx) {
 			return c.JSON(http.StatusServiceUnavailable, map[string]string{
-				"error": "local ISO serving is not configured on this server; provide imageUrl with a URL the BMC can reach",
+				"error": "local ISO serving is not enabled on this server; provide imageUrl with a URL the BMC can reach, set a default image URL, or enable AuroraBoot-served artifacts",
 			})
 		}
 		// ArtifactFiles stores each file's path relative to the server's working
@@ -563,6 +633,12 @@ func (h *DeployHandler) CreateBMCTarget(c echo.Context) error {
 	if target.Endpoint == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "endpoint is required"})
 	}
+	// SSRF-validate a per-BMC image-URL override on write (and again at deploy).
+	if target.ImageURL != "" {
+		if err := isoserve.ValidateMediaURL(target.ImageURL); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid imageUrl: %v", err)})
+		}
+	}
 
 	if err := h.bmcTargets.Create(c.Request().Context(), &target); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create BMC target"})
@@ -593,6 +669,12 @@ func (h *DeployHandler) UpdateBMCTarget(c echo.Context) error {
 	if err := c.Bind(&updated); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 	}
+	// SSRF-validate a per-BMC image-URL override on write (and again at deploy).
+	if updated.ImageURL != "" {
+		if err := isoserve.ValidateMediaURL(updated.ImageURL); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid imageUrl: %v", err)})
+		}
+	}
 
 	existing.Name = updated.Name
 	existing.Endpoint = updated.Endpoint
@@ -603,6 +685,7 @@ func (h *DeployHandler) UpdateBMCTarget(c echo.Context) error {
 	}
 	existing.VerifySSL = updated.VerifySSL
 	existing.SystemID = updated.SystemID
+	existing.ImageURL = updated.ImageURL
 	existing.NodeID = updated.NodeID
 
 	if err := h.bmcTargets.Update(ctx, existing); err != nil {

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -804,6 +804,7 @@ func (h *DeployHandler) UpdateBMCTarget(c echo.Context) error {
 	existing.ImageURL = updated.ImageURL
 	existing.NodeID = updated.NodeID
 	existing.EjectAfterInstall = updated.EjectAfterInstall
+	existing.EjectPowerCycle = updated.EjectPowerCycle
 
 	if err := h.bmcTargets.Update(ctx, existing); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update BMC target"})

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -731,6 +731,13 @@ func (h *DeployHandler) CreateBMCTarget(c echo.Context) error {
 	if target.Endpoint == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "endpoint is required"})
 	}
+	// SSRF-validate the BMC endpoint on write. The session-free reachability ping
+	// and refresh-all actively GET this endpoint, so an unvalidated value is a
+	// confused-deputy/internal-fetch primitive. Mirror the CLI, which guards the
+	// endpoint with the same validator (internal/cmd/redfish.go).
+	if err := isoserve.ValidateMediaURL(target.Endpoint); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid endpoint: %v", err)})
+	}
 	// SSRF-validate a per-BMC image-URL override on write (and again at deploy).
 	if target.ImageURL != "" {
 		if err := isoserve.ValidateMediaURL(target.ImageURL); err != nil {
@@ -770,6 +777,13 @@ func (h *DeployHandler) UpdateBMCTarget(c echo.Context) error {
 	var updated store.BMCTarget
 	if err := c.Bind(&updated); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+	}
+	// SSRF-validate the BMC endpoint on write (same posture as Create and the CLI).
+	// The ping/refresh-all paths actively fetch this endpoint, so it must be guarded.
+	if updated.Endpoint != "" {
+		if err := isoserve.ValidateMediaURL(updated.Endpoint); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid endpoint: %v", err)})
+		}
 	}
 	// SSRF-validate a per-BMC image-URL override on write (and again at deploy).
 	if updated.ImageURL != "" {

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -62,6 +62,11 @@ type DeployHandler struct {
 	// concurrent RefreshAllBMCTargets call returns 409 rather than launching a
 	// second parallel sweep that would double the BMC-ping load.
 	refreshAll refreshGuard
+
+	// finalizerFn builds the redfishFinalizer used by the eject/finalize path. nil
+	// uses the real gofish-backed Deployer; tests inject a fake via
+	// WithFinalizerFactory.
+	finalizerFn finalizerFactory
 }
 
 // NewDeployHandler creates a new DeployHandler.
@@ -142,6 +147,17 @@ func ReconcileOrphanedDeployments(ctx context.Context, deployments store.Deploym
 		return fmt.Errorf("listing deployments: %w", err)
 	}
 	for _, dep := range deps {
+		// A finalize goroutine that died mid-eject leaves EjectState=="ejecting"
+		// with no routine to advance it. Reset it to pending so the next phone-home
+		// or a manual finalize retries. NEVER auto-eject at startup, and never touch
+		// a terminal ejected/eject-failed row.
+		if dep.EjectState == store.EjectStateEjecting {
+			dep.EjectState = store.EjectStatePending
+			if err := deployments.Update(ctx, dep); err != nil {
+				return fmt.Errorf("resetting orphaned eject %s: %w", dep.ID, err)
+			}
+		}
+
 		if dep.Status != store.DeployActive {
 			continue
 		}
@@ -211,6 +227,11 @@ type deployRedfishRequest struct {
 	// set it takes precedence over a saved target's SystemID; required when the BMC
 	// exposes more than one system. Mirrors the CLI's --system-id.
 	SystemID string `json:"systemId"`
+	// EjectAfterInstall overrides the target's durable eject policy for this one
+	// deploy. nil leaves the target's BMCTarget.EjectAfterInstall in effect; a
+	// non-nil value forces it on/off. When effectively on, the deployment is marked
+	// pending-eject at completion and auto-ejected on the node's phone-home.
+	EjectAfterInstall *bool `json:"ejectAfterInstall"`
 }
 
 // imageURLUsesHTTPS reports whether an operator-supplied media URL is fetched
@@ -282,14 +303,15 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 	}
 
 	var (
-		endpoint    string
-		username    string
-		password    string
-		vendor      string
-		verifySSL   bool
-		systemID    string
-		bmcImageURL string
-		bmcID       string
+		endpoint        string
+		username        string
+		password        string
+		vendor          string
+		verifySSL       bool
+		systemID        string
+		bmcImageURL     string
+		bmcID           string
+		bmcEjectDefault bool
 	)
 
 	if req.BMCTargetID != "" {
@@ -305,6 +327,7 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 		systemID = target.SystemID
 		bmcImageURL = target.ImageURL
 		bmcID = target.ID
+		bmcEjectDefault = target.EjectAfterInstall
 	} else {
 		if req.Endpoint == "" || req.Username == "" || req.Password == "" {
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": "endpoint, username, and password are required when bmcTargetId is not provided"})
@@ -328,6 +351,15 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 	// back to whatever the saved target carries.
 	if req.SystemID != "" {
 		systemID = req.SystemID
+	}
+
+	// Resolve the effective eject policy: a per-deploy override wins, else the
+	// target's durable default, else off. Eject only makes sense for a saved BMC
+	// target (the auto path correlates node -> BMC -> deployment); an inline-creds
+	// deploy has no durable BMC to link, so it can only opt in per-deploy.
+	ejectAfter := bmcEjectDefault
+	if req.EjectAfterInstall != nil {
+		ejectAfter = *req.EjectAfterInstall
 	}
 
 	// Locate the artifact's on-disk ISO. InsertMedia is URL-pull (no byte
@@ -423,7 +455,7 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 	runCtx, cancel := context.WithTimeout(h.baseCtx, redfishDeployTimeout)
 	h.registerRun(dep.ID, cancel)
 
-	go h.runRedfishDeploy(runCtx, cancel, dep.ID, imageURL, serveToken, endpoint, username, password, vendor, systemID, verifySSL, useHTTPS)
+	go h.runRedfishDeploy(runCtx, cancel, dep.ID, imageURL, serveToken, endpoint, username, password, vendor, systemID, verifySSL, useHTTPS, ejectAfter)
 
 	return c.JSON(http.StatusAccepted, dep)
 }
@@ -434,7 +466,7 @@ func (h *DeployHandler) DeployRedfish(c echo.Context) error {
 // deploy timeout; cancel is its cancel func, deregistered and called on return so
 // the run-registry never retains a finished deploy. useHTTPS sets the InsertMedia
 // TransferProtocolType so it matches the scheme the BMC actually fetches over.
-func (h *DeployHandler) runRedfishDeploy(ctx context.Context, cancel context.CancelFunc, deploymentID, imageURL, serveToken, endpoint, username, password, vendor, systemID string, verifySSL, useHTTPS bool) {
+func (h *DeployHandler) runRedfishDeploy(ctx context.Context, cancel context.CancelFunc, deploymentID, imageURL, serveToken, endpoint, username, password, vendor, systemID string, verifySSL, useHTTPS, ejectAfter bool) {
 	logPrefix := fmt.Sprintf("deployment %s", deploymentID)
 
 	defer cancel()
@@ -483,6 +515,30 @@ func (h *DeployHandler) runRedfishDeploy(ctx context.Context, cancel context.Can
 		msg = fmt.Sprintf("Deployment completed (task state: %s)", result.TaskState)
 	}
 	h.completeDeployment(deploymentID, msg)
+
+	// Arm the eject lifecycle when the policy is on: mark the deployment
+	// pending-eject so the freshly-installed node's phone-home (or a manual
+	// finalize) ejects the media. We do NOT eject inline — that would be
+	// mid-reboot, the wrong moment (the install loop this whole mechanism fixes).
+	if ejectAfter {
+		h.markEjectPending(deploymentID)
+	}
+}
+
+// markEjectPending arms the eject lifecycle on a completed deployment: it sets the
+// policy to on-phone-home and EjectState to pending so the auto path (node
+// phone-home) or a manual finalize picks it up. Best-effort: a store failure leaves
+// the deployment un-armed (no eject), which is safe — the operator can finalize
+// manually.
+func (h *DeployHandler) markEjectPending(id string) {
+	ctx := context.Background()
+	dep, err := h.deployments.GetByID(ctx, id)
+	if err != nil {
+		return
+	}
+	dep.EjectPolicy = store.EjectPolicyOnPhoneHome
+	dep.EjectState = store.EjectStatePending
+	_ = h.deployments.Update(ctx, dep)
 }
 
 // broadcastProgress fans a live deploy-progress event to all connected UI
@@ -733,6 +789,7 @@ func (h *DeployHandler) UpdateBMCTarget(c echo.Context) error {
 	existing.SystemID = updated.SystemID
 	existing.ImageURL = updated.ImageURL
 	existing.NodeID = updated.NodeID
+	existing.EjectAfterInstall = updated.EjectAfterInstall
 
 	if err := h.bmcTargets.Update(ctx, existing); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update BMC target"})

--- a/pkg/handlers/deploy_precedence_test.go
+++ b/pkg/handlers/deploy_precedence_test.go
@@ -1,0 +1,138 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/kairos-io/AuroraBoot/pkg/isoserve"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/labstack/echo/v4"
+)
+
+var _ = Describe("DeployRedfish image-source precedence", func() {
+	// The pure precedence matrix: per-deploy > per-BMC > global default. The empty
+	// result signals "fall back to local serving".
+	DescribeTable("resolveOperatorImageURL selects the highest-priority tier",
+		func(reqURL, bmcURL, defaultURL, want string) {
+			Expect(handlers.ResolveOperatorImageURL(reqURL, bmcURL, defaultURL)).To(Equal(want))
+		},
+		Entry("per-deploy wins over everything",
+			"https://req/os.iso", "https://bmc/os.iso", "https://default/os.iso", "https://req/os.iso"),
+		Entry("per-BMC wins over global default when no per-deploy URL",
+			"", "https://bmc/os.iso", "https://default/os.iso", "https://bmc/os.iso"),
+		Entry("global default used when neither per-deploy nor per-BMC set",
+			"", "", "https://default/os.iso", "https://default/os.iso"),
+		Entry("empty when no tier supplies a URL (fall back to local serve)",
+			"", "", "", ""),
+	)
+
+	// Integration-level: drive DeployRedfish and assert which path was taken by the
+	// resulting status code (202 = an operator URL resolved and a deploy queued;
+	// 503 = nothing resolved and local serve unavailable).
+	var (
+		e            *echo.Echo
+		artifacts    *fakeArtifactStore
+		deployments  *fakeDeploymentStore
+		bmcTargets   *fakeBMCTargetStore
+		settings     *fakeSettingsStore
+		artifactsDir string
+	)
+
+	newHandler := func(withServe bool) *handlers.DeployHandler {
+		var serve *isoserve.Server
+		if withServe {
+			serve = isoserve.New(isoserve.Config{BaseURL: "http://10.0.0.5:8090"})
+		}
+		return handlers.NewDeployHandler(artifacts, deployments, bmcTargets, nil, artifactsDir, serve, nil).
+			WithSettings(settings)
+	}
+
+	doDeploy := func(h *handlers.DeployHandler, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts/art-1/deploy/redfish", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues("art-1")
+		Expect(h.DeployRedfish(c)).To(Succeed())
+		return rec
+	}
+
+	BeforeEach(func() {
+		e = echo.New()
+		artifactsDir = GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(artifactsDir, "art-1"), 0755)).To(Succeed())
+		isoPath := filepath.Join(artifactsDir, "art-1", "kairos.iso")
+		Expect(os.WriteFile(isoPath, []byte("ISO-BYTES"), 0644)).To(Succeed())
+
+		artifacts = &fakeArtifactStore{}
+		Expect(artifacts.Create(context.Background(), &store.ArtifactRecord{
+			ID:            "art-1",
+			ArtifactFiles: []string{isoPath},
+		})).To(Succeed())
+		deployments = &fakeDeploymentStore{}
+		bmcTargets = &fakeBMCTargetStore{}
+		settings = newFakeSettingsStore()
+	})
+
+	It("uses the per-BMC ImageURL when no per-deploy URL is given", func() {
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID: "bmc-1", Endpoint: "https://10.0.0.9", Username: "u", Password: "p",
+			ImageURL: "http://10.0.0.5/per-bmc.iso",
+		})).To(Succeed())
+		// A global default is also set; the per-BMC URL must win over it.
+		settings.values[handlers.SettingDefaultImageURL] = "http://10.0.0.5/global.iso"
+
+		rec := doDeploy(newHandler(false), `{"bmcTargetId":"bmc-1"}`)
+		// 202: an operator URL resolved (per-BMC), so a deploy was queued even with
+		// no local-serve configured.
+		Expect(rec.Code).To(Equal(http.StatusAccepted))
+	})
+
+	It("falls back to the global default when neither per-deploy nor per-BMC URL is set", func() {
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID: "bmc-1", Endpoint: "https://10.0.0.9", Username: "u", Password: "p",
+		})).To(Succeed())
+		settings.values[handlers.SettingDefaultImageURL] = "http://10.0.0.5/global.iso"
+
+		rec := doDeploy(newHandler(false), `{"bmcTargetId":"bmc-1"}`)
+		Expect(rec.Code).To(Equal(http.StatusAccepted))
+	})
+
+	It("rejects an SSRF-blocked global default at deploy time", func() {
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID: "bmc-1", Endpoint: "https://10.0.0.9", Username: "u", Password: "p",
+		})).To(Succeed())
+		settings.values[handlers.SettingDefaultImageURL] = "http://169.254.169.254/x.iso"
+
+		rec := doDeploy(newHandler(false), `{"bmcTargetId":"bmc-1"}`)
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		Expect(rec.Body.String()).To(ContainSubstring("invalid imageUrl"))
+	})
+
+	It("returns 503 when nothing resolves and local serve is configured but not enabled", func() {
+		rec := doDeploy(newHandler(true), `{"endpoint":"http://10.0.0.9","username":"u","password":"p"}`)
+		Expect(rec.Code).To(Equal(http.StatusServiceUnavailable))
+		Expect(rec.Body.String()).To(ContainSubstring("local ISO serving is not enabled"))
+	})
+
+	It("serves the local artifact ISO when nothing resolves and local serve is enabled", func() {
+		settings.values[handlers.SettingLocalServeEnabled] = "true"
+		rec := doDeploy(newHandler(true), `{"endpoint":"http://10.0.0.9","username":"u","password":"p"}`)
+		Expect(rec.Code).To(Equal(http.StatusAccepted))
+	})
+
+	It("returns 503 when nothing resolves and no local-serve listener exists", func() {
+		settings.values[handlers.SettingLocalServeEnabled] = "true"
+		rec := doDeploy(newHandler(false), `{"endpoint":"http://10.0.0.9","username":"u","password":"p"}`)
+		Expect(rec.Code).To(Equal(http.StatusServiceUnavailable))
+	})
+})

--- a/pkg/handlers/deploy_registry_test.go
+++ b/pkg/handlers/deploy_registry_test.go
@@ -48,6 +48,16 @@ func (m *memDeploymentStore) ListByArtifact(_ context.Context, _ string) ([]*sto
 	return nil, nil
 }
 func (m *memDeploymentStore) Delete(_ context.Context, _ string) error { return nil }
+func (m *memDeploymentStore) CASEjectState(_ context.Context, id, from, to string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.deps[id]
+	if !ok || d.EjectState != from {
+		return false, nil
+	}
+	d.EjectState = to
+	return true, nil
+}
 
 // TestRunRegistryCancel verifies the run-registry stores a cancel func that, when
 // invoked via CancelRun, actually cancels the associated context and that the run

--- a/pkg/handlers/deploy_systemid_test.go
+++ b/pkg/handlers/deploy_systemid_test.go
@@ -1,0 +1,226 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// multiSystemBMC is a compact, spec-accurate Redfish service that exposes more
+// than one ComputerSystem. It serves only what the inspect path exercises:
+// a session-less ServiceRoot (so Connect's auto auth-mode falls back to Basic),
+// the Systems collection with N members, and each ComputerSystem document. This
+// lets a handler-level test prove the multi-system fail-safe: without a SystemID
+// the Deployer refuses to guess (500); with the target's SystemID it targets the
+// chosen system (no 500).
+type multiSystemBMC struct {
+	server    *httptest.Server
+	systemIDs []string
+}
+
+func newMultiSystemBMC(systemIDs ...string) *multiSystemBMC {
+	b := &multiSystemBMC{systemIDs: systemIDs}
+	b.server = httptest.NewTLSServer(http.HandlerFunc(b.handle))
+	return b
+}
+
+func (b *multiSystemBMC) Close()      { b.server.Close() }
+func (b *multiSystemBMC) URL() string { return b.server.URL }
+
+func (b *multiSystemBMC) knownSystem(id string) bool {
+	for _, s := range b.systemIDs {
+		if s == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *multiSystemBMC) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := func(v any) { _ = json.NewEncoder(w).Encode(v) }
+
+	if r.URL.Path == "/redfish/v1/" || r.URL.Path == "/redfish/v1" {
+		// Session-less ServiceRoot: no SessionService/Links.Sessions, so the
+		// Deployer's auto auth-mode pre-check falls back to HTTP Basic.
+		enc(map[string]any{
+			"@odata.id":      "/redfish/v1/",
+			"@odata.type":    "#ServiceRoot.v1_5_0.ServiceRoot",
+			"Id":             "RootService",
+			"Name":           "Root Service",
+			"RedfishVersion": "1.6.0",
+			"Systems":        map[string]any{"@odata.id": "/redfish/v1/Systems"},
+		})
+		return
+	}
+
+	if r.URL.Path == "/redfish/v1/Systems" {
+		members := make([]map[string]any, 0, len(b.systemIDs))
+		for _, id := range b.systemIDs {
+			members = append(members, map[string]any{"@odata.id": "/redfish/v1/Systems/" + id})
+		}
+		enc(map[string]any{
+			"@odata.id":           "/redfish/v1/Systems",
+			"@odata.type":         "#ComputerSystemCollection.ComputerSystemCollection",
+			"Name":                "Systems Collection",
+			"Members@odata.count": len(members),
+			"Members":             members,
+		})
+		return
+	}
+
+	if id, ok := pathTail(r.URL.Path); ok && b.knownSystem(id) && r.Method == http.MethodGet {
+		enc(map[string]any{
+			"@odata.id":    "/redfish/v1/Systems/" + id,
+			"@odata.type":  "#ComputerSystem.v1_5_0.ComputerSystem",
+			"Id":           id,
+			"Name":         "System " + id,
+			"Manufacturer": "ACME",
+			"Model":        "ProLiant-" + id,
+			"SerialNumber": "SN-" + id,
+			"PowerState":   "On",
+			"MemorySummary": map[string]any{
+				"TotalSystemMemoryGiB": 64,
+			},
+			"ProcessorSummary": map[string]any{
+				"Count": 8,
+			},
+			"Boot": map[string]any{
+				"BootSourceOverrideEnabled": "Disabled",
+				"BootSourceOverrideTarget":  "None",
+			},
+		})
+		return
+	}
+
+	http.Error(w, "not found: "+r.URL.Path, http.StatusNotFound)
+}
+
+// pathTail returns the final path segment under /redfish/v1/Systems/, reporting
+// false when the path is not a single-segment system member.
+func pathTail(path string) (string, bool) {
+	const prefix = "/redfish/v1/Systems/"
+	if len(path) <= len(prefix) || path[:len(prefix)] != prefix {
+		return "", false
+	}
+	rest := path[len(prefix):]
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == '/' {
+			return "", false
+		}
+	}
+	return rest, true
+}
+
+var _ = Describe("DeployHandler.InspectHardware system selection", func() {
+	var (
+		e          *echo.Echo
+		bmcTargets *fakeBMCTargetStore
+		bmc        *multiSystemBMC
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		bmcTargets = &fakeBMCTargetStore{}
+		// A BMC fronting two ComputerSystems: selecting one requires a SystemID.
+		bmc = newMultiSystemBMC("node-a", "node-b")
+	})
+
+	AfterEach(func() {
+		bmc.Close()
+	})
+
+	// inspect runs InspectHardware for the stored target id and returns the
+	// recorder. VerifySSL is false because the fake uses a self-signed TLS cert.
+	inspect := func(targetID string) *httptest.ResponseRecorder {
+		h := handlers.NewDeployHandler(nil, nil, bmcTargets, nil, "", nil, nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/bmc-targets/"+targetID+"/inspect", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(targetID)
+		Expect(h.InspectHardware(c)).To(Succeed())
+		return rec
+	}
+
+	It("fails safe with 500 when the BMC exposes multiple systems and no SystemID is set", func() {
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID:        "t-multi",
+			Name:      "multi",
+			Endpoint:  bmc.URL(),
+			Username:  "admin",
+			Password:  "p",
+			VerifySSL: false,
+		})).To(Succeed())
+
+		rec := inspect("t-multi")
+		Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+		// The Deployer refuses to guess and lists the available system Ids.
+		Expect(rec.Body.String()).To(ContainSubstring("a system selection is required"))
+		Expect(rec.Body.String()).To(ContainSubstring("node-a"))
+		Expect(rec.Body.String()).To(ContainSubstring("node-b"))
+	})
+
+	It("targets the right system (no 500) when the target carries a SystemID", func() {
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID:        "t-pinned",
+			Name:      "pinned",
+			Endpoint:  bmc.URL(),
+			Username:  "admin",
+			Password:  "p",
+			VerifySSL: false,
+			SystemID:  "node-b",
+		})).To(Succeed())
+
+		rec := inspect("t-pinned")
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		var resp struct {
+			MemoryGiB      int    `json:"memoryGiB"`
+			ProcessorCount int    `json:"processorCount"`
+			Model          string `json:"model"`
+		}
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		// The chosen system was read (Model carries its Id), not an arbitrary one.
+		Expect(resp.Model).To(Equal("ProLiant-node-b"))
+		Expect(resp.MemoryGiB).To(Equal(64))
+		Expect(resp.ProcessorCount).To(Equal(8))
+	})
+})
+
+var _ = Describe("DeployHandler.UpdateBMCTarget SystemID", func() {
+	It("persists an edited SystemID through the fixed-field copy", func() {
+		e := echo.New()
+		bmcTargets := &fakeBMCTargetStore{}
+		Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+			ID:       "t-1",
+			Name:     "bmc",
+			Endpoint: "https://10.0.0.9",
+			Username: "admin",
+			Password: "p",
+		})).To(Succeed())
+
+		h := handlers.NewDeployHandler(nil, nil, bmcTargets, nil, "", nil, nil)
+		body := `{"name":"bmc","endpoint":"https://10.0.0.9","username":"admin","systemId":"node-b"}`
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/bmc-targets/t-1", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues("t-1")
+		Expect(h.UpdateBMCTarget(c)).To(Succeed())
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		got, err := bmcTargets.GetByID(context.Background(), "t-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.SystemID).To(Equal("node-b"))
+	})
+})

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -119,7 +119,15 @@ func (f *fakeBMCTargetStore) List(_ context.Context) ([]*store.BMCTarget, error)
 }
 
 func (f *fakeBMCTargetStore) Update(_ context.Context, t *store.BMCTarget) error {
-	return nil
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i, existing := range f.targets {
+		if existing.ID == t.ID {
+			f.targets[i] = t
+			return nil
+		}
+	}
+	return fmt.Errorf("not found")
 }
 
 func (f *fakeBMCTargetStore) Delete(_ context.Context, id string) error {

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -43,7 +43,8 @@ func (f *fakeDeploymentStore) GetByID(_ context.Context, id string) (*store.Depl
 	defer f.mu.Unlock()
 	for _, d := range f.deps {
 		if d.ID == id {
-			return d, nil
+			cp := *d // return a copy (gorm materializes a fresh struct)
+			return &cp, nil
 		}
 	}
 	return nil, fmt.Errorf("not found")
@@ -52,7 +53,17 @@ func (f *fakeDeploymentStore) GetByID(_ context.Context, id string) (*store.Depl
 func (f *fakeDeploymentStore) List(_ context.Context) ([]*store.Deployment, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.deps, nil
+	// Return copies, not the stored pointers: real gorm List materializes a fresh
+	// struct per query, so concurrent callers (e.g. the eject-on-phone-home goroutines
+	// in MaybeFinalizeForNode) must each get their own object to read/mutate. The
+	// stored row is only mutated under-lock via CASEjectState/Update, which remain the
+	// serialization point. Returning shared pointers here races under -race.
+	out := make([]*store.Deployment, len(f.deps))
+	for i, d := range f.deps {
+		cp := *d
+		out[i] = &cp
+	}
+	return out, nil
 }
 
 func (f *fakeDeploymentStore) ListByArtifact(_ context.Context, artifactID string) ([]*store.Deployment, error) {
@@ -72,7 +83,11 @@ func (f *fakeDeploymentStore) Update(_ context.Context, dep *store.Deployment) e
 	defer f.mu.Unlock()
 	for i, d := range f.deps {
 		if d.ID == dep.ID {
-			f.deps[i] = dep
+			// Store a copy, not the caller's pointer: gorm persists values, so the
+			// caller may keep mutating its struct (e.g. finalizeDeployment after
+			// Update) without that aliasing the stored row a concurrent List reads.
+			cp := *dep
+			f.deps[i] = &cp
 			return nil
 		}
 	}

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -140,18 +140,23 @@ var _ = Describe("DeployHandler.DeployRedfish", func() {
 		artifacts    *fakeArtifactStore
 		deployments  *fakeDeploymentStore
 		bmcTargets   *fakeBMCTargetStore
+		settings     *fakeSettingsStore
 		serve        *isoserve.Server
 		artifactsDir string
 	)
 
-	// newHandler builds a handler, optionally wiring an iso-serve.
+	// newHandler builds a handler, optionally wiring an iso-serve. When a serve is
+	// wired the runtime local-serve enable flag is also set, since local serving is
+	// now gated on both a launch-configured listener AND the enable flag.
 	newHandler := func(withServe bool) *handlers.DeployHandler {
 		if withServe {
 			serve = isoserve.New(isoserve.Config{BaseURL: "http://10.0.0.5:8090"})
+			settings.values[handlers.SettingLocalServeEnabled] = "true"
 		} else {
 			serve = nil
 		}
-		return handlers.NewDeployHandler(artifacts, deployments, bmcTargets, nil, artifactsDir, serve, nil)
+		return handlers.NewDeployHandler(artifacts, deployments, bmcTargets, nil, artifactsDir, serve, nil).
+			WithSettings(settings)
 	}
 
 	// doDeploy posts a deploy request for artifact "art-1" with the given body.
@@ -184,6 +189,7 @@ var _ = Describe("DeployHandler.DeployRedfish", func() {
 		})).To(Succeed())
 		deployments = &fakeDeploymentStore{}
 		bmcTargets = &fakeBMCTargetStore{}
+		settings = newFakeSettingsStore()
 	})
 
 	It("rejects an SSRF-blocked imageUrl", func() {
@@ -206,7 +212,7 @@ var _ = Describe("DeployHandler.DeployRedfish", func() {
 		h := newHandler(false)
 		rec := doDeploy(h, `{"endpoint":"http://10.0.0.9","username":"u","password":"p"}`)
 		Expect(rec.Code).To(Equal(http.StatusServiceUnavailable))
-		Expect(rec.Body.String()).To(ContainSubstring("local ISO serving is not configured"))
+		Expect(rec.Body.String()).To(ContainSubstring("local ISO serving is not enabled"))
 	})
 
 	It("registers the on-disk ISO with the serve helper when no imageUrl is given", func() {

--- a/pkg/handlers/deploy_test.go
+++ b/pkg/handlers/deploy_test.go
@@ -25,6 +25,7 @@ type fakeDeploymentStore struct {
 	mu        sync.Mutex
 	deps      []*store.Deployment
 	createErr error
+	casErr    error // when set, CASEjectState returns this error (fail-closed paths)
 }
 
 func (f *fakeDeploymentStore) Create(_ context.Context, dep *store.Deployment) error {
@@ -88,6 +89,24 @@ func (f *fakeDeploymentStore) Delete(_ context.Context, id string) error {
 		}
 	}
 	return fmt.Errorf("not found")
+}
+
+// CASEjectState mirrors the gorm compare-and-set: it transitions eject_state under
+// the store mutex so two concurrent finalize attempts race exactly as production
+// does (exactly one observes the still-`from` row and wins).
+func (f *fakeDeploymentStore) CASEjectState(_ context.Context, id, from, to string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.casErr != nil {
+		return false, f.casErr
+	}
+	for _, d := range f.deps {
+		if d.ID == id && d.EjectState == from {
+			d.EjectState = to
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // fakeBMCTargetStore implements store.BMCTargetStore for testing.

--- a/pkg/handlers/export_test.go
+++ b/pkg/handlers/export_test.go
@@ -4,3 +4,8 @@ package handlers
 // (handlers_test) tests so the InsertMedia transfer-protocol derivation can be
 // exercised directly.
 var ImageURLUsesHTTPS = imageURLUsesHTTPS
+
+// ResolveOperatorImageURL exposes the unexported image-URL precedence helper so
+// the per-deploy > per-BMC > global-default selection can be unit-tested
+// directly, without driving the async deploy goroutine.
+var ResolveOperatorImageURL = resolveOperatorImageURL

--- a/pkg/handlers/export_test.go
+++ b/pkg/handlers/export_test.go
@@ -1,5 +1,25 @@
 package handlers
 
+import (
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+)
+
+// RedfishFinalizer is the test-visible alias of the unexported redfishFinalizer
+// interface, so external (handlers_test) tests can supply a fake BMC client to the
+// eject/finalize path without standing up a real gofish connection.
+type RedfishFinalizer = redfishFinalizer
+
+// WithTestFinalizerFactory injects a fake redfishFinalizer factory keyed on the
+// redfish.Config the deploy/finalize path would otherwise pass to NewDeployer. It
+// returns the handler for chaining. Test-only.
+func (h *DeployHandler) WithTestFinalizerFactory(f func(cfg redfish.Config) RedfishFinalizer) *DeployHandler {
+	return h.WithFinalizerFactory(func(cfg redfish.Config) redfishFinalizer { return f(cfg) })
+}
+
+// MarkEjectPendingForTest exposes the unexported markEjectPending so a test can arm
+// a deployment's eject lifecycle without driving the full async deploy goroutine.
+func (h *DeployHandler) MarkEjectPendingForTest(id string) { h.markEjectPending(id) }
+
 // ImageURLUsesHTTPS exposes the unexported imageURLUsesHTTPS helper to external
 // (handlers_test) tests so the InsertMedia transfer-protocol derivation can be
 // exercised directly.

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -497,6 +497,52 @@ func (f *fakeBuilder) Cancel(_ context.Context, id string) error {
 	return nil
 }
 
+// fakeSettingsStore implements store.SettingsStore for testing.
+type fakeSettingsStore struct {
+	mu     sync.Mutex
+	values map[string]string
+	getErr error // when set, Get returns this error (to exercise fail-closed paths)
+	setErr error // when set, Set returns this error
+	allErr error // when set, GetAll returns this error
+}
+
+func newFakeSettingsStore() *fakeSettingsStore {
+	return &fakeSettingsStore{values: map[string]string{}}
+}
+
+func (f *fakeSettingsStore) Get(_ context.Context, key string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return "", false, f.getErr
+	}
+	v, ok := f.values[key]
+	return v, ok, nil
+}
+
+func (f *fakeSettingsStore) Set(_ context.Context, key, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.values[key] = value
+	return nil
+}
+
+func (f *fakeSettingsStore) GetAll(_ context.Context) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.allErr != nil {
+		return nil, f.allErr
+	}
+	out := make(map[string]string, len(f.values))
+	for k, v := range f.values {
+		out[k] = v
+	}
+	return out, nil
+}
+
 // fakeSecureBootKeySetStore implements store.SecureBootKeySetStore for testing.
 type fakeSecureBootKeySetStore struct {
 	mu      sync.Mutex

--- a/pkg/handlers/finalize.go
+++ b/pkg/handlers/finalize.go
@@ -79,7 +79,14 @@ func (h *DeployHandler) runFinalize(ctx context.Context, target *store.BMCTarget
 	}
 	defer func() { _ = deployer.Close() }()
 
-	if err := deployer.Finalize(ctx, redfish.FinalizeRequest{}); err != nil {
+	if err := deployer.Finalize(ctx, redfish.FinalizeRequest{
+		// Opt-in power-cycle: when the BMC target requests it, power the machine off
+		// before ejecting and back on after, for BMCs/emulators that do not apply a
+		// live eject. Default (false) preserves the in-place eject. This single
+		// chokepoint covers every Finalize call site (manual finalize, eject, and the
+		// auto eject-on-phone-home).
+		PowerCycle: target.EjectPowerCycle,
+	}); err != nil {
 		return fmt.Errorf("finalizing (eject): %w", err)
 	}
 	return nil

--- a/pkg/handlers/finalize.go
+++ b/pkg/handlers/finalize.go
@@ -1,0 +1,314 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/labstack/echo/v4"
+)
+
+// finalizeTimeout bounds a single eject/finalize session (Connect -> discover ->
+// EjectMedia -> best-effort boot-to-disk -> Close). It is far shorter than a
+// deploy: there is no media fetch or install boot to wait on.
+const finalizeTimeout = 2 * time.Minute
+
+// redfishFinalizer is the slice of the Redfish Deployer the finalize path needs.
+// Keeping it an interface (mirroring hardware.systemInspector) lets tests inject a
+// fake BMC client without standing up a real gofish connection.
+type redfishFinalizer interface {
+	Connect(ctx context.Context) error
+	Finalize(ctx context.Context, req redfish.FinalizeRequest) error
+	Close() error
+}
+
+// finalizerFactory builds a redfishFinalizer from connection params. The default
+// (defaultFinalizerFactory) returns a real *redfish.Deployer; tests override it.
+type finalizerFactory func(cfg redfish.Config) redfishFinalizer
+
+// defaultFinalizerFactory builds a real gofish-backed Deployer.
+func defaultFinalizerFactory(cfg redfish.Config) redfishFinalizer {
+	return redfish.NewDeployer(cfg)
+}
+
+// finalizer returns the configured factory, defaulting to the real Deployer when
+// none was injected.
+func (h *DeployHandler) finalizer() finalizerFactory {
+	if h.finalizerFn != nil {
+		return h.finalizerFn
+	}
+	return defaultFinalizerFactory
+}
+
+// WithFinalizerFactory overrides the Deployer factory used by the finalize path.
+// Intended for tests; production wiring leaves it nil so the real Deployer is used.
+func (h *DeployHandler) WithFinalizerFactory(f finalizerFactory) *DeployHandler {
+	h.finalizerFn = f
+	return h
+}
+
+// runFinalize connects to the deployment's BMC, ejects the media (and best-effort
+// boots to disk), and tears the session down. It does NOT touch EjectState — the
+// caller owns the CAS lifecycle (so the same routine drives both the auto and the
+// manual path). The BMC credentials are decrypted by the store on read and used
+// only for this session; they are never logged.
+func (h *DeployHandler) runFinalize(ctx context.Context, target *store.BMCTarget) error {
+	deployer := h.finalizer()(redfish.Config{
+		Endpoint:  target.Endpoint,
+		Username:  target.Username,
+		Password:  target.Password,
+		Vendor:    redfish.VendorType(target.Vendor),
+		VerifySSL: target.VerifySSL,
+		SystemID:  target.SystemID,
+		Timeout:   finalizeTimeout,
+	})
+	if err := deployer.Connect(ctx); err != nil {
+		return fmt.Errorf("connecting to redfish endpoint: %w", err)
+	}
+	defer func() { _ = deployer.Close() }()
+
+	if err := deployer.Finalize(ctx, redfish.FinalizeRequest{}); err != nil {
+		return fmt.Errorf("finalizing (eject): %w", err)
+	}
+	return nil
+}
+
+// finalizeDeployment runs the full guarded finalize for one deployment: resolve its
+// BMC, run the eject session, and CAS EjectState to a terminal value. It assumes the
+// caller already won the CAS into store.EjectStateEjecting (so exactly one routine
+// reaches here for a given deployment). On success it CASes ejecting->ejected and
+// stamps EjectedAt; on failure ejecting->eject-failed with a scrubbed EjectError.
+//
+// A nil bmcTargetID is a programming error (the deploy path only sets pending when a
+// BMC is attached); it is surfaced as eject-failed rather than panicking.
+func (h *DeployHandler) finalizeDeployment(ctx context.Context, dep *store.Deployment) error {
+	if dep.BMCTargetID == "" {
+		h.markEjectFailed(ctx, dep.ID, "deployment has no BMC target to eject")
+		return fmt.Errorf("deployment %s has no BMC target", dep.ID)
+	}
+
+	target, err := h.bmcTargets.GetByID(ctx, dep.BMCTargetID)
+	if err != nil {
+		h.markEjectFailed(ctx, dep.ID, "BMC target not found")
+		return fmt.Errorf("resolving BMC target: %w", err)
+	}
+
+	if err := h.runFinalize(ctx, target); err != nil {
+		h.markEjectFailed(ctx, dep.ID, scrubBMCError(err))
+		return err
+	}
+
+	h.markEjected(ctx, dep.ID)
+	return nil
+}
+
+// markEjected CASes ejecting->ejected and stamps EjectedAt. Best-effort: a store
+// failure leaves the row in ejecting for the restart reconciler to reset.
+func (h *DeployHandler) markEjected(ctx context.Context, id string) {
+	ok, err := h.deployments.CASEjectState(ctx, id, store.EjectStateEjecting, store.EjectStateEjected)
+	if err != nil || !ok {
+		return
+	}
+	dep, err := h.deployments.GetByID(ctx, id)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	dep.EjectedAt = &now
+	dep.EjectError = ""
+	_ = h.deployments.Update(ctx, dep)
+}
+
+// markEjectFailed CASes ejecting->eject-failed and records a scrubbed reason.
+func (h *DeployHandler) markEjectFailed(ctx context.Context, id, reason string) {
+	ok, err := h.deployments.CASEjectState(ctx, id, store.EjectStateEjecting, store.EjectStateFailed)
+	if err != nil || !ok {
+		return
+	}
+	dep, err := h.deployments.GetByID(ctx, id)
+	if err != nil {
+		return
+	}
+	dep.EjectError = reason
+	_ = h.deployments.Update(ctx, dep)
+}
+
+// MaybeFinalizeForNode is the auto eject-on-phone-home entry point. It is called
+// off the request goroutine from Register/Heartbeat (the "OS is up" signal). It
+// finds a Redfish deployment pending eject that legitimately belongs to this node
+// and finalizes it. Correlation is deliberately conservative (mirrors the BOLA
+// hardening): it acts only on a deployment whose BMC is linked to this node, or —
+// when no such link exists — on the SOLE unambiguous pending-eject deployment.
+// When the correlation is ambiguous (zero, or more than one candidate) it does
+// nothing and leaves the operator the manual Finalize action.
+//
+// It must add no latency to registration: callers spawn it on a background
+// goroutine with the server base context.
+func (h *DeployHandler) MaybeFinalizeForNode(ctx context.Context, nodeID string) {
+	deps, err := h.deployments.List(ctx)
+	if err != nil {
+		return
+	}
+
+	var pending []*store.Deployment
+	for _, dep := range deps {
+		if dep.Method == "redfish" && dep.EjectState == store.EjectStatePending {
+			pending = append(pending, dep)
+		}
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	chosen := h.correlateDeployment(ctx, nodeID, pending)
+	if chosen == nil {
+		// Ambiguous or unlinked: refuse to auto-eject. The operator can finalize
+		// manually. This is the security-critical refusal — never finalize a
+		// deployment a node is not legitimately correlated with.
+		return
+	}
+
+	// CAS pending->ejecting: only one winner across concurrent phone-homes / a
+	// racing manual finalize. The loser returns without touching the BMC.
+	ok, err := h.deployments.CASEjectState(ctx, chosen.ID, store.EjectStatePending, store.EjectStateEjecting)
+	if err != nil || !ok {
+		return
+	}
+
+	// Record the node linkage now that we own the deployment.
+	chosen.NodeID = nodeID
+	chosen.EjectState = store.EjectStateEjecting
+	_ = h.deployments.Update(ctx, chosen)
+
+	_ = h.finalizeDeployment(ctx, chosen)
+}
+
+// correlateDeployment picks the one pending-eject deployment this node may finalize,
+// or nil when the correlation is ambiguous. Preference order:
+//  1. deployments whose linked BMCTarget.NodeID == nodeID — if exactly one, that's
+//     it (multiple linked is ambiguous -> nil).
+//  2. otherwise, when there is exactly ONE pending-eject deployment in total, use it
+//     (the unambiguous-single fallback).
+//  3. otherwise nil.
+func (h *DeployHandler) correlateDeployment(ctx context.Context, nodeID string, pending []*store.Deployment) *store.Deployment {
+	var linked []*store.Deployment
+	for _, dep := range pending {
+		// A deployment already linked to this node (e.g. a manual finalize set it).
+		if dep.NodeID == nodeID {
+			linked = append(linked, dep)
+			continue
+		}
+		if dep.BMCTargetID == "" {
+			continue
+		}
+		target, err := h.bmcTargets.GetByID(ctx, dep.BMCTargetID)
+		if err != nil {
+			continue
+		}
+		if target.NodeID == nodeID {
+			linked = append(linked, dep)
+		}
+	}
+	if len(linked) == 1 {
+		return linked[0]
+	}
+	if len(linked) > 1 {
+		// Multiple deployments correlate to this node: ambiguous, refuse.
+		return nil
+	}
+	// No explicit link. Fall back to the sole unambiguous pending deployment.
+	if len(pending) == 1 {
+		return pending[0]
+	}
+	return nil
+}
+
+// --- Manual finalize / eject endpoints (admin-only) ---
+
+// FinalizeDeployment handles POST /api/v1/deployments/:id/finalize. It is the
+// universal, network-independent operator override: eject the media and boot to
+// disk for one deployment, regardless of its eject policy. It is CAS-guarded so it
+// cannot race the auto path: it claims pending|eject-failed|ejected -> ejecting and
+// returns 409 when another finalize already holds the slot (state == ejecting).
+func (h *DeployHandler) FinalizeDeployment(c echo.Context) error {
+	id := c.Param("id")
+	ctx := c.Request().Context()
+
+	dep, err := h.deployments.GetByID(ctx, id)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "deployment not found"})
+	}
+	if dep.BMCTargetID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "deployment has no BMC target to eject"})
+	}
+
+	// Claim the slot from any non-in-flight state. A manual finalize is allowed to
+	// retry an eject-failed row and to re-eject an already-ejected one (idempotent
+	// operator action), but never to double-run a finalize that is in flight.
+	if !h.claimManualFinalize(ctx, dep) {
+		return c.JSON(http.StatusConflict, map[string]string{"error": "a finalize is already in progress for this deployment"})
+	}
+
+	if err := h.finalizeDeployment(ctx, dep); err != nil {
+		// finalizeDeployment already CAS'd the row to eject-failed and recorded the
+		// scrubbed reason; surface it.
+		updated, gerr := h.deployments.GetByID(ctx, id)
+		if gerr == nil {
+			return c.JSON(http.StatusInternalServerError, updated)
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": scrubBMCError(err)})
+	}
+
+	updated, err := h.deployments.GetByID(ctx, id)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "finalize succeeded but failed to read back deployment"})
+	}
+	return c.JSON(http.StatusOK, updated)
+}
+
+// claimManualFinalize CASes the deployment into ejecting from any of the allowed
+// resting states (pending, eject-failed, ejected, or unset/off). It returns true on
+// the winning transition. An unset EjectState ("") is allowed so an operator can
+// finalize a completed deployment whose policy was off. It returns false only when
+// the row is already ejecting (an in-flight finalize).
+func (h *DeployHandler) claimManualFinalize(ctx context.Context, dep *store.Deployment) bool {
+	for _, from := range []string{
+		store.EjectStatePending,
+		store.EjectStateFailed,
+		store.EjectStateEjected,
+		"", // policy was off: allow an explicit operator override.
+	} {
+		ok, err := h.deployments.CASEjectState(ctx, dep.ID, from, store.EjectStateEjecting)
+		if err != nil {
+			return false
+		}
+		if ok {
+			dep.EjectState = store.EjectStateEjecting
+			return true
+		}
+	}
+	return false
+}
+
+// EjectBMCTarget handles POST /api/v1/bmc-targets/:id/eject. It is the pure
+// operator escape hatch: eject the virtual media (and best-effort boot to disk) for
+// a BMC directly, with no deployment context or eject-state bookkeeping. Admin-only.
+func (h *DeployHandler) EjectBMCTarget(c echo.Context) error {
+	id := c.Param("id")
+	ctx := c.Request().Context()
+
+	target, err := h.bmcTargets.GetByID(ctx, id)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "BMC target not found"})
+	}
+
+	finalizeCtx, cancel := context.WithTimeout(ctx, finalizeTimeout)
+	defer cancel()
+	if err := h.runFinalize(finalizeCtx, target); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": scrubBMCError(err)})
+	}
+	return c.JSON(http.StatusOK, map[string]string{"status": "ejected"})
+}

--- a/pkg/handlers/finalize.go
+++ b/pkg/handlers/finalize.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -15,6 +16,14 @@ import (
 // EjectMedia -> best-effort boot-to-disk -> Close). It is far shorter than a
 // deploy: there is no media fetch or install boot to wait on.
 const finalizeTimeout = 2 * time.Minute
+
+// ejectFallbackWindow time-boxes the unlinked single-pending auto-eject fallback.
+// When there is no node<->BMC link, we only treat the sole pending deployment as
+// "this node's" if it completed recently — a phone-home long after the install is
+// unlikely to be the freshly provisioned node and must not auto-eject on a guess.
+// The window is generous (slow installs, first-boot config) but bounded; older
+// pending deployments stay pending for the explicit manual Finalize endpoint.
+const ejectFallbackWindow = 60 * time.Minute
 
 // redfishFinalizer is the slice of the Redfish Deployer the finalize path needs.
 // Keeping it an interface (mirroring hardware.systemInspector) lets tests inject a
@@ -163,12 +172,21 @@ func (h *DeployHandler) MaybeFinalizeForNode(ctx context.Context, nodeID string)
 		return
 	}
 
-	chosen := h.correlateDeployment(ctx, nodeID, pending)
+	chosen, viaFallback := h.correlateDeployment(ctx, nodeID, pending)
 	if chosen == nil {
 		// Ambiguous or unlinked: refuse to auto-eject. The operator can finalize
 		// manually. This is the security-critical refusal — never finalize a
 		// deployment a node is not legitimately correlated with.
 		return
+	}
+
+	if viaFallback {
+		// Loudly distinguish the heuristic fallback from a real node<->BMC link:
+		// this path ejected a deployment a node is only *circumstantially*
+		// correlated with (sole recent pending), and is worth auditing.
+		log.Printf("finalize: node %s triggered eject of deployment %s via the unlinked single-pending fallback (no node<->BMC link)", nodeID, chosen.ID)
+	} else {
+		log.Printf("finalize: node %s triggered eject of deployment %s via node<->BMC link", nodeID, chosen.ID)
 	}
 
 	// CAS pending->ejecting: only one winner across concurrent phone-homes / a
@@ -187,13 +205,17 @@ func (h *DeployHandler) MaybeFinalizeForNode(ctx context.Context, nodeID string)
 }
 
 // correlateDeployment picks the one pending-eject deployment this node may finalize,
-// or nil when the correlation is ambiguous. Preference order:
-//  1. deployments whose linked BMCTarget.NodeID == nodeID — if exactly one, that's
-//     it (multiple linked is ambiguous -> nil).
-//  2. otherwise, when there is exactly ONE pending-eject deployment in total, use it
-//     (the unambiguous-single fallback).
+// or nil when the correlation is ambiguous. The second return reports whether the
+// pick came from the unlinked single-pending fallback (true) rather than a real
+// node<->BMC link (false), so the caller can audit-log the heuristic path. A nil
+// deployment always pairs with false. Preference order:
+//  1. deployments whose linked BMCTarget.NodeID == nodeID (or Deployment.NodeID ==
+//     nodeID) — if exactly one, that's it (multiple linked is ambiguous -> nil).
+//     The linked path is always honoured and is NOT time-boxed.
+//  2. otherwise, when there is exactly ONE pending-eject deployment in total AND it
+//     completed within ejectFallbackWindow, use it (the time-boxed fallback).
 //  3. otherwise nil.
-func (h *DeployHandler) correlateDeployment(ctx context.Context, nodeID string, pending []*store.Deployment) *store.Deployment {
+func (h *DeployHandler) correlateDeployment(ctx context.Context, nodeID string, pending []*store.Deployment) (*store.Deployment, bool) {
 	var linked []*store.Deployment
 	for _, dep := range pending {
 		// A deployment already linked to this node (e.g. a manual finalize set it).
@@ -213,17 +235,31 @@ func (h *DeployHandler) correlateDeployment(ctx context.Context, nodeID string, 
 		}
 	}
 	if len(linked) == 1 {
-		return linked[0]
+		// A real link is always honoured regardless of age.
+		return linked[0], false
 	}
 	if len(linked) > 1 {
 		// Multiple deployments correlate to this node: ambiguous, refuse.
-		return nil
+		return nil, false
 	}
-	// No explicit link. Fall back to the sole unambiguous pending deployment.
-	if len(pending) == 1 {
-		return pending[0]
+	// No explicit link. Fall back to the sole pending deployment ONLY when it
+	// completed recently: a phone-home long after install is unlikely to be the
+	// node we just provisioned, and auto-ejecting on that guess is unsafe. An
+	// out-of-window deployment stays pending for the manual Finalize endpoint.
+	if len(pending) == 1 && withinEjectFallbackWindow(pending[0]) {
+		return pending[0], true
 	}
-	return nil
+	return nil, false
+}
+
+// withinEjectFallbackWindow reports whether dep completed recently enough for the
+// unlinked single-pending fallback to act on it. A deployment with no CompletedAt
+// stamp is treated as out of window (we cannot prove it is recent).
+func withinEjectFallbackWindow(dep *store.Deployment) bool {
+	if dep.CompletedAt == nil {
+		return false
+	}
+	return time.Since(*dep.CompletedAt) <= ejectFallbackWindow
 }
 
 // --- Manual finalize / eject endpoints (admin-only) ---

--- a/pkg/handlers/finalize_test.go
+++ b/pkg/handlers/finalize_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -107,7 +108,42 @@ var _ = Describe("Eject / finalize", func() {
 			Expect(got.EjectedAt).NotTo(BeNil())
 		})
 
-		It("finalizes the sole unambiguous pending deployment when there is no explicit link", func() {
+		It("finalizes the sole unambiguous pending deployment when there is no explicit link and it completed within the window", func() {
+			completed := time.Now().Add(-1 * time.Minute)
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", Status: store.DeployCompleted,
+				BMCTargetID: "bmc-1", EjectState: store.EjectStatePending, CompletedAt: &completed,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-unlinked")
+
+			Expect(fin.calls()).To(Equal(1))
+			got, _ := deployments.GetByID(context.Background(), "dep-1")
+			Expect(got.EjectState).To(Equal(store.EjectStateEjected))
+		})
+
+		It("does NOT fire the unlinked single-pending fallback when the sole deployment is older than the window", func() {
+			// Completed well past ejectFallbackWindow (60m). A late phone-home is not
+			// trusted to be the freshly provisioned node; it stays pending for the
+			// manual Finalize endpoint.
+			completed := time.Now().Add(-2 * time.Hour)
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", Status: store.DeployCompleted,
+				BMCTargetID: "bmc-1", EjectState: store.EjectStatePending, CompletedAt: &completed,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-unlinked")
+
+			// Fallback refused: no eject, deployment untouched.
+			Expect(fin.calls()).To(Equal(0))
+			got, _ := deployments.GetByID(context.Background(), "dep-1")
+			Expect(got.EjectState).To(Equal(store.EjectStatePending))
+		})
+
+		It("does NOT fire the unlinked single-pending fallback when the sole deployment has no CompletedAt stamp", func() {
+			// No completion stamp -> cannot prove recency -> out of window.
 			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9"})).To(Succeed())
 			Expect(deployments.Create(context.Background(), &store.Deployment{
 				ID: "dep-1", Method: "redfish", Status: store.DeployCompleted,
@@ -115,6 +151,22 @@ var _ = Describe("Eject / finalize", func() {
 			})).To(Succeed())
 
 			h.MaybeFinalizeForNode(context.Background(), "node-unlinked")
+
+			Expect(fin.calls()).To(Equal(0))
+			got, _ := deployments.GetByID(context.Background(), "dep-1")
+			Expect(got.EjectState).To(Equal(store.EjectStatePending))
+		})
+
+		It("honours the node<->BMC link regardless of age (linked path is not time-boxed)", func() {
+			// Completed long ago, but legitimately linked to this node -> always ejects.
+			completed := time.Now().Add(-72 * time.Hour)
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9", NodeID: "node-1"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", Status: store.DeployCompleted,
+				BMCTargetID: "bmc-1", EjectState: store.EjectStatePending, CompletedAt: &completed,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-1")
 
 			Expect(fin.calls()).To(Equal(1))
 			got, _ := deployments.GetByID(context.Background(), "dep-1")

--- a/pkg/handlers/finalize_test.go
+++ b/pkg/handlers/finalize_test.go
@@ -1,0 +1,296 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/labstack/echo/v4"
+)
+
+// fakeFinalizer is an injectable redfish.Deployer stand-in for the eject/finalize
+// path. It records that Finalize was called and against which endpoint, and can be
+// made to fail Connect or Finalize to exercise the eject-failed path.
+type fakeFinalizer struct {
+	mu            sync.Mutex
+	cfg           redfish.Config
+	connectErr    error
+	finalizeErr   error
+	connected     bool
+	finalizeCalls int
+}
+
+func (f *fakeFinalizer) Connect(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.connectErr != nil {
+		return f.connectErr
+	}
+	f.connected = true
+	return nil
+}
+
+func (f *fakeFinalizer) Finalize(_ context.Context, _ redfish.FinalizeRequest) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.finalizeCalls++
+	return f.finalizeErr
+}
+
+func (f *fakeFinalizer) Close() error { return nil }
+
+func (f *fakeFinalizer) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.finalizeCalls
+}
+
+var _ = Describe("Eject / finalize", func() {
+	var (
+		deployments *fakeDeploymentStore
+		bmcTargets  *fakeBMCTargetStore
+		artifacts   *fakeArtifactStore
+		fin         *fakeFinalizer
+		h           *handlers.DeployHandler
+	)
+
+	BeforeEach(func() {
+		deployments = &fakeDeploymentStore{}
+		bmcTargets = &fakeBMCTargetStore{}
+		artifacts = &fakeArtifactStore{}
+		fin = &fakeFinalizer{}
+		h = handlers.NewDeployHandler(artifacts, deployments, bmcTargets, nil, "", nil, nil).
+			WithTestFinalizerFactory(func(cfg redfish.Config) handlers.RedfishFinalizer {
+				fin.cfg = cfg
+				return fin
+			})
+	})
+
+	Describe("deploy completion arms the eject lifecycle", func() {
+		It("marks the deployment pending-eject without ejecting inline", func() {
+			dep := &store.Deployment{ID: "dep-1", Method: "redfish", Status: store.DeployCompleted, BMCTargetID: "bmc-1"}
+			Expect(deployments.Create(context.Background(), dep)).To(Succeed())
+
+			h.MarkEjectPendingForTest("dep-1")
+
+			got, err := deployments.GetByID(context.Background(), "dep-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.EjectState).To(Equal(store.EjectStatePending))
+			Expect(got.EjectPolicy).To(Equal(store.EjectPolicyOnPhoneHome))
+			// No inline eject ran.
+			Expect(fin.calls()).To(Equal(0))
+		})
+	})
+
+	Describe("MaybeFinalizeForNode", func() {
+		It("finalizes a deployment linked via BMCTarget.NodeID and CAS-transitions to ejected", func() {
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9", NodeID: "node-1"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", Status: store.DeployCompleted,
+				BMCTargetID: "bmc-1", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-1")
+
+			Expect(fin.calls()).To(Equal(1))
+			Expect(fin.cfg.Endpoint).To(Equal("https://10.0.0.9"))
+			got, _ := deployments.GetByID(context.Background(), "dep-1")
+			Expect(got.EjectState).To(Equal(store.EjectStateEjected))
+			Expect(got.NodeID).To(Equal("node-1"))
+			Expect(got.EjectedAt).NotTo(BeNil())
+		})
+
+		It("finalizes the sole unambiguous pending deployment when there is no explicit link", func() {
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", Status: store.DeployCompleted,
+				BMCTargetID: "bmc-1", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-unlinked")
+
+			Expect(fin.calls()).To(Equal(1))
+			got, _ := deployments.GetByID(context.Background(), "dep-1")
+			Expect(got.EjectState).To(Equal(store.EjectStateEjected))
+		})
+
+		It("refuses to auto-eject when there are multiple unlinked pending deployments (ambiguous)", func() {
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9"})).To(Succeed())
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-2", Endpoint: "https://10.0.0.10"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", BMCTargetID: "bmc-1", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-2", Method: "redfish", BMCTargetID: "bmc-2", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-unlinked")
+
+			// No eject: ambiguous correlation must be refused.
+			Expect(fin.calls()).To(Equal(0))
+			for _, id := range []string{"dep-1", "dep-2"} {
+				got, _ := deployments.GetByID(context.Background(), id)
+				Expect(got.EjectState).To(Equal(store.EjectStatePending))
+			}
+		})
+
+		It("SECURITY: never finalizes a deployment a node is not linked to when another node's deployment is also pending", func() {
+			// node-1 owns bmc-1/dep-1; bmc-2/dep-2 belongs to a DIFFERENT node. When
+			// node-1 phones home it must eject ONLY dep-1, never dep-2. Because dep-1
+			// is unambiguously linked, the unambiguous-single fallback does not even
+			// engage — and dep-2 (linked to node-2) is untouched.
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9", NodeID: "node-1"})).To(Succeed())
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-2", Endpoint: "https://10.0.0.10", NodeID: "node-2"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", BMCTargetID: "bmc-1", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-2", Method: "redfish", BMCTargetID: "bmc-2", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-1")
+
+			Expect(fin.calls()).To(Equal(1))
+			Expect(fin.cfg.Endpoint).To(Equal("https://10.0.0.9")) // bmc-1, never bmc-2
+			d1, _ := deployments.GetByID(context.Background(), "dep-1")
+			d2, _ := deployments.GetByID(context.Background(), "dep-2")
+			Expect(d1.EjectState).To(Equal(store.EjectStateEjected))
+			Expect(d2.EjectState).To(Equal(store.EjectStatePending)) // untouched
+		})
+
+		It("records eject-failed with a scrubbed error when finalize fails", func() {
+			fin.finalizeErr = context.DeadlineExceeded
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9", NodeID: "node-1"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", BMCTargetID: "bmc-1", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-1")
+
+			got, _ := deployments.GetByID(context.Background(), "dep-1")
+			Expect(got.EjectState).To(Equal(store.EjectStateFailed))
+			Expect(got.EjectError).NotTo(BeEmpty())
+		})
+
+		It("CAS idempotency: two concurrent finalize attempts only finalize once", func() {
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9", NodeID: "node-1"})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", BMCTargetID: "bmc-1", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+
+			var wg sync.WaitGroup
+			for i := 0; i < 8; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					h.MaybeFinalizeForNode(context.Background(), "node-1")
+				}()
+			}
+			wg.Wait()
+
+			// Exactly one winner reached the BMC despite 8 concurrent phone-homes.
+			Expect(fin.calls()).To(Equal(1))
+			got, _ := deployments.GetByID(context.Background(), "dep-1")
+			Expect(got.EjectState).To(Equal(store.EjectStateEjected))
+		})
+	})
+
+	Describe("manual POST /deployments/:id/finalize", func() {
+		finalize := func(id string) *httptest.ResponseRecorder {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/deployments/"+id+"/finalize", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues(id)
+			Expect(h.FinalizeDeployment(c)).To(Succeed())
+			return rec
+		}
+
+		It("ejects regardless of policy and returns the updated deployment", func() {
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9"})).To(Succeed())
+			// Policy off (EjectState empty): a manual finalize is an operator override.
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", Status: store.DeployCompleted, BMCTargetID: "bmc-1",
+			})).To(Succeed())
+
+			rec := finalize("dep-1")
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(fin.calls()).To(Equal(1))
+			got, _ := deployments.GetByID(context.Background(), "dep-1")
+			Expect(got.EjectState).To(Equal(store.EjectStateEjected))
+		})
+
+		It("404s for an unknown deployment", func() {
+			rec := finalize("missing")
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("400s when the deployment has no BMC target", func() {
+			Expect(deployments.Create(context.Background(), &store.Deployment{ID: "dep-1", Method: "redfish"})).To(Succeed())
+			rec := finalize("dep-1")
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Describe("POST /bmc-targets/:id/eject", func() {
+		eject := func(id string) *httptest.ResponseRecorder {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/bmc-targets/"+id+"/eject", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues(id)
+			Expect(h.EjectBMCTarget(c)).To(Succeed())
+			return rec
+		}
+
+		It("ejects directly with no deployment context", func() {
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9"})).To(Succeed())
+			rec := eject("bmc-1")
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(fin.calls()).To(Equal(1))
+			Expect(fin.cfg.Endpoint).To(Equal("https://10.0.0.9"))
+		})
+
+		It("404s for an unknown BMC target", func() {
+			rec := eject("missing")
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("500s with a scrubbed error when the eject fails", func() {
+			fin.finalizeErr = context.DeadlineExceeded
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{ID: "bmc-1", Endpoint: "https://10.0.0.9"})).To(Succeed())
+			rec := eject("bmc-1")
+			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("reconcile flips ejecting -> pending", func() {
+		It("resets an orphaned ejecting row to pending without auto-ejecting", func() {
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", Status: store.DeployCompleted, EjectState: store.EjectStateEjecting,
+			})).To(Succeed())
+			// A terminal ejected row must be left alone.
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-2", Method: "redfish", Status: store.DeployCompleted, EjectState: store.EjectStateEjected,
+			})).To(Succeed())
+
+			Expect(handlers.ReconcileOrphanedDeployments(context.Background(), deployments)).To(Succeed())
+
+			d1, _ := deployments.GetByID(context.Background(), "dep-1")
+			d2, _ := deployments.GetByID(context.Background(), "dep-2")
+			Expect(d1.EjectState).To(Equal(store.EjectStatePending))
+			Expect(d2.EjectState).To(Equal(store.EjectStateEjected))
+			// Reconcile NEVER ejects.
+			Expect(fin.calls()).To(Equal(0))
+		})
+	})
+})

--- a/pkg/handlers/finalize_test.go
+++ b/pkg/handlers/finalize_test.go
@@ -26,6 +26,9 @@ type fakeFinalizer struct {
 	finalizeErr   error
 	connected     bool
 	finalizeCalls int
+	// lastReq records the most recent FinalizeRequest so specs can assert the
+	// PowerCycle flag was threaded through from the BMC target.
+	lastReq redfish.FinalizeRequest
 }
 
 func (f *fakeFinalizer) Connect(_ context.Context) error {
@@ -38,11 +41,18 @@ func (f *fakeFinalizer) Connect(_ context.Context) error {
 	return nil
 }
 
-func (f *fakeFinalizer) Finalize(_ context.Context, _ redfish.FinalizeRequest) error {
+func (f *fakeFinalizer) Finalize(_ context.Context, req redfish.FinalizeRequest) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.finalizeCalls++
+	f.lastReq = req
 	return f.finalizeErr
+}
+
+func (f *fakeFinalizer) lastPowerCycle() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastReq.PowerCycle
 }
 
 func (f *fakeFinalizer) Close() error { return nil }
@@ -215,6 +225,34 @@ var _ = Describe("Eject / finalize", func() {
 			d2, _ := deployments.GetByID(context.Background(), "dep-2")
 			Expect(d1.EjectState).To(Equal(store.EjectStateEjected))
 			Expect(d2.EjectState).To(Equal(store.EjectStatePending)) // untouched
+		})
+
+		It("threads BMCTarget.EjectPowerCycle into the FinalizeRequest", func() {
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+				ID: "bmc-1", Endpoint: "https://10.0.0.9", NodeID: "node-1", EjectPowerCycle: true,
+			})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", BMCTargetID: "bmc-1", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-1")
+
+			Expect(fin.calls()).To(Equal(1))
+			Expect(fin.lastPowerCycle()).To(BeTrue())
+		})
+
+		It("leaves FinalizeRequest.PowerCycle false when the BMC target does not request it", func() {
+			Expect(bmcTargets.Create(context.Background(), &store.BMCTarget{
+				ID: "bmc-1", Endpoint: "https://10.0.0.9", NodeID: "node-1",
+			})).To(Succeed())
+			Expect(deployments.Create(context.Background(), &store.Deployment{
+				ID: "dep-1", Method: "redfish", BMCTargetID: "bmc-1", EjectState: store.EjectStatePending,
+			})).To(Succeed())
+
+			h.MaybeFinalizeForNode(context.Background(), "node-1")
+
+			Expect(fin.calls()).To(Equal(1))
+			Expect(fin.lastPowerCycle()).To(BeFalse())
 		})
 
 		It("records eject-failed with a scrubbed error when finalize fails", func() {

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -19,6 +20,12 @@ import (
 // that comes online after the window is closed will not run the teardown.
 const decommissionTimeout = 30 * time.Second
 
+// nodeFinalizer is the auto eject-on-phone-home hook: given a node id it ejects the
+// virtual media of that node's pending-eject Redfish deployment (when one can be
+// unambiguously correlated). It is satisfied by DeployHandler.maybeFinalizeForNode.
+// It is always invoked off the request goroutine so it adds no registration latency.
+type nodeFinalizer func(ctx context.Context, nodeID string)
+
 // NodeHandler handles node-related REST endpoints.
 type NodeHandler struct {
 	nodes         store.NodeStore
@@ -27,6 +34,15 @@ type NodeHandler struct {
 	hub           *ws.Hub // optional; when nil, Decommission reports the node as offline
 	regToken      string
 	aurorabootURL string
+
+	// finalize, when non-nil, is the auto eject-on-phone-home hook invoked from
+	// Register and Heartbeat on a background goroutine bound to baseCtx. nil
+	// disables auto-eject (e.g. when no deploy/BMC stores are wired).
+	finalize nodeFinalizer
+	// baseCtx is the parent context for the background finalize goroutine, tied to
+	// the server lifecycle so a shutdown cancels an in-flight eject. Defaults to
+	// context.Background().
+	baseCtx context.Context
 }
 
 // NewNodeHandler creates a new NodeHandler.
@@ -38,7 +54,35 @@ func NewNodeHandler(nodes store.NodeStore, commands store.CommandStore, groups s
 		hub:           hub,
 		regToken:      regToken,
 		aurorabootURL: aurorabootURL,
+		baseCtx:       context.Background(),
 	}
+}
+
+// WithFinalizer wires the auto eject-on-phone-home hook and the server base context
+// for its background goroutine. Passing a nil finalizer leaves auto-eject disabled.
+// Returns the handler for chaining.
+func (h *NodeHandler) WithFinalizer(f nodeFinalizer, baseCtx context.Context) *NodeHandler {
+	h.finalize = f
+	if baseCtx != nil {
+		h.baseCtx = baseCtx
+	}
+	return h
+}
+
+// triggerFinalize fires the auto eject-on-phone-home hook off the request goroutine
+// so it never adds latency to register/heartbeat. The background context is derived
+// from the server base context (cancelled on shutdown) plus a short timeout; the
+// finalize hook owns its own per-deployment CAS so a duplicate phone-home is a
+// harmless no-op. It is nil-safe.
+func (h *NodeHandler) triggerFinalize(nodeID string) {
+	if h.finalize == nil || nodeID == "" {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(h.baseCtx, finalizeTimeout)
+		defer cancel()
+		h.finalize(ctx, nodeID)
+	}()
 }
 
 // registerRequest is the expected body for node registration.
@@ -75,6 +119,9 @@ func (h *NodeHandler) Register(c echo.Context) error {
 	// Check if node already exists by machineID
 	existing, _ := h.nodes.GetByMachineID(c.Request().Context(), req.MachineID)
 	if existing != nil {
+		// A re-register is a strong "OS is up" signal too (a freshly-installed node
+		// phones home on first boot): attempt the auto eject-on-phone-home.
+		h.triggerFinalize(existing.ID)
 		// Return existing node info
 		return c.JSON(http.StatusOK, map[string]any{
 			"id":     existing.ID,
@@ -95,6 +142,10 @@ func (h *NodeHandler) Register(c echo.Context) error {
 	if err := h.nodes.Register(c.Request().Context(), node); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to register node"})
 	}
+
+	// The node just phoned home for the first time — the OS is up. Attempt the auto
+	// eject-on-phone-home for its pending-eject Redfish deployment, off-request.
+	h.triggerFinalize(node.ID)
 
 	return c.JSON(http.StatusCreated, map[string]any{
 		"id":     node.ID,
@@ -350,6 +401,10 @@ func (h *NodeHandler) Heartbeat(c echo.Context) error {
 	if err := h.nodes.UpdatePhase(c.Request().Context(), nodeID, store.PhaseOnline); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update phase"})
 	}
+	// Heartbeat is the universal "OS is up" signal (and the fallback when a node
+	// never re-registers): attempt the auto eject-on-phone-home off-request. The
+	// per-deployment CAS makes a repeated heartbeat a harmless no-op once ejected.
+	h.triggerFinalize(nodeID)
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }
 

--- a/pkg/handlers/redfish_profiles.go
+++ b/pkg/handlers/redfish_profiles.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+	"github.com/labstack/echo/v4"
+)
+
+// quirkProfileResponse is the JSON shape the UI consumes to populate the BMC
+// vendor selector from the profiles actually loaded at server start (built-in +
+// operator), each with its project-derived support tier. It deliberately carries
+// no quirks/hook detail — only what an operator needs to pick a profile.
+type quirkProfileResponse struct {
+	// Name is the selection name a BMCTarget.Vendor matches.
+	Name string `json:"name"`
+	// Tier is the support tier letter (A/B/C).
+	Tier string `json:"tier"`
+	// TierDescription is the human-readable tier annotation for a badge/tooltip.
+	TierDescription string `json:"tierDescription"`
+	// Origin is "builtin" or "operator".
+	Origin string `json:"origin"`
+	// ValidatedFirmware is the informational firmware label, when the profile
+	// declared one (empty otherwise).
+	ValidatedFirmware string `json:"validatedFirmware,omitempty"`
+}
+
+// ListQuirkProfiles returns the Redfish quirk profiles loaded into this server
+// (the built-in profiles plus any from --redfish-quirks-dir), sorted by name, so
+// the UI can offer them as vendor options with a tier badge instead of a hardcoded
+// list. Read-only; consults the process-wide registry installed at start.
+func (h *DeployHandler) ListQuirkProfiles(c echo.Context) error {
+	infos := redfish.DefaultRegistry().Profiles()
+	out := make([]quirkProfileResponse, 0, len(infos))
+	for _, p := range infos {
+		out = append(out, quirkProfileResponse{
+			Name:              p.Name,
+			Tier:              string(p.Tier),
+			TierDescription:   p.TierDescription,
+			Origin:            p.Origin,
+			ValidatedFirmware: p.ValidatedFirmware,
+		})
+	}
+	return c.JSON(http.StatusOK, out)
+}

--- a/pkg/handlers/settings.go
+++ b/pkg/handlers/settings.go
@@ -1,12 +1,32 @@
 package handlers
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"sync"
 
 	"github.com/google/uuid"
+	"github.com/kairos-io/AuroraBoot/pkg/isoserve"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
 	"github.com/labstack/echo/v4"
+)
+
+// Namespaced settings keys backing the runtime image-source configuration. They
+// live in the SettingsStore (a plain key/value table); the handler owns typing
+// and validation of the values.
+const (
+	// SettingDefaultImageURL is the global default image URL the BMC pulls the ISO
+	// from when neither a per-deploy nor a per-BMC override is set (model a).
+	SettingDefaultImageURL = "imageSource.defaultImageURL"
+	// SettingLocalServeEnabled gates whether AuroraBoot serves the built artifact
+	// ISO locally (model b). "true"/"false"; defaults to false.
+	SettingLocalServeEnabled = "imageSource.localServeEnabled"
+	// SettingLocalServeAdvertisedURL is the advertised base URL the BMC reaches the
+	// locally-served ISO at, when set (model b). Advertised-only; the bind address
+	// is a launch decision.
+	SettingLocalServeAdvertisedURL = "imageSource.localServeAdvertisedURL"
 )
 
 // SettingsHandler handles settings-related REST endpoints.
@@ -14,6 +34,27 @@ type SettingsHandler struct {
 	mu           sync.RWMutex
 	regToken     *string // keep pointer for middleware compatibility
 	regTokenFile string  // path to persist the token so rotations survive restarts
+
+	// settings persists the runtime image-source settings. May be nil (e.g. in
+	// tests or when no DB-backed store is wired), in which case the image-source
+	// endpoints report unconfigured defaults and reject writes.
+	settings store.SettingsStore
+	// isoServe is the launch-configured local ISO-serve listener, or nil when none
+	// was configured. Its presence is what makes local serving available at all;
+	// the enable flag (a setting) only gates an already-available listener.
+	//
+	// TODO(P3-followup): the design's "shared mode" mounts isoServe.Handler() on
+	// the main Echo server so local serving is available even without a dedicated
+	// --redfish-serve-addr listener (the enable flag would gate the mounted
+	// handler 404<->serve). That requires isoserve to mint capability URLs from a
+	// runtime advertised base (rather than its fixed launch BaseURL), which is a
+	// non-trivial isoserve change; deferred to keep this phase's blast radius
+	// small. For now local serving requires a launch-configured listener.
+	isoServe *isoserve.Server
+	// seedAdvertisedURL is the advertised URL seeded from the launch
+	// --redfish-serve-url flag, used as the default advertised URL until an
+	// operator sets one at runtime.
+	seedAdvertisedURL string
 }
 
 // NewSettingsHandler creates a new SettingsHandler.
@@ -21,6 +62,17 @@ type SettingsHandler struct {
 // regTokenFile is the path where the token is persisted; pass "" to disable persistence.
 func NewSettingsHandler(regToken *string, regTokenFile string) *SettingsHandler {
 	return &SettingsHandler{regToken: regToken, regTokenFile: regTokenFile}
+}
+
+// WithImageSource wires the dependencies for the image-source settings endpoints:
+// the settings store, the launch-configured local ISO-serve (nil when none), and
+// the advertised URL seeded from the launch --redfish-serve-url flag. Returns the
+// handler for chaining.
+func (h *SettingsHandler) WithImageSource(settings store.SettingsStore, isoServe *isoserve.Server, seedAdvertisedURL string) *SettingsHandler {
+	h.settings = settings
+	h.isoServe = isoServe
+	h.seedAdvertisedURL = seedAdvertisedURL
+	return h
 }
 
 // GetRegistrationToken handles GET /api/v1/settings/registration-token.
@@ -60,4 +112,173 @@ func (h *SettingsHandler) RotateRegistrationToken(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{
 		"registrationToken": token,
 	})
+}
+
+// imageSourceLocalServe is the local-serve (model b) view of the image-source
+// settings.
+type imageSourceLocalServe struct {
+	// Configured reports whether a local ISO-serve listener was configured at
+	// launch (--redfish-serve-addr). Without it, local serving cannot be enabled.
+	Configured bool `json:"configured"`
+	// Enabled is the runtime gate (only meaningful when Configured).
+	Enabled bool `json:"enabled"`
+	// AdvertisedURL is the advertised base URL the BMC reaches the served ISO at.
+	AdvertisedURL string `json:"advertisedURL"`
+	// UsesTLS reports whether the listener serves over HTTPS.
+	UsesTLS bool `json:"usesTLS"`
+}
+
+// imageSourceResponse is the GET /settings/image-source body.
+type imageSourceResponse struct {
+	DefaultImageURL string                `json:"defaultImageURL"`
+	LocalServe      imageSourceLocalServe `json:"localServe"`
+}
+
+// GetImageSource handles GET /api/v1/settings/image-source.
+//
+//	@Summary	Read the runtime image-source settings
+//	@Tags		Settings
+//	@Produce	json
+//	@Security	AdminBearer
+//	@Success	200	{object}	imageSourceResponse
+//	@Router		/api/v1/settings/image-source [get]
+func (h *SettingsHandler) GetImageSource(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	settings := map[string]string{}
+	if h.settings != nil {
+		all, err := h.settings.GetAll(ctx)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to read settings"})
+		}
+		settings = all
+	}
+
+	advertised := settings[SettingLocalServeAdvertisedURL]
+	if advertised == "" {
+		// Default to the URL seeded from the launch --redfish-serve-url flag until
+		// an operator sets one at runtime.
+		advertised = h.seedAdvertisedURL
+	}
+
+	resp := imageSourceResponse{
+		DefaultImageURL: settings[SettingDefaultImageURL],
+		LocalServe: imageSourceLocalServe{
+			Configured:    h.isoServe != nil,
+			Enabled:       settings[SettingLocalServeEnabled] == "true",
+			AdvertisedURL: advertised,
+		},
+	}
+	if h.isoServe != nil {
+		resp.LocalServe.UsesTLS = h.isoServe.UsesTLS()
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// updateImageSourceRequest is the PUT /settings/image-source body. Fields are
+// pointers so an absent field is left unchanged while an explicit empty string
+// clears the value.
+type updateImageSourceRequest struct {
+	DefaultImageURL         *string `json:"defaultImageURL"`
+	LocalServeEnabled       *bool   `json:"localServeEnabled"`
+	LocalServeAdvertisedURL *string `json:"localServeAdvertisedURL"`
+}
+
+// UpdateImageSource handles PUT /api/v1/settings/image-source.
+//
+//	@Summary		Update the runtime image-source settings
+//	@Description	Sets the global default image URL and the local-serve enable flag / advertised URL. Enabling local serve requires a launch-configured listener.
+//	@Tags			Settings
+//	@Accept			json
+//	@Produce		json
+//	@Security		AdminBearer
+//	@Success		200	{object}	imageSourceResponse
+//	@Router			/api/v1/settings/image-source [put]
+func (h *SettingsHandler) UpdateImageSource(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	var req updateImageSourceRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.settings == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "settings store is not configured on this server"})
+	}
+
+	// Validate every operator-supplied URL (SSRF defense in depth). An empty
+	// string is allowed to clear the value.
+	if req.DefaultImageURL != nil && *req.DefaultImageURL != "" {
+		if err := isoserve.ValidateMediaURL(*req.DefaultImageURL); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid defaultImageURL: %v", err)})
+		}
+	}
+	if req.LocalServeAdvertisedURL != nil && *req.LocalServeAdvertisedURL != "" {
+		if err := isoserve.ValidateMediaURL(*req.LocalServeAdvertisedURL); err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid localServeAdvertisedURL: %v", err)})
+		}
+	}
+
+	// Refuse to enable local serving when no listener was configured at launch:
+	// the enable flag is a gate over an existing listener, never a way to silently
+	// bind a socket.
+	if req.LocalServeEnabled != nil && *req.LocalServeEnabled && h.isoServe == nil {
+		return c.JSON(http.StatusConflict, map[string]string{
+			"error": "cannot enable local serving: no --redfish-serve-addr configured at launch",
+		})
+	}
+
+	if req.DefaultImageURL != nil {
+		if err := h.settings.Set(ctx, SettingDefaultImageURL, *req.DefaultImageURL); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to persist defaultImageURL"})
+		}
+	}
+	if req.LocalServeEnabled != nil {
+		val := "false"
+		if *req.LocalServeEnabled {
+			val = "true"
+		}
+		if err := h.settings.Set(ctx, SettingLocalServeEnabled, val); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to persist localServeEnabled"})
+		}
+	}
+	if req.LocalServeAdvertisedURL != nil {
+		if err := h.settings.Set(ctx, SettingLocalServeAdvertisedURL, *req.LocalServeAdvertisedURL); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to persist localServeAdvertisedURL"})
+		}
+	}
+
+	return h.getImageSourceLocked(c, ctx)
+}
+
+// getImageSourceLocked builds the image-source response under an already-held
+// lock (Update calls it after persisting). It mirrors GetImageSource without
+// re-locking.
+func (h *SettingsHandler) getImageSourceLocked(c echo.Context, ctx context.Context) error {
+	settings, err := h.settings.GetAll(ctx)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to read settings"})
+	}
+	advertised := settings[SettingLocalServeAdvertisedURL]
+	if advertised == "" {
+		advertised = h.seedAdvertisedURL
+	}
+	resp := imageSourceResponse{
+		DefaultImageURL: settings[SettingDefaultImageURL],
+		LocalServe: imageSourceLocalServe{
+			Configured:    h.isoServe != nil,
+			Enabled:       settings[SettingLocalServeEnabled] == "true",
+			AdvertisedURL: advertised,
+		},
+	}
+	if h.isoServe != nil {
+		resp.LocalServe.UsesTLS = h.isoServe.UsesTLS()
+	}
+	return c.JSON(http.StatusOK, resp)
 }

--- a/pkg/handlers/settings_imagesource_test.go
+++ b/pkg/handlers/settings_imagesource_test.go
@@ -1,0 +1,140 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/kairos-io/AuroraBoot/pkg/isoserve"
+	"github.com/labstack/echo/v4"
+)
+
+var _ = Describe("SettingsHandler image-source", func() {
+	var (
+		e        *echo.Echo
+		token    string
+		settings *fakeSettingsStore
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		token = "tok"
+		settings = newFakeSettingsStore()
+	})
+
+	// newHandler builds a settings handler wired with the fake settings store and,
+	// optionally, a launch-configured (non-nil) iso-serve.
+	newHandler := func(withServe bool) *handlers.SettingsHandler {
+		var serve *isoserve.Server
+		if withServe {
+			serve = isoserve.New(isoserve.Config{BaseURL: "http://10.0.0.5:8090"})
+		}
+		return handlers.NewSettingsHandler(&token, "").
+			WithImageSource(settings, serve, "http://10.0.0.5:8090")
+	}
+
+	doGet := func(h *handlers.SettingsHandler) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/image-source", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		Expect(h.GetImageSource(c)).To(Succeed())
+		return rec
+	}
+
+	doPut := func(h *handlers.SettingsHandler, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/settings/image-source", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		Expect(h.UpdateImageSource(c)).To(Succeed())
+		return rec
+	}
+
+	Describe("GET", func() {
+		It("reports configured=false and seeded advertised URL with no listener", func() {
+			rec := doGet(newHandler(false))
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var resp struct {
+				DefaultImageURL string `json:"defaultImageURL"`
+				LocalServe      struct {
+					Configured    bool   `json:"configured"`
+					Enabled       bool   `json:"enabled"`
+					AdvertisedURL string `json:"advertisedURL"`
+					UsesTLS       bool   `json:"usesTLS"`
+				} `json:"localServe"`
+			}
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.LocalServe.Configured).To(BeFalse())
+			Expect(resp.LocalServe.Enabled).To(BeFalse())
+			Expect(resp.LocalServe.AdvertisedURL).To(Equal("http://10.0.0.5:8090"))
+		})
+
+		It("reports configured=true when a listener is wired", func() {
+			rec := doGet(newHandler(true))
+			var resp struct {
+				LocalServe struct {
+					Configured bool `json:"configured"`
+				} `json:"localServe"`
+			}
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.LocalServe.Configured).To(BeTrue())
+		})
+
+		It("returns the persisted default image URL", func() {
+			settings.values[handlers.SettingDefaultImageURL] = "https://10.0.0.5/os.iso"
+			rec := doGet(newHandler(false))
+			var resp struct {
+				DefaultImageURL string `json:"defaultImageURL"`
+			}
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.DefaultImageURL).To(Equal("https://10.0.0.5/os.iso"))
+		})
+	})
+
+	Describe("PUT", func() {
+		It("persists a valid default image URL", func() {
+			rec := doPut(newHandler(false), `{"defaultImageURL":"https://10.0.0.5/os.iso"}`)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(settings.values[handlers.SettingDefaultImageURL]).To(Equal("https://10.0.0.5/os.iso"))
+		})
+
+		It("rejects an SSRF-blocked default image URL with 400", func() {
+			rec := doPut(newHandler(false), `{"defaultImageURL":"http://169.254.169.254/x.iso"}`)
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			Expect(rec.Body.String()).To(ContainSubstring("invalid defaultImageURL"))
+			Expect(settings.values).NotTo(HaveKey(handlers.SettingDefaultImageURL))
+		})
+
+		It("allows clearing the default image URL with an empty string", func() {
+			settings.values[handlers.SettingDefaultImageURL] = "https://10.0.0.5/os.iso"
+			rec := doPut(newHandler(false), `{"defaultImageURL":""}`)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(settings.values[handlers.SettingDefaultImageURL]).To(BeEmpty())
+		})
+
+		It("rejects enabling local serve with 409 when no listener is configured", func() {
+			rec := doPut(newHandler(false), `{"localServeEnabled":true}`)
+			Expect(rec.Code).To(Equal(http.StatusConflict))
+			Expect(rec.Body.String()).To(ContainSubstring("no --redfish-serve-addr"))
+			Expect(settings.values).NotTo(HaveKey(handlers.SettingLocalServeEnabled))
+		})
+
+		It("enables local serve when a listener is configured", func() {
+			rec := doPut(newHandler(true), `{"localServeEnabled":true}`)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(settings.values[handlers.SettingLocalServeEnabled]).To(Equal("true"))
+		})
+
+		It("rejects an SSRF-blocked advertised URL with 400", func() {
+			rec := doPut(newHandler(true), `{"localServeAdvertisedURL":"http://169.254.169.254/"}`)
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			Expect(rec.Body.String()).To(ContainSubstring("invalid localServeAdvertisedURL"))
+		})
+	})
+})

--- a/pkg/redfish/deployer.go
+++ b/pkg/redfish/deployer.go
@@ -107,7 +107,11 @@ func NewDeployer(cfg Config) *Deployer {
 		timeout:   timeout,
 		systemID:  cfg.SystemID,
 		authMode:  authMode,
-		quirks:    quirksFor(vendor),
+		// Resolve through the process-wide registry: name-first (operator/built-in),
+		// then the VendorType mapping, then generic. This honours operator-supplied
+		// profiles installed via SetDefaultRegistry while preserving the invariant
+		// that an unknown vendor/name resolves to the spec-default generic profile.
+		quirks: resolveQuirks(string(vendor)),
 	}
 }
 

--- a/pkg/redfish/deployer.go
+++ b/pkg/redfish/deployer.go
@@ -197,45 +197,62 @@ func (d *Deployer) resolveBasicAuth(ctx context.Context) (bool, error) {
 // the defensive HTTP client (cross-origin redirect reject + body cap + TLS-verify
 // honouring Insecure). The endpoint URL it fetches carries no credentials.
 func (d *Deployer) serviceRootHasSessionService(ctx context.Context) (bool, error) {
-	rootURL := strings.TrimRight(d.endpoint, "/") + "/redfish/v1/"
+	root, err := fetchServiceRoot(ctx, d.endpoint, !d.verifySSL)
+	if err != nil {
+		return false, err
+	}
+	return root.SessionService.ODataID != "" || root.Links.Sessions.ODataID != "", nil
+}
 
-	client := newDefensiveHTTPClient(!d.verifySSL)
+// serviceRoot is the minimal subset of the Redfish ServiceRoot we parse for the
+// session-free reachability checks (auth-mode detection and Ping).
+type serviceRoot struct {
+	SessionService struct {
+		ODataID string `json:"@odata.id"`
+	} `json:"SessionService"`
+	Links struct {
+		Sessions struct {
+			ODataID string `json:"@odata.id"`
+		} `json:"Sessions"`
+	} `json:"Links"`
+}
+
+// fetchServiceRoot performs an unauthenticated GET of {endpoint}/redfish/v1/ using
+// the defensive HTTP client (cross-origin redirect reject + body cap + TLS-verify
+// honouring insecure) and parses the minimal ServiceRoot shape. It sends NO
+// credentials and creates NO session, so it never adds to a BMC's session count.
+// A non-2xx status (including 401 on hardened BMCs) or an unparseable body is an
+// error. The endpoint URL it fetches carries no credentials.
+func fetchServiceRoot(ctx context.Context, endpoint string, insecure bool) (*serviceRoot, error) {
+	rootURL := strings.TrimRight(endpoint, "/") + "/redfish/v1/"
+
+	client := newDefensiveHTTPClient(insecure)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rootURL, nil)
 	if err != nil {
-		return false, fmt.Errorf("building ServiceRoot request: %w", err)
+		return nil, fmt.Errorf("building ServiceRoot request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return false, fmt.Errorf("fetching ServiceRoot: %w", err)
+		return nil, fmt.Errorf("fetching ServiceRoot: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return false, fmt.Errorf("fetching ServiceRoot: unexpected status %d", resp.StatusCode)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetching ServiceRoot: unexpected status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return false, fmt.Errorf("reading ServiceRoot: %w", err)
+		return nil, fmt.Errorf("reading ServiceRoot: %w", err)
 	}
 
-	var root struct {
-		SessionService struct {
-			ODataID string `json:"@odata.id"`
-		} `json:"SessionService"`
-		Links struct {
-			Sessions struct {
-				ODataID string `json:"@odata.id"`
-			} `json:"Sessions"`
-		} `json:"Links"`
-	}
+	var root serviceRoot
 	if err := json.Unmarshal(body, &root); err != nil {
-		return false, fmt.Errorf("parsing ServiceRoot: %w", err)
+		return nil, fmt.Errorf("parsing ServiceRoot: %w", err)
 	}
-
-	return root.SessionService.ODataID != "" || root.Links.Sessions.ODataID != "", nil
+	return &root, nil
 }
 
 // Close drops the connection. For session auth it logs the Redfish session out
@@ -619,15 +636,5 @@ func (d *Deployer) pollTask(ctx context.Context, uri string, report progressFunc
 // gofish does not place credentials in error strings, but a creds-bearing URL
 // could theoretically appear; redact basic-auth userinfo defensively.
 func (d *Deployer) scrub(err error) error {
-	if err == nil {
-		return nil
-	}
-	msg := err.Error()
-	if d.password != "" {
-		msg = strings.ReplaceAll(msg, d.password, "[REDACTED]")
-	}
-	if msg == err.Error() {
-		return err
-	}
-	return errors.New(msg)
+	return scrubError(err, d.password)
 }

--- a/pkg/redfish/deployer.go
+++ b/pkg/redfish/deployer.go
@@ -391,17 +391,93 @@ func (d *Deployer) Deploy(ctx context.Context, req DeployRequest) (*DeployResult
 		}
 	}
 
-	// 5. Optionally eject. Most flows leave the media mounted across the install
-	//    reboot, so this is opt-in.
-	if req.EjectAfter {
-		if _, err := media.EjectMedia(); err != nil {
-			return result, fmt.Errorf("ejecting virtual media: %w", d.scrub(err))
-		}
-	}
+	// NOTE: media is intentionally NOT ejected here. Ejecting at deploy-Task
+	// completion is mid-install — the BMC is still booting the installer ISO. On
+	// BMCs that honour the one-time boot override the media can stay mounted across
+	// the install reboot harmlessly; on BMCs that ignore it, ejecting now would not
+	// help and ejecting at the wrong moment can disrupt the running install. Eject
+	// is decoupled into Finalize, driven by an "OS is up" signal (phone-home or a
+	// manual operator action). req.EjectAfter is deprecated and ignored.
 
 	report("completed", 100)
 	result.FinishedAt = time.Now()
 	return result, nil
+}
+
+// Finalize ejects the virtual media and best-effort steers the next boot to disk.
+// It is the signal-driven counterpart to Deploy: call it once the freshly-installed
+// OS is up (phone-home) or on an explicit operator action, NOT at deploy-Task
+// completion. The eject is load-bearing — it is what breaks the post-install
+// install loop on BMCs that ignore the one-time boot override, because an empty CD
+// falls through to disk. The boot-to-disk PATCH is opportunistic: some BMCs/emulators
+// (sushy-tools) error on a PATCH that clears the boot source, and the lab confirmed
+// eject alone is sufficient, so a boot-PATCH error is logged and swallowed rather
+// than failing the finalize.
+//
+// Flow: selectSystem (honours SystemID) -> findCDMedia -> EjectMedia -> opportunistic
+// boot-to-disk. The caller owns Connect/Close (session teardown), mirroring Deploy.
+func (d *Deployer) Finalize(ctx context.Context, req FinalizeRequest) error {
+	if d.client == nil {
+		return errors.New("not connected: call Connect first")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	report := newProgressReporter(req.Progress)
+
+	report("discovering", 20)
+	system, err := d.selectSystem()
+	if err != nil {
+		return err
+	}
+
+	media, err := d.findCDMedia(system)
+	if err != nil {
+		return err
+	}
+
+	// Eject is load-bearing: this is the step that breaks the install loop.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	report("ejecting media", 60)
+	if _, err := media.EjectMedia(); err != nil {
+		return fmt.Errorf("ejecting virtual media: %w", d.scrub(enrichRedfishError(err)))
+	}
+
+	// Best-effort boot-to-disk. Never fail Finalize on a boot-PATCH error: eject
+	// alone already breaks the loop, and some BMCs reject clearing the boot source.
+	report("boot to disk", 80)
+	d.bootToDisk(system)
+
+	report("completed", 100)
+	return nil
+}
+
+// bootToDisk best-effort steers the next boot to disk. It first tries to clear the
+// one-time boot override (BootSourceOverrideEnabled: Disabled), which on a
+// spec-compliant BMC drops back to the persistent BIOS/UEFI boot order (now the
+// freshly-installed disk). If that PATCH errors (sushy-tools has been observed to
+// reject clearing the source), it falls back to an explicit one-time Hdd override.
+// Both errors are logged credential-free and swallowed — see Finalize.
+func (d *Deployer) bootToDisk(system *schemas.ComputerSystem) {
+	disabled := &schemas.Boot{
+		BootSourceOverrideEnabled: schemas.DisabledBootSourceOverrideEnabled,
+	}
+	if err := system.SetBoot(disabled); err == nil {
+		return
+	} else {
+		log.Printf("redfish: clearing boot override failed (eject already broke the loop); trying one-time Hdd: %v", d.scrub(enrichRedfishError(err)))
+	}
+
+	hdd := &schemas.Boot{
+		BootSourceOverrideEnabled: schemas.OnceBootSourceOverrideEnabled,
+		BootSourceOverrideTarget:  schemas.HddBootSource,
+	}
+	if err := system.SetBoot(hdd); err != nil {
+		log.Printf("redfish: one-time Hdd boot override also failed (eject already broke the loop, proceeding): %v", d.scrub(enrichRedfishError(err)))
+	}
 }
 
 // selectSystem discovers the Systems collection and resolves the single

--- a/pkg/redfish/deployer.go
+++ b/pkg/redfish/deployer.go
@@ -25,6 +25,17 @@ import (
 // context aborts promptly.
 const taskPollInterval = 3 * time.Second
 
+// powerOffTimeout bounds how long Finalize's power-cycle path waits for the system
+// to reach the Off PowerState after the shutdown request. It is deliberately short:
+// a graceful shutdown that has not landed within this window is escalated to a
+// ForceOff, and if even the off-poll never reports Off we proceed with the eject
+// anyway (the eject is what breaks the install loop). Honour ctx alongside it.
+const powerOffTimeout = 60 * time.Second
+
+// powerPollInterval is the delay between PowerState polls during the power-cycle
+// finalize. Kept modest so a cancelled context aborts promptly.
+const powerPollInterval = 3 * time.Second
+
 // Deployer drives a Redfish virtual-media deployment against one BMC. Create it
 // with NewDeployer, call Connect, defer Close (which logs the session out), then
 // Inspect and/or Deploy. It is not safe for concurrent use.
@@ -414,8 +425,16 @@ func (d *Deployer) Deploy(ctx context.Context, req DeployRequest) (*DeployResult
 // eject alone is sufficient, so a boot-PATCH error is logged and swallowed rather
 // than failing the finalize.
 //
-// Flow: selectSystem (honours SystemID) -> findCDMedia -> EjectMedia -> opportunistic
-// boot-to-disk. The caller owns Connect/Close (session teardown), mirroring Deploy.
+// Flow (default, in-place): selectSystem (honours SystemID) -> findCDMedia ->
+// EjectMedia -> opportunistic boot-to-disk. The caller owns Connect/Close (session
+// teardown), mirroring Deploy.
+//
+// Flow (req.PowerCycle): selectSystem -> findCDMedia -> power OFF (GracefulShutdown,
+// escalating to ForceOff, polled to the Off PowerState within powerOffTimeout) ->
+// EjectMedia (now applied while the machine is off) -> opportunistic boot-to-disk ->
+// power ON. This is the robust mode for BMCs/emulators that do not apply a live eject.
+// The power-off poll degrades gracefully: a poll timeout is logged and the eject is
+// attempted anyway rather than aborting the whole finalize.
 func (d *Deployer) Finalize(ctx context.Context, req FinalizeRequest) error {
 	if d.client == nil {
 		return errors.New("not connected: call Connect first")
@@ -437,6 +456,10 @@ func (d *Deployer) Finalize(ctx context.Context, req FinalizeRequest) error {
 		return err
 	}
 
+	if req.PowerCycle {
+		return d.finalizePowerCycle(ctx, system, media, report)
+	}
+
 	// Eject is load-bearing: this is the step that breaks the install loop.
 	if err := ctx.Err(); err != nil {
 		return err
@@ -453,6 +476,129 @@ func (d *Deployer) Finalize(ctx context.Context, req FinalizeRequest) error {
 
 	report("completed", 100)
 	return nil
+}
+
+// finalizePowerCycle runs the opt-in power-cycle finalize: power off -> eject ->
+// boot-to-disk -> power on. It is the robust path for BMCs/emulators that report a
+// live eject but keep the running machine booting the ISO; performing the eject while
+// the system is powered off forces the BMC to apply it.
+//
+// The power-off is graceful-first (GracefulShutdown, falling back to ForceOff if the
+// system has not reached Off within powerOffTimeout) and the PowerState is polled to
+// Off. A power-off poll timeout is NON-fatal: it is logged and the eject proceeds, so
+// a stubborn power-state report never blocks the load-bearing eject. Context
+// cancellation is honoured throughout. The final power-on is a best-effort On Reset.
+func (d *Deployer) finalizePowerCycle(ctx context.Context, system *schemas.ComputerSystem, media *schemas.VirtualMedia, report progressFunc) error {
+	// 1. Power off (graceful first, escalate to ForceOff, poll to Off). A timeout
+	//    here is logged and swallowed: we still eject below.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	report("powering off", 40)
+	if err := d.powerOff(ctx, system); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		// Degrade gracefully: a power-off poll timeout (or a transient reset error)
+		// must not abort the finalize — proceed to the load-bearing eject regardless.
+		log.Printf("redfish: power-off before eject did not confirm Off (proceeding to eject anyway): %v", d.scrub(err))
+	}
+
+	// 2. Eject is load-bearing and now applied while the system is off.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	report("ejecting media", 60)
+	if _, err := media.EjectMedia(); err != nil {
+		return fmt.Errorf("ejecting virtual media: %w", d.scrub(enrichRedfishError(err)))
+	}
+
+	// 3. Best-effort boot-to-disk, same as the in-place path.
+	report("boot to disk", 80)
+	d.bootToDisk(system)
+
+	// 4. Power back on. Best-effort: the eject already broke the loop; a power-on
+	//    failure is logged, not fatal, so operators can still power the node on.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	report("powering on", 90)
+	if _, err := system.Reset(schemas.OnResetType); err != nil {
+		log.Printf("redfish: powering system back on after eject failed (media is ejected; power it on manually): %v", d.scrub(enrichRedfishError(err)))
+	}
+
+	report("completed", 100)
+	return nil
+}
+
+// powerOff drives the system to the Off PowerState. It issues a GracefulShutdown
+// (preferred, validated against the system's allowable values) and polls the
+// PowerState until Off or powerOffTimeout. If the graceful shutdown has not landed
+// within the window it escalates to a ForceOff and polls once more. A system already
+// Off returns immediately. The supplied ctx bounds the whole operation and is honoured
+// during polling; a poll that exhausts powerOffTimeout (but not ctx) returns a
+// non-cancellation error the caller may log-and-proceed on.
+func (d *Deployer) powerOff(ctx context.Context, system *schemas.ComputerSystem) error {
+	if system.PowerState == schemas.OffPowerState {
+		return nil
+	}
+
+	graceful := firstSupportedPowerOff(system, schemas.GracefulShutdownResetType, schemas.ForceOffResetType)
+	if _, err := system.Reset(graceful); err != nil {
+		return fmt.Errorf("requesting power off (%s): %w", graceful, enrichRedfishError(err))
+	}
+
+	if err := d.pollPowerOff(ctx, system); err == nil {
+		return nil
+	} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	// Graceful shutdown did not reach Off in time: escalate to a hard ForceOff and
+	// poll once more. If ForceOff is not advertised we still try it (the BMC will
+	// reject it with a useful error, surfaced by the poll's final state).
+	if force := firstSupportedPowerOff(system, schemas.ForceOffResetType); force != graceful {
+		if _, err := system.Reset(force); err != nil {
+			return fmt.Errorf("requesting forced power off (%s): %w", force, enrichRedfishError(err))
+		}
+	}
+	return d.pollPowerOff(ctx, system)
+}
+
+// pollPowerOff polls the system's PowerState until it reports Off, ctx is cancelled,
+// or powerOffTimeout elapses. It re-fetches the ComputerSystem each tick (the gofish
+// struct is a snapshot; PowerState does not update in place). A timeout returns a
+// non-cancellation error so the caller can degrade gracefully and still eject.
+func (d *Deployer) pollPowerOff(ctx context.Context, system *schemas.ComputerSystem) error {
+	deadline := time.Now().Add(powerOffTimeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		fresh, err := schemas.GetComputerSystem(d.client, system.ODataID)
+		if err == nil && fresh.PowerState == schemas.OffPowerState {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("system did not reach Off PowerState within %s", powerOffTimeout)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(powerPollInterval):
+		}
+	}
+}
+
+// firstSupportedPowerOff returns the first preference advertised in the system's
+// allowable ResetTypes; when the system advertises nothing it returns the first
+// preference unchanged (the BMC then rejects an unsupported type with a useful error).
+func firstSupportedPowerOff(system *schemas.ComputerSystem, preferences ...schemas.ResetType) schemas.ResetType {
+	allowed, _ := system.GetSupportedResetTypes()
+	return firstSupported(allowed, preferences...)
 }
 
 // bootToDisk best-effort steers the next boot to disk. It first tries to clear the

--- a/pkg/redfish/deployer.go
+++ b/pkg/redfish/deployer.go
@@ -320,7 +320,7 @@ func (d *Deployer) Deploy(ctx context.Context, req DeployRequest) (*DeployResult
 	}
 	result.SystemID = system.ID
 
-	media, err := d.findCDMedia(system)
+	media, mediaView, err := d.findCDMedia(system)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (d *Deployer) Deploy(ctx context.Context, req DeployRequest) (*DeployResult
 		return nil, err
 	}
 	report("inserting media", 30)
-	insertTask, err := d.insertMedia(media, req)
+	insertTask, err := d.insertMedia(media, mediaView, req)
 	if err != nil {
 		return nil, fmt.Errorf("inserting virtual media: %w", d.scrub(enrichRedfishError(err)))
 	}
@@ -444,43 +444,123 @@ func systemIDs(systems []*schemas.ComputerSystem) []string {
 // System first, then each Manager; a vendor quirk profile (e.g. HPE iLO) may
 // reorder this. A member with no advertised MediaTypes is accepted as a last
 // resort (some BMCs omit the field).
-func (d *Deployer) findCDMedia(system *schemas.ComputerSystem) (*schemas.VirtualMedia, error) {
-	collections := d.defaultMediaCollections(system)
+//
+// The mediaSearch quirk hook works over a read-only []MediaView (the §2 boundary):
+// the core flattens the spec-default collections into the candidate list, lets the
+// hook return an ordering of indexes, then maps those indexes back to its own
+// *VirtualMedia slice (out-of-range/duplicate indexes dropped). The hook never
+// sees a gofish object or the *Deployer.
+func (d *Deployer) findCDMedia(system *schemas.ComputerSystem) (*schemas.VirtualMedia, MediaView, error) {
+	candidates, views := d.mediaCandidates(system)
+
+	order := defaultMediaOrder(len(candidates))
 	if d.quirks.mediaSearch != nil {
-		if reordered := d.quirks.mediaSearch(d, system, collections); reordered != nil {
-			collections = reordered
+		if reordered := sanitizeMediaOrder(d.quirks.mediaSearch(views), len(candidates)); len(reordered) > 0 {
+			order = reordered
 		}
 	}
 
-	var fallback *schemas.VirtualMedia
-	for _, media := range collections {
-		for _, vm := range media {
-			if mediaSupportsCD(vm) {
-				return vm, nil
-			}
-			if fallback == nil && len(vm.MediaTypes) == 0 {
-				fallback = vm
-			}
+	fallback := -1
+	for _, i := range order {
+		if mediaSupportsCD(candidates[i]) {
+			return candidates[i], views[i], nil
+		}
+		if fallback < 0 && len(candidates[i].MediaTypes) == 0 {
+			fallback = i
 		}
 	}
-	if fallback != nil {
-		return fallback, nil
+	if fallback >= 0 {
+		return candidates[fallback], views[fallback], nil
 	}
-	return nil, errors.New("no CD/DVD-capable VirtualMedia resource found on the system or its managers")
+	return nil, MediaView{}, errors.New("no CD/DVD-capable VirtualMedia resource found on the system or its managers")
 }
 
-// defaultMediaCollections returns the spec-default VirtualMedia search set:
-// System-hosted media first, then each Manager's media. quirk profiles receive
-// this as their starting point.
-func (d *Deployer) defaultMediaCollections(system *schemas.ComputerSystem) mediaCollections {
-	collections := d.systemMediaCollections(system)
-	collections = append(collections, d.managerMediaCollections()...)
-	return collections
+// mediaCandidates flattens the spec-default VirtualMedia collections (System-hosted
+// first, then each Manager's) into a parallel pair: the gofish members the core
+// will act on, and their read-only MediaView projections handed to a quirk hook.
+// The two slices share indexes, which is how a hook's returned ordering maps back
+// to the real members. Manager-hosted members are labelled "manager:<id>" and
+// System-hosted ones "system" so a profile can select by location.
+func (d *Deployer) mediaCandidates(system *schemas.ComputerSystem) ([]*schemas.VirtualMedia, []MediaView) {
+	var (
+		members []*schemas.VirtualMedia
+		views   []MediaView
+	)
+	add := func(vms []*schemas.VirtualMedia, location string) {
+		for _, vm := range vms {
+			views = append(views, MediaView{
+				Index:        len(members),
+				ID:           vm.ID,
+				Location:     location,
+				MediaTypes:   mediaTypeStrings(vm.MediaTypes),
+				ConnectedVia: string(vm.ConnectedVia),
+				Inserted:     vm.Inserted != nil && *vm.Inserted,
+			})
+			members = append(members, vm)
+		}
+	}
+
+	for _, c := range d.systemMediaCollections(system) {
+		add(c, "system")
+	}
+	if managers, err := d.client.GetService().Managers(); err == nil {
+		for _, m := range managers {
+			if mgrMedia, err := m.VirtualMedia(); err == nil {
+				add(mgrMedia, "manager:"+m.ID)
+			}
+		}
+	}
+	return members, views
+}
+
+// defaultMediaOrder returns the identity ordering 0..n-1, the spec-default search
+// order used when no quirk hook reorders the candidates.
+func defaultMediaOrder(n int) []int {
+	order := make([]int, n)
+	for i := range order {
+		order[i] = i
+	}
+	return order
+}
+
+// sanitizeMediaOrder constrains a quirk hook's returned ordering to valid,
+// de-duplicated indexes into a candidate list of length n. Out-of-range and
+// duplicate indexes are dropped — a profile can reorder/filter but never conjure a
+// member that does not exist. An empty result tells the caller to fall back to the
+// default order.
+func sanitizeMediaOrder(order []int, n int) []int {
+	if len(order) == 0 {
+		return nil
+	}
+	seen := make(map[int]bool, len(order))
+	out := make([]int, 0, len(order))
+	for _, i := range order {
+		if i < 0 || i >= n || seen[i] {
+			continue
+		}
+		seen[i] = true
+		out = append(out, i)
+	}
+	return out
+}
+
+// mediaTypeStrings projects gofish VirtualMediaType values to plain strings for a
+// MediaView (the boundary carries no gofish types).
+func mediaTypeStrings(types []schemas.VirtualMediaType) []string {
+	if len(types) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(types))
+	for _, t := range types {
+		out = append(out, string(t))
+	}
+	return out
 }
 
 // systemMediaCollections returns the VirtualMedia hosted on the ComputerSystem
 // (zero or one collection). Errors are swallowed: a missing System.VirtualMedia
-// link simply means there is nothing to search there.
+// link simply means there is nothing to search there. mediaCandidates uses it for
+// the System-hosted half of the flat candidate list.
 func (d *Deployer) systemMediaCollections(system *schemas.ComputerSystem) mediaCollections {
 	if sysMedia, err := system.VirtualMedia(); err == nil {
 		return mediaCollections{sysMedia}
@@ -488,27 +568,12 @@ func (d *Deployer) systemMediaCollections(system *schemas.ComputerSystem) mediaC
 	return nil
 }
 
-// managerMediaCollections returns the VirtualMedia hosted on each Manager. This is
-// where HPE iLO (and many BMCs) expose virtual media. Errors are swallowed per
-// manager so one unreadable manager does not hide the others.
-func (d *Deployer) managerMediaCollections() mediaCollections {
-	var collections mediaCollections
-	if managers, err := d.client.GetService().Managers(); err == nil {
-		for _, m := range managers {
-			if mgrMedia, err := m.VirtualMedia(); err == nil {
-				collections = append(collections, mgrMedia)
-			}
-		}
-	}
-	return collections
-}
-
 // insertMedia performs the media insertion. By default this is the spec
 // VirtualMedia.InsertMedia URL-pull action; a vendor profile may take over via the
 // pushMedia hook (a stub seam for a future multipart push — no profile uses it
 // today). The InsertMedia parameters and MediaType flow through the quirk profile
 // so a vendor can tweak them without re-implementing the flow.
-func (d *Deployer) insertMedia(media *schemas.VirtualMedia, req DeployRequest) (*schemas.TaskMonitorInfo, error) {
+func (d *Deployer) insertMedia(media *schemas.VirtualMedia, view MediaView, req DeployRequest) (*schemas.TaskMonitorInfo, error) {
 	// Future multipart-push extension point. No profile implements it yet; the
 	// default (nil hook) always falls through to the URL-pull InsertMedia below.
 	if d.quirks.pushMedia != nil {
@@ -522,7 +587,7 @@ func (d *Deployer) insertMedia(media *schemas.VirtualMedia, req DeployRequest) (
 
 	mediaType := schemas.CDVirtualMediaType
 	if d.quirks.mediaType != nil {
-		mediaType = d.quirks.mediaType(media)
+		mediaType = d.quirks.mediaType(view)
 	}
 
 	params := &schemas.VirtualMediaInsertMediaParameters{
@@ -537,11 +602,60 @@ func (d *Deployer) insertMedia(media *schemas.VirtualMedia, req DeployRequest) (
 	}
 	params.TransferProtocolType = &protocol
 
+	// tuneInsertParams works over a read-only InsertParamsView (which carries NO
+	// image URL) and returns a sparse patch the core applies to the allowlisted
+	// fields. The image URL is core-owned and SSRF-validated, so it is structurally
+	// out of a profile's reach.
 	if d.quirks.tuneInsertParams != nil {
-		d.quirks.tuneInsertParams(params, req)
+		applyInsertPatch(params, d.quirks.tuneInsertParams(insertParamsView(params)))
 	}
 
 	return media.InsertMedia(params)
+}
+
+// insertParamsView projects the spec-default InsertMedia parameters into the
+// read-only InsertParamsView handed to the tuneInsertParams hook. It deliberately
+// drops the image URL, exposing only HasImage.
+func insertParamsView(p *schemas.VirtualMediaInsertMediaParameters) InsertParamsView {
+	v := InsertParamsView{
+		MediaType: string(p.MediaType),
+		HasImage:  p.Image != "",
+	}
+	if p.TransferProtocolType != nil {
+		v.TransferProtocolType = string(*p.TransferProtocolType)
+	}
+	if p.Inserted != nil {
+		v.Inserted, v.InsertedSet = *p.Inserted, true
+	}
+	if p.WriteProtected != nil {
+		v.WriteProtected, v.WriteProtectedSet = *p.WriteProtected, true
+	}
+	return v
+}
+
+// applyInsertPatch applies a tuneInsertParams hook's sparse patch to the
+// InsertMedia parameters. Only the allowlisted fields are reachable; the image URL
+// is never touched. Clear takes precedence over Set for TransferProtocolType so a
+// profile can unconditionally drop it.
+func applyInsertPatch(p *schemas.VirtualMediaInsertMediaParameters, patch InsertParamsPatch) {
+	if patch.SetMediaType != "" {
+		p.MediaType = schemas.VirtualMediaType(patch.SetMediaType)
+	}
+	switch {
+	case patch.ClearTransferProtocolType:
+		p.TransferProtocolType = nil
+	case patch.SetTransferProtocolType != "":
+		t := schemas.TransferProtocolType(patch.SetTransferProtocolType)
+		p.TransferProtocolType = &t
+	}
+	if patch.SetInsertedSet {
+		v := patch.SetInserted
+		p.Inserted = &v
+	}
+	if patch.SetWriteProtectedSet {
+		v := patch.SetWriteProtected
+		p.WriteProtected = &v
+	}
 }
 
 // setOneTimeBoot patches the system to boot once from the requested target. The
@@ -565,17 +679,43 @@ func (d *Deployer) setOneTimeBoot(system *schemas.ComputerSystem, req DeployRequ
 // reset powers/restarts the system using an explicit ResetType. The caller can
 // force a ResetType; otherwise one is chosen from the current power state and
 // validated against the system's allowable values.
+//
+// A vendor profile may prefer a different ResetType via the resetType hook (over a
+// read-only ResetView). It only runs when the caller did not force one, so an
+// explicit DeployRequest.ResetType always wins. The hook's preference is still
+// re-validated against the system's advertised allowable values (firstSupported):
+// a profile can prefer but never force an unsupported type.
 func (d *Deployer) reset(system *schemas.ComputerSystem, req DeployRequest) (*schemas.TaskMonitorInfo, error) {
 	rt := schemas.ResetType(req.ResetType)
 	if rt == "" {
 		rt = chooseResetType(system)
-		// A vendor profile may prefer a different ResetType. It only runs when the
-		// caller did not force one, so an explicit DeployRequest.ResetType always wins.
 		if d.quirks.resetType != nil {
-			rt = d.quirks.resetType(system, rt)
+			allowed, _ := system.GetSupportedResetTypes()
+			preferred := d.quirks.resetType(ResetView{
+				PowerState:          string(system.PowerState),
+				AllowableResetTypes: resetTypeStrings(allowed),
+				Default:             string(rt),
+			})
+			// Re-validate the hook's preference: if the BMC advertises allowable
+			// values and the preference is not among them, fall back to the core
+			// default rather than sending an unsupported type.
+			rt = firstSupported(allowed, preferred, rt)
 		}
 	}
 	return system.Reset(rt)
+}
+
+// resetTypeStrings projects gofish ResetType values to plain strings for a
+// ResetView (the boundary carries no gofish types).
+func resetTypeStrings(types []schemas.ResetType) []string {
+	if len(types) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(types))
+	for _, t := range types {
+		out = append(out, string(t))
+	}
+	return out
 }
 
 // pollTask GETs the Task at uri repeatedly until it reaches a terminal state or

--- a/pkg/redfish/deployer_test.go
+++ b/pkg/redfish/deployer_test.go
@@ -173,6 +173,23 @@ var _ = Describe("Deployer", func() {
 			Expect(bmc.sawRequest(http.MethodDelete, bmc.sessionLocation)).To(BeTrue())
 		})
 
+		It("never ejects media during Deploy, even with the deprecated EjectAfter set", func() {
+			// The mid-install eject is GONE: ejecting at deploy-Task completion is the
+			// wrong moment (the install loop). Setting the deprecated EjectAfter must
+			// have no effect — eject is now Finalize's job.
+			Expect(d.Connect(ctx)).To(Succeed())
+			defer func() { _ = d.Close() }()
+
+			_, err := d.Deploy(ctx, redfish.DeployRequest{
+				ImageURL:   testImageURL,
+				BootTarget: redfish.BootTargetCd,
+				EjectAfter: true, // deprecated, must be ignored
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bmc.ejectCalled).To(BeFalse())
+			Expect(bmc.sawRequest(http.MethodPost, "/redfish/v1/Systems/sys-xyz/VirtualMedia/Cd/Actions/VirtualMedia.EjectMedia")).To(BeFalse())
+		})
+
 		It("sends BootSourceOverrideMode=UEFI when BootModeUEFI is explicitly requested", func() {
 			Expect(d.Connect(ctx)).To(Succeed())
 			defer func() { _ = d.Close() }()

--- a/pkg/redfish/export_test.go
+++ b/pkg/redfish/export_test.go
@@ -1,0 +1,31 @@
+package redfish
+
+// This file exposes a few internal seams to the external redfish_test package so
+// the fake-BMC-driven specs can exercise compiled quirk profiles end-to-end
+// without making the quirks seam itself public. It is compiled only under `go
+// test`.
+
+// InstallProfileForTest compiles a YAML quirk profile and installs it on the
+// Deployer, replacing whatever profile NewDeployer selected. It lets a spec drive
+// a YAML-compiled profile through the same flow as the in-tree Go profiles, which
+// is how the YAML-ilo ≡ Go-ilo equivalence is asserted.
+func (d *Deployer) InstallProfileForTest(yamlProfile []byte) error {
+	q, err := LoadProfile(yamlProfile)
+	if err != nil {
+		return err
+	}
+	d.quirks = q
+	return nil
+}
+
+// InstallGoProfileForTest installs the named in-tree Go profile on the Deployer
+// (e.g. "ilo"), so a spec can pin the Go producer regardless of VendorType
+// selection. It reports whether the name was known.
+func (d *Deployer) InstallGoProfileForTest(name string) bool {
+	q, ok := quirksByName(name)
+	if !ok {
+		return false
+	}
+	d.quirks = q
+	return true
+}

--- a/pkg/redfish/fakebmc_test.go
+++ b/pkg/redfish/fakebmc_test.go
@@ -194,10 +194,10 @@ func (f *fakeBMC) handle(w http.ResponseWriter, r *http.Request) {
 		f.mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 		f.writeJSON(w, f.computerSystem(f.systemIDFromPath(r.URL.Path)))
-	case f.isSystemResetPath(r.URL.Path) && r.Method == http.MethodPost:
+	case strings.HasSuffix(r.URL.Path, "/Actions/ComputerSystem.Reset") && r.Method == http.MethodPost:
 		f.mu.Lock()
 		f.resetBody = decodeBody(r)
-		f.resetSystemID = f.systemIDFromResetPath(r.URL.Path)
+		f.resetSystemID = resetSystemIDFromPath(r.URL.Path)
 		f.mu.Unlock()
 		w.Header().Set("Location", "/redfish/v1/TaskService/Tasks/task-1")
 		w.WriteHeader(http.StatusAccepted)
@@ -219,7 +219,7 @@ func (f *fakeBMC) handle(w http.ResponseWriter, r *http.Request) {
 		f.writeJSON(w, f.collection("VirtualMedia Collection", "/redfish/v1/Managers/mgr-1/VirtualMedia/Cd"))
 	case r.URL.Path == "/redfish/v1/Managers/mgr-1/VirtualMedia/Cd" && r.Method == http.MethodGet:
 		f.writeJSON(w, f.virtualMedia("/redfish/v1/Managers/mgr-1/VirtualMedia/Cd"))
-	case strings.HasSuffix(r.URL.Path, "/VirtualMedia/Cd/Actions/VirtualMedia.InsertMedia") && r.Method == http.MethodPost:
+	case strings.HasSuffix(r.URL.Path, "/Actions/VirtualMedia.InsertMedia") && r.Method == http.MethodPost:
 		f.mu.Lock()
 		f.insertBody = decodeBody(r)
 		status := f.insertMediaStatus
@@ -245,7 +245,7 @@ func (f *fakeBMC) handle(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Location", "/redfish/v1/TaskService/Tasks/task-insert")
 		w.WriteHeader(http.StatusAccepted)
 		f.writeJSON(w, f.task("Running"))
-	case strings.HasSuffix(r.URL.Path, "/VirtualMedia/Cd/Actions/VirtualMedia.EjectMedia") && r.Method == http.MethodPost:
+	case strings.HasSuffix(r.URL.Path, "/Actions/VirtualMedia.EjectMedia") && r.Method == http.MethodPost:
 		w.WriteHeader(http.StatusNoContent)
 
 	// --- tasks ---
@@ -345,17 +345,19 @@ func (f *fakeBMC) systemIDFromPath(path string) string {
 	return rest
 }
 
-func (f *fakeBMC) isSystemResetPath(path string) bool {
-	return f.systemIDFromResetPath(path) != ""
-}
-
-func (f *fakeBMC) systemIDFromResetPath(path string) string {
+// resetSystemIDFromPath extracts the ComputerSystem Id from a Reset action path
+// (/redfish/v1/Systems/{id}/Actions/ComputerSystem.Reset). Unlike the GET/PATCH
+// member routing it does NOT gate on the configured systemIDs: the Reset handler
+// is matched purely by its action suffix so it works for both the synthesized
+// fake (sys-xyz / node-*) and a recorded mockup tree (e.g. iLO's "1"). Returns ""
+// when the path is not a System Reset action.
+func resetSystemIDFromPath(path string) string {
 	rest, ok := strings.CutPrefix(path, "/redfish/v1/Systems/")
 	if !ok {
 		return ""
 	}
 	id, ok := strings.CutSuffix(rest, "/Actions/ComputerSystem.Reset")
-	if !ok || strings.Contains(id, "/") || !f.knownSystemID(id) {
+	if !ok || strings.Contains(id, "/") {
 		return ""
 	}
 	return id

--- a/pkg/redfish/fakebmc_test.go
+++ b/pkg/redfish/fakebmc_test.go
@@ -72,6 +72,15 @@ type fakeBMC struct {
 	// resetSystemID records the Id of the ComputerSystem whose Reset action was
 	// last invoked, so a multi-system spec can assert the correct machine was hit.
 	resetSystemID string
+	// resetTypes records every ResetType received, in order, so the power-cycle
+	// finalize specs can assert the off->on sequence around the eject.
+	resetTypes []string
+
+	// powerState is the PowerState the ComputerSystem reports. The power-cycle
+	// finalize re-fetches the system and polls this to Off; a GracefulShutdown/
+	// ForceOff Reset flips it to Off so pollPowerOff terminates, an On Reset flips it
+	// back to On. Defaults to "On".
+	powerState string
 }
 
 type recordedRequest struct {
@@ -95,6 +104,8 @@ func newFakeBMC() *fakeBMC {
 		bootModeAllowableValues: []string{"Legacy", "UEFI"},
 		// A single system by default, preserving the original fake's behaviour.
 		systemIDs: []string{"sys-xyz"},
+		// Systems power on by default (matches the computerSystem PowerState below).
+		powerState: "On",
 	}
 	f.server = httptest.NewTLSServer(http.HandlerFunc(f.handle))
 	return f
@@ -132,6 +143,36 @@ func (f *fakeBMC) sawAuthType(authType, pathPrefix string) bool {
 		}
 	}
 	return false
+}
+
+// finalizeEventOrder returns the ordered sequence of the load-bearing finalize
+// actions as they were received: "power-off" (a GracefulShutdown/ForceOff Reset),
+// "eject" (VirtualMedia.EjectMedia), and "power-on" (an On/ForceOn Reset). It lets a
+// power-cycle spec assert the off -> eject -> on ordering. Boot PATCHes and other
+// requests are ignored.
+func (f *fakeBMC) finalizeEventOrder() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	resetIdx := 0
+	var events []string
+	for _, req := range f.requests {
+		switch {
+		case strings.HasSuffix(req.Path, "/Actions/VirtualMedia.EjectMedia") && req.Method == http.MethodPost:
+			events = append(events, "eject")
+		case strings.HasSuffix(req.Path, "/Actions/ComputerSystem.Reset") && req.Method == http.MethodPost:
+			// Map this reset to the ResetType captured at the same ordinal.
+			if resetIdx < len(f.resetTypes) {
+				switch f.resetTypes[resetIdx] {
+				case "GracefulShutdown", "ForceOff":
+					events = append(events, "power-off")
+				case "On", "ForceOn":
+					events = append(events, "power-on")
+				}
+			}
+			resetIdx++
+		}
+	}
+	return events
 }
 
 // sawRequest reports whether a request with the given method and path prefix was
@@ -207,6 +248,17 @@ func (f *fakeBMC) handle(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		f.resetBody = decodeBody(r)
 		f.resetSystemID = f.systemIDFromResetPath(r.URL.Path)
+		if rt, ok := f.resetBody["ResetType"].(string); ok {
+			f.resetTypes = append(f.resetTypes, rt)
+			// Reflect the requested power transition so a power-cycle finalize can
+			// poll PowerState to Off and confirm the On reset afterwards.
+			switch rt {
+			case "GracefulShutdown", "ForceOff":
+				f.powerState = "Off"
+			case "On", "ForceOn":
+				f.powerState = "On"
+			}
+		}
 		f.mu.Unlock()
 		w.Header().Set("Location", "/redfish/v1/TaskService/Tasks/task-1")
 		w.WriteHeader(http.StatusAccepted)
@@ -403,6 +455,12 @@ func (f *fakeBMC) isSystemVirtualMediaCdPath(path string) bool {
 
 func (f *fakeBMC) computerSystem(id string) map[string]any {
 	base := "/redfish/v1/Systems/" + id
+	f.mu.Lock()
+	power := f.powerState
+	f.mu.Unlock()
+	if power == "" {
+		power = "On"
+	}
 	cs := map[string]any{
 		"@odata.id":    base,
 		"@odata.type":  "#ComputerSystem.v1_5_0.ComputerSystem",
@@ -411,7 +469,7 @@ func (f *fakeBMC) computerSystem(id string) map[string]any {
 		"Manufacturer": "ACME",
 		"Model":        "ProLiant-Test",
 		"SerialNumber": "SN-0001",
-		"PowerState":   "On",
+		"PowerState":   power,
 		// Nested summaries: the historical bug read these as flat fields and got
 		// 0/0. They must be populated from the nested objects.
 		"MemorySummary": map[string]any{

--- a/pkg/redfish/fakebmc_test.go
+++ b/pkg/redfish/fakebmc_test.go
@@ -27,6 +27,14 @@ type fakeBMC struct {
 	taskStates        []string
 	taskIdx           int
 
+	// ejectCalled records that the VirtualMedia.EjectMedia action was invoked, so
+	// Finalize specs can assert the load-bearing eject actually fired.
+	ejectCalled bool
+	// bootPatchStatus, when non-zero, is the HTTP status the ComputerSystem boot
+	// PATCH returns. Default 200. Set 4xx/5xx to drive the boot-to-disk error path
+	// and confirm Finalize still succeeds (boot-to-disk is best-effort).
+	bootPatchStatus int
+
 	// noSessionService, when true, serves a ServiceRoot WITHOUT a SessionService
 	// (no top-level SessionService and no Links.Sessions) and returns 404 for the
 	// session-create path, mimicking sushy-tools emulators and BMCs that expose no
@@ -187,7 +195,12 @@ func (f *fakeBMC) handle(w http.ResponseWriter, r *http.Request) {
 	case f.isSystemPath(r.URL.Path) && r.Method == http.MethodPatch:
 		f.mu.Lock()
 		f.bootPatchBody = decodeBody(r)
+		status := f.bootPatchStatus
 		f.mu.Unlock()
+		if status >= 400 {
+			http.Error(w, "boot PATCH rejected", status)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		f.writeJSON(w, f.computerSystem(f.systemIDFromPath(r.URL.Path)))
 	case f.isSystemResetPath(r.URL.Path) && r.Method == http.MethodPost:
@@ -242,6 +255,9 @@ func (f *fakeBMC) handle(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 		f.writeJSON(w, f.task("Running"))
 	case strings.HasSuffix(r.URL.Path, "/VirtualMedia/Cd/Actions/VirtualMedia.EjectMedia") && r.Method == http.MethodPost:
+		f.mu.Lock()
+		f.ejectCalled = true
+		f.mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 
 	// --- tasks ---

--- a/pkg/redfish/fakebmc_test.go
+++ b/pkg/redfish/fakebmc_test.go
@@ -55,6 +55,10 @@ type fakeBMC struct {
 	// SecureBoot feature detection can be asserted.
 	withSecureBoot bool
 
+	// biosVersion, when non-empty, is served as the ComputerSystem BiosVersion so
+	// the probe's firmware reporting can be asserted. Empty omits the field.
+	biosVersion string
+
 	// captured bodies
 	sessionBody     map[string]any
 	insertBody      map[string]any
@@ -419,6 +423,9 @@ func (f *fakeBMC) computerSystem(id string) map[string]any {
 	}
 	if f.withSecureBoot {
 		cs["SecureBoot"] = map[string]any{"@odata.id": base + "/SecureBoot"}
+	}
+	if f.biosVersion != "" {
+		cs["BiosVersion"] = f.biosVersion
 	}
 	return cs
 }

--- a/pkg/redfish/finalize_test.go
+++ b/pkg/redfish/finalize_test.go
@@ -74,4 +74,47 @@ var _ = Describe("Deployer.Finalize", func() {
 		Expect(d.Finalize(cancelled, redfish.FinalizeRequest{})).To(MatchError(context.Canceled))
 		Expect(bmc.ejectCalled).To(BeFalse())
 	})
+
+	It("does NOT power-cycle by default (in-place eject, no power Reset)", func() {
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		Expect(d.Finalize(ctx, redfish.FinalizeRequest{})).To(Succeed())
+
+		Expect(bmc.ejectCalled).To(BeTrue())
+		// No power Reset at all: the in-place path only ejects and boots to disk.
+		Expect(bmc.finalizeEventOrder()).To(Equal([]string{"eject"}))
+	})
+
+	It("with PowerCycle powers off, then ejects, then boots to disk, then powers on", func() {
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		Expect(d.Finalize(ctx, redfish.FinalizeRequest{PowerCycle: true})).To(Succeed())
+
+		// The load-bearing eject fired while the machine was off, and the ordering is
+		// power-off -> eject -> power-on.
+		Expect(bmc.ejectCalled).To(BeTrue())
+		Expect(bmc.finalizeEventOrder()).To(Equal([]string{"power-off", "eject", "power-on"}))
+
+		// The graceful shutdown is preferred for the power-off, On for the power-on.
+		Expect(bmc.resetTypes).To(Equal([]string{"GracefulShutdown", "On"}))
+
+		// The opportunistic boot-to-disk PATCH still fired (after eject, before power-on).
+		Expect(bmc.bootPatchBody).To(HaveKey("Boot"))
+	})
+
+	It("with PowerCycle still ejects when the system is already off", func() {
+		bmc.powerState = "Off"
+
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		Expect(d.Finalize(ctx, redfish.FinalizeRequest{PowerCycle: true})).To(Succeed())
+
+		Expect(bmc.ejectCalled).To(BeTrue())
+		// Already off: no shutdown Reset is issued; only the final power-on Reset runs.
+		Expect(bmc.finalizeEventOrder()).To(Equal([]string{"eject", "power-on"}))
+		Expect(bmc.resetTypes).To(Equal([]string{"On"}))
+	})
 })

--- a/pkg/redfish/finalize_test.go
+++ b/pkg/redfish/finalize_test.go
@@ -1,0 +1,77 @@
+package redfish_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+)
+
+var _ = Describe("Deployer.Finalize", func() {
+	var (
+		bmc *fakeBMC
+		ctx context.Context
+		d   *redfish.Deployer
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		bmc = newFakeBMC()
+		d = redfish.NewDeployer(redfish.Config{
+			Endpoint:  bmc.URL(),
+			Username:  testUser,
+			Password:  testPassword,
+			VerifySSL: false, // fake BMC uses a self-signed TLS cert
+			Timeout:   30 * time.Second,
+		})
+	})
+
+	AfterEach(func() {
+		bmc.Close()
+	})
+
+	It("ejects the virtual media and best-effort boots to disk", func() {
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		Expect(d.Finalize(ctx, redfish.FinalizeRequest{})).To(Succeed())
+
+		// The load-bearing eject fired.
+		Expect(bmc.ejectCalled).To(BeTrue())
+		// The opportunistic boot-to-disk PATCH cleared the boot override.
+		Expect(bmc.bootPatchBody).To(HaveKey("Boot"))
+		boot, ok := bmc.bootPatchBody["Boot"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(boot).To(HaveKeyWithValue("BootSourceOverrideEnabled", "Disabled"))
+	})
+
+	It("still succeeds when the boot-to-disk PATCH errors (boot is best-effort)", func() {
+		// Both the clear-override PATCH and the fallback Hdd PATCH return 500; the
+		// eject must still fire and Finalize must still succeed.
+		bmc.bootPatchStatus = 500
+
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		Expect(d.Finalize(ctx, redfish.FinalizeRequest{})).To(Succeed())
+		Expect(bmc.ejectCalled).To(BeTrue())
+	})
+
+	It("requires a connection", func() {
+		// No Connect: Finalize must refuse rather than nil-panic.
+		Expect(d.Finalize(ctx, redfish.FinalizeRequest{})).To(MatchError(ContainSubstring("not connected")))
+	})
+
+	It("honours a cancelled context before touching the BMC", func() {
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		cancelled, cancel := context.WithCancel(ctx)
+		cancel()
+		Expect(d.Finalize(cancelled, redfish.FinalizeRequest{})).To(MatchError(context.Canceled))
+		Expect(bmc.ejectCalled).To(BeFalse())
+	})
+})

--- a/pkg/redfish/mockup_golden_test.go
+++ b/pkg/redfish/mockup_golden_test.go
@@ -1,0 +1,173 @@
+package redfish_test
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+)
+
+// This is the P4 per-vendor golden test (design §4a). For each (mockup, profile)
+// pair it replays the FULL deploy flow — discover → InsertMedia → boot → reset →
+// task → teardown — against a vendor's recorded DMTF GET tree (served by mockupBMC)
+// and asserts the request sequence the profile must produce. The recorded responses
+// are that vendor's REAL GET bodies (sanitized, hand-authored here for iLO), so the
+// profile is exercised against real-shaped hardware with no metal in CI.
+//
+// Adding the next vendor is one new row: a recorded testdata/mockups/<vendor>/<fw>
+// tree and the profile selected for it. See testdata/mockups/README.md.
+
+// goldenCase is one (recorded mockup, selected profile) pair plus the request
+// sequence the profile is expected to produce against that tree.
+type goldenCase struct {
+	name string
+	// mockupDir is the recorded tree root (the dir holding the "redfish" folder).
+	mockupDir string
+	// vendor selects the in-tree quirk profile under test.
+	vendor redfish.VendorType
+	// wantSystemID / wantMediaID are the discovered Ids the deploy must resolve.
+	wantSystemID string
+	wantMediaID  string
+	// wantInsertPath is the path prefix the InsertMedia POST must hit, proving the
+	// mediaSearch order picked the right (e.g. Manager-hosted) member.
+	wantInsertPath string
+	// wantResetType is the ResetType the profile + firstSupported must select from
+	// the recorded allowable values.
+	wantResetType string
+}
+
+var _ = Describe("Recorded-mockup golden replay", func() {
+	const (
+		goldenUser     = "admin"
+		goldenPassword = "s3cr3t-p@ss"
+		goldenImageURL = "http://serve.example/kairos.iso"
+		iloMockup      = "testdata/mockups/ilo/gen10-ilo5-fw2.44"
+	)
+
+	cases := []goldenCase{
+		{
+			name:           "ilo (HPE) — Manager-hosted CD selected by mediaSearch",
+			mockupDir:      iloMockup,
+			vendor:         redfish.VendorHPE,
+			wantSystemID:   "1",
+			wantMediaID:    "2", // the CD/DVD member (member 1 is Floppy/USBStick)
+			wantInsertPath: "/redfish/v1/Managers/1/VirtualMedia/2/Actions/VirtualMedia.InsertMedia",
+			wantResetType:  "ForceRestart",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		It(tc.name, func() {
+			bmc := newMockupBMC(tc.mockupDir)
+			defer bmc.Close()
+
+			ctx := context.Background()
+			d := redfish.NewDeployer(redfish.Config{
+				Endpoint:  bmc.URL(),
+				Username:  goldenUser,
+				Password:  goldenPassword,
+				Vendor:    tc.vendor,
+				VerifySSL: false, // mockup server uses a self-signed TLS cert
+				Timeout:   30 * time.Second,
+			})
+			Expect(d.Connect(ctx)).To(Succeed())
+
+			result, err := d.Deploy(ctx, redfish.DeployRequest{
+				ImageURL:   goldenImageURL,
+				BootTarget: redfish.BootTargetCd,
+				// BootMode left empty: the deploy must NOT force a firmware mode.
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Discovery resolved the expected system and the expected media member —
+			// for iLO this proves mediaSearch.order picked the Manager-hosted CD over
+			// the Floppy/USB member and over the (absent) System media.
+			Expect(result.SystemID).To(Equal(tc.wantSystemID))
+			Expect(result.MediaID).To(Equal(tc.wantMediaID))
+
+			// InsertMedia hit the chosen member's action, and the body's Image is the
+			// harness's served URL UNCHANGED — proving the profile never rewrote it
+			// (the Image URL is core-owned and SSRF-validated; no profile can touch it).
+			Expect(bmc.sawRequest(http.MethodPost, tc.wantInsertPath)).To(BeTrue(),
+				"InsertMedia must hit the profile-selected media member")
+			Expect(bmc.insertBody()).To(HaveKeyWithValue("Image", goldenImageURL))
+			Expect(bmc.insertBody()).To(HaveKeyWithValue("Inserted", true))
+			Expect(bmc.insertBody()).To(HaveKeyWithValue("WriteProtected", true))
+
+			// Boot PATCH: one-time override to Cd, and — with no BootMode requested —
+			// NO BootSourceOverrideMode (forcing the firmware mode breaks some BMCs).
+			boot, ok := bmc.bootPatchBody()["Boot"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(boot).To(HaveKeyWithValue("BootSourceOverrideEnabled", "Once"))
+			Expect(boot).To(HaveKeyWithValue("BootSourceOverrideTarget", "Cd"))
+			Expect(boot).NotTo(HaveKey("BootSourceOverrideMode"))
+
+			// Reset carried the ResetType firstSupported chose from the RECORDED
+			// allowable values (the system is "On", so ForceRestart, which the
+			// recorded tree advertises).
+			Expect(bmc.resetBody()).To(HaveKeyWithValue("ResetType", tc.wantResetType))
+			Expect(bmc.resetSystemID()).To(Equal(tc.wantSystemID))
+
+			// Async Task polled to a terminal Completed state.
+			Expect(result.TaskCompleted).To(BeTrue())
+			Expect(result.TaskState).To(Equal("Completed"))
+
+			// Teardown invariant: the session is DELETEd on Close even though the GET
+			// tree was recorded (session create/delete are synthesized + recorded).
+			Expect(d.Close()).To(Succeed())
+			Expect(bmc.sawRequest(http.MethodDelete, bmc.sessionLocation())).To(BeTrue(),
+				"the session must be torn down on Close")
+		})
+	}
+
+	// Negative guard / regression value: the profile must actually change the outcome
+	// on a recorded tree. We use a second recorded iLO-shaped tree where BOTH the
+	// System and the Manager expose a CD/DVD member. The spec-default (generic) flat
+	// order is System-first, so generic selects the System CD; the iLO profile's
+	// manager-first mediaSearch selects the Manager CD instead. Same recorded tree,
+	// two profiles, two different InsertMedia targets — proving the profile, not the
+	// harness, drives the selection (this is the regression value of the golden test).
+	It("(negative guard) generic and ilo pick DIFFERENT media on the same recorded tree", func() {
+		const dualMockup = "testdata/mockups/ilo/system-and-manager-cd"
+		ctx := context.Background()
+
+		newDeployer := func(vendor redfish.VendorType) (*redfish.Deployer, *mockupBMC) {
+			bmc := newMockupBMC(dualMockup)
+			d := redfish.NewDeployer(redfish.Config{
+				Endpoint: bmc.URL(), Username: goldenUser, Password: goldenPassword,
+				Vendor: vendor, VerifySSL: false, Timeout: 30 * time.Second,
+			})
+			return d, bmc
+		}
+
+		// generic: spec-default System-first — selects the System-hosted CD.
+		gd, gbmc := newDeployer(redfish.VendorGeneric)
+		defer gbmc.Close()
+		Expect(gd.Connect(ctx)).To(Succeed())
+		gres, err := gd.Deploy(ctx, redfish.DeployRequest{ImageURL: goldenImageURL, BootTarget: redfish.BootTargetCd})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gbmc.sawRequest(http.MethodPost,
+			"/redfish/v1/Systems/1/VirtualMedia/Cd/Actions/VirtualMedia.InsertMedia")).To(BeTrue(),
+			"generic must pick the System-hosted CD (spec-default System-first order)")
+		Expect(gd.Close()).To(Succeed())
+
+		// ilo: manager-first mediaSearch — selects the Manager-hosted CD instead.
+		id, ibmc := newDeployer(redfish.VendorHPE)
+		defer ibmc.Close()
+		Expect(id.Connect(ctx)).To(Succeed())
+		ires, err := id.Deploy(ctx, redfish.DeployRequest{ImageURL: goldenImageURL, BootTarget: redfish.BootTargetCd})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ibmc.sawRequest(http.MethodPost,
+			"/redfish/v1/Managers/1/VirtualMedia/2/Actions/VirtualMedia.InsertMedia")).To(BeTrue(),
+			"ilo must pick the Manager-hosted CD (manager-first mediaSearch order)")
+		Expect(id.Close()).To(Succeed())
+
+		// The two profiles demonstrably diverged on the SAME recorded tree.
+		Expect(gres.MediaID).NotTo(Equal(ires.MediaID))
+	})
+})

--- a/pkg/redfish/mockupbmc_test.go
+++ b/pkg/redfish/mockupbmc_test.go
@@ -1,0 +1,139 @@
+package redfish_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// mockupBMC is the P4 recorded-mockup replay harness (design §4a, "approach A").
+// It stands up an httptest TLS server that serves GET requests from a recorded
+// DMTF mockup directory tree (the layout produced by redfish-mockup-creator: each
+// resource URI is a directory whose index.json is the GET body for that URI) while
+// keeping the synthesized POST/PATCH/DELETE action handlers a static mockup cannot
+// record.
+//
+// This is the no-hardware fidelity substitute for metal: a contributor records the
+// read-only GET tree of a real BMC, and CI replays the deploy flow's *request
+// sequence* against those recorded responses. The InsertMedia / Reset / Task
+// responses are still synthesized (202 + Task, 204, Completed) because a read-only
+// walk cannot capture action results — this is the honest caveat the support tiers
+// name.
+//
+// It reuses the existing fakeBMC for the synthesized write-side handlers and the
+// per-request recording (method/path/auth, captured bodies), so the golden tests
+// can assert the protocol flow exactly as deployer_test.go does. GETs that the
+// mockup tree does not cover fall through to fakeBMC's synthesized GET handlers
+// (session create, Task polling), so a full Connect→Deploy→Close runs end to end.
+type mockupBMC struct {
+	server *httptest.Server
+	// root is the directory holding the recorded tree's "redfish/v1/..." hierarchy.
+	root string
+	// fake provides the synthesized action handlers, request recording, and the
+	// captured-body fields (insertBody, resetBody, bootPatchBody, sessionBody,
+	// resetSystemID, sessionLocation). Its own httptest server is never started;
+	// only its handler logic is reused.
+	fake *fakeBMC
+}
+
+// newMockupBMC builds a replay harness serving the recorded tree rooted at dir.
+// dir is the directory that contains the top-level "redfish" folder (i.e. the
+// mockup root, e.g. testdata/mockups/ilo/<firmware>).
+func newMockupBMC(dir string) *mockupBMC {
+	m := &mockupBMC{
+		root: dir,
+		// A bare fakeBMC supplies the synthesized write handlers and recording. We
+		// never start fake.server (it would bind a port we do not use); newFakeBMC
+		// does start one, so close it immediately and keep only the handler state.
+		fake: newFakeBMC(),
+	}
+	m.fake.Close()
+	m.server = httptest.NewTLSServer(http.HandlerFunc(m.handle))
+	return m
+}
+
+func (m *mockupBMC) Close() { m.server.Close() }
+
+func (m *mockupBMC) URL() string { return m.server.URL }
+
+// handle serves GETs from the recorded mockup tree and delegates every write
+// (POST/PATCH/DELETE) and the synthesized session/task GETs to the embedded
+// fakeBMC. Requests are recorded on the fake so the golden tests can assert the
+// full method+path+auth sequence and the captured bodies.
+func (m *mockupBMC) handle(w http.ResponseWriter, r *http.Request) {
+	// Static resource GETs come from the recorded tree.
+	if r.Method == http.MethodGet {
+		if body, ok := m.lookup(r.URL.Path); ok {
+			m.fake.record(r)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+			return
+		}
+	}
+
+	// The one-time boot override PATCHes a recorded ComputerSystem resource. A
+	// static mockup records the GET but not the PATCH result, so the harness
+	// captures the boot body (for golden assertions) and echoes the recorded
+	// resource back — keeping the discovered member IDs from the mockup rather than
+	// the synthesized fake's hardcoded sys-xyz.
+	if r.Method == http.MethodPatch {
+		if body, ok := m.lookup(r.URL.Path); ok {
+			m.fake.record(r)
+			m.fake.mu.Lock()
+			m.fake.bootPatchBody = decodeBody(r)
+			m.fake.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+			return
+		}
+	}
+
+	// Everything else — the session create POST, the InsertMedia/Reset actions, the
+	// session DELETE, and the Task poll GET — is synthesized by the fakeBMC handler,
+	// which records the request and serves the spec-shaped action responses (and
+	// 404s anything genuinely unknown).
+	m.fake.handle(w, r)
+}
+
+// lookup resolves a Redfish URI path to the bytes of the recorded index.json for
+// that resource, following the DMTF mockup layout. It returns (body, true) on a
+// hit and (nil, false) when the tree does not record that path (the caller then
+// falls back to the synthesized handler). Trailing slashes are tolerated and the
+// "/redfish/v1" root resolves to redfish/v1/index.json.
+func (m *mockupBMC) lookup(urlPath string) ([]byte, bool) {
+	clean := strings.Trim(urlPath, "/")
+	if clean == "" {
+		return nil, false
+	}
+	// Reject any traversal in the request path: the mockup tree is a fixed,
+	// committed fixture and a request must never escape it.
+	if strings.Contains(clean, "..") {
+		return nil, false
+	}
+	indexPath := filepath.Join(m.root, filepath.FromSlash(clean), "index.json")
+	body, err := os.ReadFile(indexPath)
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// The golden tests assert against the same captured state the deployer_test specs
+// use; these accessors forward to the embedded fakeBMC so the harness reads like
+// the synthesized one.
+
+func (m *mockupBMC) sawRequest(method, pathPrefix string) bool {
+	return m.fake.sawRequest(method, pathPrefix)
+}
+
+func (m *mockupBMC) sessionLocation() string { return m.fake.sessionLocation }
+
+func (m *mockupBMC) insertBody() map[string]any { return m.fake.insertBody }
+
+func (m *mockupBMC) bootPatchBody() map[string]any { return m.fake.bootPatchBody }
+
+func (m *mockupBMC) resetBody() map[string]any { return m.fake.resetBody }
+
+func (m *mockupBMC) resetSystemID() string { return m.fake.resetSystemID }

--- a/pkg/redfish/mockups.go
+++ b/pkg/redfish/mockups.go
@@ -1,0 +1,64 @@
+package redfish
+
+import (
+	"bufio"
+	"embed"
+	"strings"
+)
+
+// This file makes the P3 tier seam real (design §4a/§4b): an in-tree quirk profile
+// that ships with a recorded, sanitized DMTF mockup of real hardware is promoted to
+// tier B, because the §4a golden test replays that mockup against the deploy flow in
+// every-PR CI. builtinHasMockup is the lookup deriveTier consults; before P4 it was
+// a stub returning false, so no profile reached B.
+//
+// Runtime vs test-only — why an embedded manifest:
+// The recorded mockup trees live under pkg/redfish/testdata/mockups/<name>/, and Go
+// does NOT compile testdata/ into the binary. But the tier a profile reports is a
+// RUNTIME fact (it appears in the load-time log line and, later, a UI badge), so
+// builtinHasMockup must work in the shipped binary too — not only under `go test`.
+//
+// We therefore embed a tiny, hand-kept manifest (mockups.manifest: one built-in
+// profile name per line) listing the in-tree profiles that have a recorded mockup.
+// The manifest — not the multi-hundred-KB mockup trees — is what ships in the
+// binary, keeping it small while letting the runtime know which built-ins are
+// tier B. A test (TestMockupManifestMatchesTestdata) keeps the manifest honest:
+// it must list EXACTLY the built-in profiles that actually have a
+// testdata/mockups/<name>/ tree, so the manifest can never drift from the evidence
+// or claim a mockup that isn't there.
+
+//go:embed mockups.manifest
+var mockupManifest embed.FS
+
+// builtinsWithMockup is the set of in-tree profile names that ship with a recorded
+// mockup (read once from the embedded manifest). Membership ⇒ the built-in profile
+// is tier B via deriveTier.
+var builtinsWithMockup = loadMockupManifest()
+
+// loadMockupManifest parses the embedded manifest into a set of profile names. It
+// ignores blank lines and "#"-prefixed comments. A missing/unreadable manifest
+// yields an empty set (every built-in stays at its no-mockup tier), failing safe.
+func loadMockupManifest() map[string]bool {
+	set := map[string]bool{}
+	data, err := mockupManifest.ReadFile("mockups.manifest")
+	if err != nil {
+		return set
+	}
+	sc := bufio.NewScanner(strings.NewReader(string(data)))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		set[line] = true
+	}
+	return set
+}
+
+// builtinHasMockup reports whether an in-tree profile carries a recorded mockup and
+// is therefore tier B. It is the single seam deriveTier consults; see the file
+// comment for why the determination is driven by an embedded manifest rather than
+// the (non-embedded) testdata tree.
+func builtinHasMockup(name string) bool {
+	return builtinsWithMockup[name]
+}

--- a/pkg/redfish/mockups.manifest
+++ b/pkg/redfish/mockups.manifest
@@ -1,0 +1,8 @@
+# Built-in quirk profiles that ship with a recorded, sanitized DMTF mockup under
+# pkg/redfish/testdata/mockups/<name>/ and are replayed by the §4a golden test
+# (mockup_golden_test.go). Listing a name here promotes that in-tree profile to
+# tier B (see mockups.go / deriveTier). One profile name per line; "#" comments and
+# blank lines are ignored. TestMockupManifestMatchesTestdata keeps this list in
+# exact sync with the committed testdata trees, so it can never claim a mockup that
+# isn't there or omit one that is.
+ilo

--- a/pkg/redfish/mockups_internal_test.go
+++ b/pkg/redfish/mockups_internal_test.go
@@ -1,0 +1,109 @@
+package redfish
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMockupManifestMatchesTestdata keeps the embedded mockups.manifest honest: it
+// must list EXACTLY the built-in profiles that actually have a recorded mockup tree
+// under testdata/mockups/<name>/. This prevents the runtime tier-B determination
+// (which reads the embedded manifest, not testdata) from drifting from the evidence
+// — claiming a mockup that isn't committed, or omitting one that is.
+//
+// A "mockup for built-in <name>" is a testdata/mockups/<name>/ directory that holds
+// at least one firmware/model subtree with a redfish/v1/index.json (the recorded
+// ServiceRoot). The directory name must match a built-in profile name; other dirs
+// under testdata/mockups (none today) would be operator/example fixtures and are
+// not part of the manifest.
+func TestMockupManifestMatchesTestdata(t *testing.T) {
+	root := filepath.Join("testdata", "mockups")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("reading %s: %v", root, err)
+	}
+
+	found := map[string]bool{}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		name := ent.Name()
+		// Only directories that name a built-in profile AND contain a recorded
+		// ServiceRoot count as evidence for that built-in.
+		if _, ok := builtinQuirks[name]; !ok {
+			continue
+		}
+		if hasRecordedServiceRoot(t, filepath.Join(root, name)) {
+			found[name] = true
+		}
+	}
+
+	// Every manifest entry must have evidence on disk.
+	for name := range builtinsWithMockup {
+		if !found[name] {
+			t.Errorf("mockups.manifest lists %q but no testdata/mockups/%s/<fw>/redfish/v1/index.json exists", name, name)
+		}
+		if _, ok := builtinQuirks[name]; !ok {
+			t.Errorf("mockups.manifest lists %q which is not a built-in profile", name)
+		}
+	}
+	// Every built-in with evidence on disk must be in the manifest.
+	for name := range found {
+		if !builtinsWithMockup[name] {
+			t.Errorf("testdata/mockups/%s/ exists but %q is not listed in mockups.manifest (it would not report tier B at runtime)", name, name)
+		}
+	}
+}
+
+// hasRecordedServiceRoot reports whether dir contains at least one firmware/model
+// subtree with a redfish/v1/index.json (a recorded ServiceRoot).
+func hasRecordedServiceRoot(t *testing.T, dir string) bool {
+	t.Helper()
+	subs, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, sub := range subs {
+		if !sub.IsDir() {
+			continue
+		}
+		root := filepath.Join(dir, sub.Name(), "redfish", "v1", "index.json")
+		if _, err := os.Stat(root); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBuiltinTiersWithMockup locks the P4 tier outcome: the in-tree ilo profile (now
+// shipping a recorded mockup) reports tier B; supermicro (no mockup) stays C; the
+// spec-default generic stays A. This is the user-visible result of the seam flip.
+func TestBuiltinTiersWithMockup(t *testing.T) {
+	if !builtinHasMockup("ilo") {
+		t.Fatal("ilo must have a recorded mockup (manifest + testdata) after P4")
+	}
+	if builtinHasMockup("supermicro") {
+		t.Fatal("supermicro must NOT have a mockup (stays tier C)")
+	}
+
+	r := newRegistry()
+	cases := []struct {
+		name string
+		want Tier
+	}{
+		{"ilo", TierB},
+		{"supermicro", TierC},
+		{"generic", TierA},
+	}
+	for _, c := range cases {
+		_, tier, ok := r.quirksForName(c.name)
+		if !ok {
+			t.Fatalf("%q must resolve as a built-in", c.name)
+		}
+		if tier != c.want {
+			t.Errorf("tier for %q = %q, want %q", c.name, tier, c.want)
+		}
+	}
+}

--- a/pkg/redfish/ping.go
+++ b/pkg/redfish/ping.go
@@ -1,0 +1,53 @@
+package redfish
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// Reachable performs a session-free, unauthenticated reachability check against a
+// Redfish endpoint: a single GET {endpoint}/redfish/v1/ (ServiceRoot) through the
+// defensive HTTP client (cross-origin redirect reject + response-body cap +
+// TLS-verify honouring insecure). It sends NO credentials and creates NO Redfish
+// session, so it never consumes one of a BMC's capped concurrent sessions — that
+// is the whole point: status can be polled without the session churn a full
+// session-based Inspect incurs.
+//
+// A 2xx response carrying a parseable ServiceRoot returns nil (reachable). A
+// refused connection, TLS error, timeout, non-2xx status, or an unparseable body
+// returns a non-nil error (unreachable). On hardened BMCs that gate the
+// ServiceRoot behind auth, the 401 surfaces here as an error — the caller should
+// steer the operator to an authenticated Inspect for a real liveness check.
+//
+// insecure is the inverse of the target's VerifySSL: pass false to keep TLS
+// verification on (the default), true only when the caller explicitly opted out.
+// The returned error is scrubbed of any basic-auth credentials defensively, though
+// no credentials are ever supplied to this call.
+func Reachable(ctx context.Context, endpoint string, insecure bool) error {
+	if strings.TrimSpace(endpoint) == "" {
+		return errors.New("redfish endpoint is empty")
+	}
+	if _, err := fetchServiceRoot(ctx, endpoint, insecure); err != nil {
+		return scrubError(err, "")
+	}
+	return nil
+}
+
+// scrubError removes a credential substring from an error before it crosses the
+// package boundary. It mirrors Deployer.scrub but is free-standing so the
+// session-free Reachable helper (which has no Deployer) can reuse it. An empty
+// secret leaves the error unchanged.
+func scrubError(err error, secret string) error {
+	if err == nil {
+		return nil
+	}
+	if secret == "" {
+		return err
+	}
+	msg := strings.ReplaceAll(err.Error(), secret, "[REDACTED]")
+	if msg == err.Error() {
+		return err
+	}
+	return errors.New(msg)
+}

--- a/pkg/redfish/ping_test.go
+++ b/pkg/redfish/ping_test.go
@@ -1,0 +1,80 @@
+package redfish_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+)
+
+var _ = Describe("redfish.Reachable", func() {
+	It("returns nil for a 2xx ServiceRoot it can parse", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Path).To(Equal("/redfish/v1/"))
+			Expect(r.Method).To(Equal(http.MethodGet))
+			// No credentials: a session-free reachability probe never authenticates.
+			Expect(r.Header.Get("Authorization")).To(BeEmpty())
+			Expect(r.Header.Get("X-Auth-Token")).To(BeEmpty())
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/","SessionService":{"@odata.id":"/redfish/v1/SessionService"}}`))
+		}))
+		defer srv.Close()
+
+		Expect(redfish.Reachable(context.Background(), srv.URL, false)).To(Succeed())
+	})
+
+	It("does not create a Redfish session (single GET, no POST)", func() {
+		var posts int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				posts++
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/"}`))
+		}))
+		defer srv.Close()
+
+		Expect(redfish.Reachable(context.Background(), srv.URL, false)).To(Succeed())
+		Expect(posts).To(Equal(0), "Reachable must not POST a session-create")
+	})
+
+	It("errors on a non-2xx ServiceRoot (e.g. 401 on a hardened BMC)", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		err := redfish.Reachable(context.Background(), srv.URL, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("status 401"))
+	})
+
+	It("errors on a refused/closed endpoint", func() {
+		// Stand a server up then immediately close it so the address refuses.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		Expect(redfish.Reachable(ctx, url, false)).To(HaveOccurred())
+	})
+
+	It("errors on an unparseable body", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("not json"))
+		}))
+		defer srv.Close()
+
+		Expect(redfish.Reachable(context.Background(), srv.URL, false)).To(HaveOccurred())
+	})
+
+	It("rejects an empty endpoint", func() {
+		Expect(redfish.Reachable(context.Background(), "", false)).To(HaveOccurred())
+	})
+})

--- a/pkg/redfish/probe.go
+++ b/pkg/redfish/probe.go
@@ -1,0 +1,198 @@
+package redfish
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// This file implements the READ-ONLY `redfish probe` diagnostic (design §4c / RFC
+// 0001 P2). Probe recombines the existing discovery building blocks — the same the
+// deploy flow uses — to report what a BMC actually exposes and to emit a starter
+// quirk profile (tier C: UNVERIFIED) the operator can tweak. It performs NO writes:
+// no InsertMedia, no boot PATCH, no Reset, no Eject. Like Inspect, it returns a
+// plain ProbeReport so gofish types never leak into internal/cmd (the D1 guardrail).
+
+// ProbeReport is the plain, gofish-free result of Deployer.Probe. internal/cmd
+// renders it to human-readable text and/or a starter YAML quirk profile; it never
+// sees a gofish object.
+type ProbeReport struct {
+	// Endpoint is the BMC endpoint that was probed.
+	Endpoint string
+	// HasSessionService reports whether the ServiceRoot advertises a SessionService
+	// (a top-level SessionService or Links.Sessions). When false, session auth is
+	// unavailable and only Basic auth works.
+	HasSessionService bool
+	// AuthModeUsed is the auth mode the probe's connection actually used
+	// ("session" or "basic"), after resolving AuthModeAuto against the ServiceRoot.
+	AuthModeUsed string
+
+	// SystemIDs lists the Redfish Ids of every ComputerSystem member, in collection
+	// order. With more than one, the operator must pass --system-id (and set
+	// BMCTarget.SystemID); the media/reset/inspect sections below describe
+	// SelectedSystemID.
+	SystemIDs []string
+	// SelectedSystemID is the ComputerSystem the media/reset/inspect sections were
+	// gathered against. With exactly one system it is that system; with more than
+	// one and no --system-id it is the first member (MultipleSystems is then true).
+	SelectedSystemID string
+	// MultipleSystems is true when the BMC exposes more than one ComputerSystem and
+	// no explicit system was pinned, so the report is for the first member only.
+	MultipleSystems bool
+
+	// System is the typed hardware summary of SelectedSystemID (model, manufacturer,
+	// serial, memory, CPU, detected features). Serial is printed as-is: this is the
+	// operator's own BMC. firmware is reported separately below.
+	System SystemInfo
+	// FirmwareVersion is the system's BIOS/firmware version string when the BMC
+	// advertises one (ComputerSystem.BiosVersion), otherwise empty.
+	FirmwareVersion string
+
+	// Media is the flattened, spec-default-ordered VirtualMedia candidate list (the
+	// same []MediaView the deploy flow's quirk seam receives): System-hosted first,
+	// then each Manager's. Empty when the BMC exposes no virtual media.
+	Media []MediaView
+	// DefaultCDIndex is the index into Media of the member the spec-default search
+	// would pick for a CD/DVD deployment, or -1 when none is CD/DVD-capable.
+	DefaultCDIndex int
+	// ManagerHostedCDOnly is true when the only CD/DVD-capable media is hosted on a
+	// Manager (the HPE iLO signal): the starter profile then suggests a
+	// manager-first mediaSearch order.
+	ManagerHostedCDOnly bool
+
+	// PowerState is the selected system's current Redfish PowerState (e.g. "On").
+	PowerState string
+	// AllowableResetTypes is the system's advertised ResetType allowable values,
+	// empty when the BMC does not advertise them.
+	AllowableResetTypes []string
+	// DefaultResetType is the ResetType the core would choose by default for the
+	// current power state, validated against AllowableResetTypes.
+	DefaultResetType string
+}
+
+// Probe performs a read-only diagnostic of the connected BMC and returns a plain
+// ProbeReport. It must be called after Connect. It selects the system the same way
+// Deploy does when a SystemID is pinned; otherwise, to stay diagnostic against a
+// multi-system BMC (where selectSystem deliberately refuses to guess), it reports
+// every system Id and gathers the media/reset/inspect sections against the first
+// member, flagging MultipleSystems so the caller can tell the operator to pin one.
+//
+// Probe issues only GETs (discovery, Inspect, reset-type allowable values). It never
+// inserts media, patches boot, resets, or ejects.
+func (d *Deployer) Probe(ctx context.Context) (*ProbeReport, error) {
+	if d.client == nil {
+		return nil, errors.New("not connected: call Connect first")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	report := &ProbeReport{
+		Endpoint:          d.endpoint,
+		HasSessionService: !d.usedBasicAuth,
+		DefaultCDIndex:    -1,
+	}
+	if d.usedBasicAuth {
+		report.AuthModeUsed = string(AuthModeBasic)
+	} else {
+		report.AuthModeUsed = string(AuthModeSession)
+	}
+
+	systems, err := d.client.GetService().Systems()
+	if err != nil {
+		return nil, fmt.Errorf("discovering systems: %w", d.scrub(err))
+	}
+	if len(systems) == 0 {
+		return nil, errors.New("no ComputerSystem members found on the Redfish service")
+	}
+	report.SystemIDs = systemIDs(systems)
+
+	// Pick the system to describe. Honour an explicit SystemID; otherwise, unlike
+	// the deploy flow's fail-safe selectSystem (which refuses to guess), the probe
+	// describes the first member but flags that the operator must pin one.
+	system := systems[0]
+	if d.systemID != "" {
+		found := false
+		for _, sys := range systems {
+			if sys.ID == d.systemID {
+				system, found = sys, true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("no ComputerSystem with Id %q found on the Redfish service; available system Ids: %s",
+				d.systemID, strings.Join(report.SystemIDs, ", "))
+		}
+	} else if len(systems) > 1 {
+		report.MultipleSystems = true
+	}
+	report.SelectedSystemID = system.ID
+
+	// Inspect (read-only): model/manufacturer/serial/memory/cpu/features.
+	report.System = SystemInfo{
+		ID:           system.ID,
+		Name:         system.Name,
+		Model:        system.Model,
+		Manufacturer: system.Manufacturer,
+		SerialNumber: system.SerialNumber,
+		PowerState:   string(system.PowerState),
+		Features:     detectFeatures(system),
+	}
+	if v := system.MemorySummary.TotalSystemMemoryGiB; v != nil {
+		report.System.MemoryGiB = int(*v)
+	}
+	if v := system.ProcessorSummary.Count; v != nil {
+		report.System.ProcessorCount = int(*v)
+	}
+	report.FirmwareVersion = strings.TrimSpace(system.BiosVersion)
+
+	// Virtual media: the flattened, spec-default-ordered candidate views — exactly
+	// what the deploy flow's mediaSearch hook sees. No writes; discovery GETs only.
+	candidates, views := d.mediaCandidates(system)
+	report.Media = views
+	report.DefaultCDIndex = firstCDIndex(candidates)
+	report.ManagerHostedCDOnly = onlyManagerHostedCD(candidates, views)
+
+	// Reset: the advertised allowable types and the core's default for this state.
+	report.PowerState = string(system.PowerState)
+	if allowed, err := system.GetSupportedResetTypes(); err == nil {
+		report.AllowableResetTypes = resetTypeStrings(allowed)
+	}
+	report.DefaultResetType = string(chooseResetType(system))
+
+	return report, nil
+}
+
+// firstCDIndex returns the index of the first CD/DVD-capable media in the
+// spec-default candidate order, or -1 when none advertises CD/DVD.
+func firstCDIndex(candidates []*schemas.VirtualMedia) int {
+	for i, vm := range candidates {
+		if mediaSupportsCD(vm) {
+			return i
+		}
+	}
+	return -1
+}
+
+// onlyManagerHostedCD reports whether the BMC exposes CD/DVD-capable virtual media
+// AND every such member is Manager-hosted (Location "manager:<id>"). That is the
+// HPE iLO signal: the spec-default System-first search finds nothing, and a
+// manager-first mediaSearch order is required. It returns false when there is no
+// CD/DVD media at all, or when at least one CD/DVD member is System-hosted (the
+// spec default already works).
+func onlyManagerHostedCD(candidates []*schemas.VirtualMedia, views []MediaView) bool {
+	sawCD := false
+	for i, vm := range candidates {
+		if !mediaSupportsCD(vm) {
+			continue
+		}
+		sawCD = true
+		if views[i].Location == "system" {
+			return false
+		}
+	}
+	return sawCD
+}

--- a/pkg/redfish/probe_profile.go
+++ b/pkg/redfish/probe_profile.go
@@ -1,0 +1,154 @@
+package redfish
+
+import (
+	"fmt"
+	"strings"
+)
+
+// This file renders a ProbeReport into a starter quirk profile (tier C: UNVERIFIED).
+// The emitted YAML is a VALID profile: it round-trips through ParseProfile (a profile
+// with only a name + match is valid). Anything the probe can only *suggest* — notably
+// ResetType candidates the operator must confirm — is emitted as YAML comments, which
+// ParseProfile ignores, so the document always parses while still guiding the operator.
+
+// StarterProfileHeader is the delimiter line callers print before the emitted
+// starter YAML in mixed (text+yaml) output, clearly marking the tier and the path to
+// promotion (add a recorded mockup to reach tier B — design §4b). It is a visual
+// delimiter only and is NOT part of the profile body — yaml-only output omits it so
+// the stream piped to a file parses cleanly via ParseProfile.
+const StarterProfileHeader = "--- suggested profile (tier C: UNVERIFIED — add a recorded mockup to reach tier B) ---"
+
+// StarterProfile renders the probe report into a starter quirk-profile YAML document.
+// The document is guaranteed to parse via ParseProfile. It pre-fills:
+//   - name: a slug of the manufacturer (or "custom").
+//   - match.vendor: the manufacturer string.
+//   - mediaSearch.order: [manager, system] ONLY when the only CD/DVD media is
+//     Manager-hosted (the iLO signal); otherwise omitted (the spec default is correct),
+//     with a comment saying so.
+//   - mediaType: only when the chosen CD/DVD member advertises DVD-but-not-CD (a
+//     non-default); otherwise omitted.
+//   - validatedFirmware: the firmware string as a stub the operator confirms.
+//
+// ResetType candidates are emitted as comments (suggestions the operator confirms),
+// keeping the document minimal and the active rules empty.
+func (r *ProbeReport) StarterProfile() string {
+	var b strings.Builder
+
+	name := slugify(r.System.Manufacturer)
+	if name == "" {
+		name = "custom"
+	}
+
+	b.WriteString("name: " + name + "\n")
+
+	// match.vendor: the manufacturer string, when the BMC reported one.
+	if v := strings.TrimSpace(r.System.Manufacturer); v != "" {
+		b.WriteString("match:\n")
+		b.WriteString("  vendor: " + yamlScalar(v) + "\n")
+	} else {
+		b.WriteString("# match.vendor: <manufacturer> (the BMC reported none; fill in if you know it)\n")
+	}
+
+	// mediaSearch: only when the only CD/DVD media is Manager-hosted.
+	if r.ManagerHostedCDOnly {
+		b.WriteString("# The only CD/DVD media is Manager-hosted (the HPE iLO signal): the\n")
+		b.WriteString("# spec-default System-first search misses it, so search Manager first.\n")
+		b.WriteString("mediaSearch:\n")
+		b.WriteString("  order: [manager, system]\n")
+	} else {
+		b.WriteString("# mediaSearch omitted: the spec-default media search order is correct for this BMC.\n")
+	}
+
+	// mediaType: only when the chosen member advertises DVD but not CD (non-default).
+	if mt := suggestedMediaType(r); mt != "" {
+		b.WriteString("# The default CD/DVD member advertises " + mt + " but not CD; pin the MediaType.\n")
+		b.WriteString("mediaType: " + mt + "\n")
+	} else {
+		b.WriteString("# mediaType omitted: the spec default (CD) matches the chosen media.\n")
+	}
+
+	// resetType: suggestions only, as comments. The core re-validates any rule, but
+	// the operator should confirm the right one for their hardware.
+	b.WriteString("# resetType suggestions (uncomment and confirm against your hardware):\n")
+	b.WriteString("#   the core default for power state " + nonEmpty(r.PowerState, "<unknown>") +
+		" is: " + nonEmpty(r.DefaultResetType, "<none>") + "\n")
+	if len(r.AllowableResetTypes) > 0 {
+		b.WriteString("#   the BMC advertises these allowable ResetTypes: " +
+			strings.Join(r.AllowableResetTypes, ", ") + "\n")
+	} else {
+		b.WriteString("#   the BMC advertised no allowable ResetTypes.\n")
+	}
+	b.WriteString("# resetType:\n")
+	b.WriteString("#   - { when: { powerState: \"Off\" }, then: \"On\" }\n")
+	b.WriteString("#   - { when: { powerState: \"*\" },   then: \"" +
+		nonEmpty(r.DefaultResetType, "ForceRestart") + "\" }\n")
+
+	// validatedFirmware: a stub the operator confirms.
+	if fw := strings.TrimSpace(r.FirmwareVersion); fw != "" {
+		b.WriteString("validatedFirmware: " + yamlScalar(fw) + "\n")
+	} else {
+		b.WriteString("# validatedFirmware: <firmware version> (the BMC reported none)\n")
+	}
+
+	return b.String()
+}
+
+// suggestedMediaType returns the MediaType to pin in the starter profile, or "".
+// It returns "DVD" only when the spec-default-chosen CD/DVD member advertises DVD
+// but NOT CD — the one non-default case worth pinning. Otherwise the spec default
+// (CD) is correct and nothing is emitted.
+func suggestedMediaType(r *ProbeReport) string {
+	if r.DefaultCDIndex < 0 || r.DefaultCDIndex >= len(r.Media) {
+		return ""
+	}
+	view := r.Media[r.DefaultCDIndex]
+	hasCD, hasDVD := false, false
+	for _, t := range view.MediaTypes {
+		switch t {
+		case "CD":
+			hasCD = true
+		case "DVD":
+			hasDVD = true
+		}
+	}
+	if hasDVD && !hasCD {
+		return "DVD"
+	}
+	return ""
+}
+
+// slugify lowercases s and replaces any run of non-alphanumeric characters with a
+// single hyphen, trimming leading/trailing hyphens. It yields a profile name that is
+// stable and readable (e.g. "Hewlett Packard Enterprise" → "hewlett-packard-enterprise").
+func slugify(s string) string {
+	var b strings.Builder
+	lastHyphen := true // suppress a leading hyphen
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastHyphen = false
+		default:
+			if !lastHyphen {
+				b.WriteByte('-')
+				lastHyphen = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// yamlScalar quotes a YAML scalar so a value containing characters with YAML meaning
+// (colons, leading symbols, etc.) round-trips intact. Plain strings are double-quoted
+// with embedded quotes/backslashes escaped — always-valid flow scalar syntax.
+func yamlScalar(s string) string {
+	return fmt.Sprintf("%q", s)
+}
+
+// nonEmpty returns s when it is non-empty, otherwise fallback.
+func nonEmpty(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}

--- a/pkg/redfish/probe_test.go
+++ b/pkg/redfish/probe_test.go
@@ -1,0 +1,224 @@
+package redfish_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/redfish"
+)
+
+var _ = Describe("Deployer.Probe", Label("redfish", "probe"), func() {
+	var (
+		bmc *fakeBMC
+		ctx context.Context
+		d   *redfish.Deployer
+	)
+
+	newDeployer := func() *redfish.Deployer {
+		return redfish.NewDeployer(redfish.Config{
+			Endpoint:  bmc.URL(),
+			Username:  testUser,
+			Password:  testPassword,
+			VerifySSL: false,
+			Timeout:   30 * time.Second,
+		})
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		bmc = newFakeBMC()
+	})
+
+	AfterEach(func() {
+		bmc.Close()
+	})
+
+	It("reports systems, inspect fields, media, and reset (System-hosted media)", func() {
+		bmc.biosVersion = "U30 v2.44 (07/24/2023)"
+		d = newDeployer()
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		report, err := d.Probe(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Service / auth.
+		Expect(report.Endpoint).To(Equal(bmc.URL()))
+		Expect(report.HasSessionService).To(BeTrue())
+		Expect(report.AuthModeUsed).To(Equal("session"))
+
+		// Systems.
+		Expect(report.SystemIDs).To(Equal([]string{"sys-xyz"}))
+		Expect(report.SelectedSystemID).To(Equal("sys-xyz"))
+		Expect(report.MultipleSystems).To(BeFalse())
+
+		// Inspect.
+		Expect(report.System.Manufacturer).To(Equal("ACME"))
+		Expect(report.System.Model).To(Equal("ProLiant-Test"))
+		Expect(report.System.SerialNumber).To(Equal("SN-0001"))
+		Expect(report.System.MemoryGiB).To(Equal(64))
+		Expect(report.System.ProcessorCount).To(Equal(8))
+		Expect(report.System.Features).To(HaveKeyWithValue(redfish.FeatureUEFI, true))
+		Expect(report.FirmwareVersion).To(Equal("U30 v2.44 (07/24/2023)"))
+
+		// Media: one System-hosted CD/DVD member, the default search picks it,
+		// and it is NOT manager-hosted-only.
+		Expect(report.Media).To(HaveLen(1))
+		Expect(report.Media[0].Location).To(Equal("system"))
+		Expect(report.Media[0].MediaTypes).To(ContainElements("CD", "DVD"))
+		Expect(report.DefaultCDIndex).To(Equal(0))
+		Expect(report.ManagerHostedCDOnly).To(BeFalse())
+
+		// Reset.
+		Expect(report.PowerState).To(Equal("On"))
+		Expect(report.AllowableResetTypes).To(ContainElement("ForceRestart"))
+		Expect(report.DefaultResetType).To(Equal("ForceRestart"))
+
+		// Read-only: no InsertMedia, boot PATCH, or Reset POST was issued.
+		Expect(bmc.sawRequest(http.MethodPost, "/redfish/v1/Systems/sys-xyz/VirtualMedia/Cd/Actions")).To(BeFalse())
+		Expect(bmc.sawRequest(http.MethodPatch, "/redfish/v1/Systems/sys-xyz")).To(BeFalse())
+		Expect(bmc.sawRequest(http.MethodPost, "/redfish/v1/Systems/sys-xyz/Actions/ComputerSystem.Reset")).To(BeFalse())
+		Expect(bmc.insertBody).To(BeNil())
+		Expect(bmc.bootPatchBody).To(BeNil())
+		Expect(bmc.resetBody).To(BeNil())
+	})
+
+	It("flags manager-hosted CD media (the iLO signal)", func() {
+		bmc.mediaOnManager = true
+		d = newDeployer()
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		report, err := d.Probe(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(report.Media).To(HaveLen(1))
+		Expect(report.Media[0].Location).To(HavePrefix("manager:"))
+		Expect(report.DefaultCDIndex).To(Equal(0))
+		Expect(report.ManagerHostedCDOnly).To(BeTrue())
+	})
+
+	It("reports every system Id and flags multiple systems when none is pinned", func() {
+		bmc.systemIDs = []string{"sys-a", "sys-b"}
+		d = newDeployer()
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		report, err := d.Probe(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(report.SystemIDs).To(ConsistOf("sys-a", "sys-b"))
+		Expect(report.MultipleSystems).To(BeTrue())
+		// The selected system is the first reported member (gofish does not
+		// guarantee collection order, so assert consistency, not a fixed Id).
+		Expect(report.SelectedSystemID).To(Equal(report.SystemIDs[0]))
+	})
+
+	It("describes the pinned system when --system-id is set", func() {
+		bmc.systemIDs = []string{"sys-a", "sys-b"}
+		d = redfish.NewDeployer(redfish.Config{
+			Endpoint:  bmc.URL(),
+			Username:  testUser,
+			Password:  testPassword,
+			VerifySSL: false,
+			Timeout:   30 * time.Second,
+			SystemID:  "sys-b",
+		})
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		report, err := d.Probe(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(report.SelectedSystemID).To(Equal("sys-b"))
+		Expect(report.MultipleSystems).To(BeFalse())
+	})
+
+	It("errors when the pinned system Id is unknown, listing the available Ids", func() {
+		bmc.systemIDs = []string{"sys-a", "sys-b"}
+		d = redfish.NewDeployer(redfish.Config{
+			Endpoint:  bmc.URL(),
+			Username:  testUser,
+			Password:  testPassword,
+			VerifySSL: false,
+			Timeout:   30 * time.Second,
+			SystemID:  "nope",
+		})
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		_, err := d.Probe(ctx)
+		Expect(err).To(MatchError(ContainSubstring("nope")))
+		Expect(err).To(MatchError(ContainSubstring("sys-a")))
+		Expect(err).To(MatchError(ContainSubstring("sys-b")))
+	})
+
+	It("uses basic auth mode in the report when the BMC has no SessionService", func() {
+		bmc.noSessionService = true
+		d = newDeployer()
+		Expect(d.Connect(ctx)).To(Succeed())
+		defer func() { _ = d.Close() }()
+
+		report, err := d.Probe(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(report.HasSessionService).To(BeFalse())
+		Expect(report.AuthModeUsed).To(Equal("basic"))
+	})
+
+	Describe("StarterProfile round-trips through ParseProfile", func() {
+		It("produces a valid profile WITHOUT mediaSearch for System-hosted media", func() {
+			bmc.biosVersion = "U30 v2.44"
+			d = newDeployer()
+			Expect(d.Connect(ctx)).To(Succeed())
+			defer func() { _ = d.Close() }()
+
+			report, err := d.Probe(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			yaml := report.StarterProfile()
+			profile, err := redfish.ParseProfile([]byte(yaml))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(profile.Name).To(Equal("acme"))
+			Expect(profile.Match).NotTo(BeNil())
+			Expect(profile.Match.Vendor).To(Equal("ACME"))
+			Expect(profile.MediaSearch).To(BeNil(), "System-hosted media needs no mediaSearch")
+			Expect(profile.ValidatedFirmware).To(Equal("U30 v2.44"))
+			// resetType suggestions are comments, never active rules.
+			Expect(profile.ResetType).To(BeEmpty())
+		})
+
+		It("produces a valid profile WITH a manager-first mediaSearch for manager-hosted media", func() {
+			bmc.mediaOnManager = true
+			d = newDeployer()
+			Expect(d.Connect(ctx)).To(Succeed())
+			defer func() { _ = d.Close() }()
+
+			report, err := d.Probe(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			yaml := report.StarterProfile()
+			Expect(yaml).To(ContainSubstring("mediaSearch"))
+
+			profile, err := redfish.ParseProfile([]byte(yaml))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(profile.MediaSearch).NotTo(BeNil())
+			Expect(profile.MediaSearch.Order).To(Equal([]string{"manager", "system"}))
+		})
+
+		It("slugs to \"custom\" when the BMC reports no manufacturer", func() {
+			report := &redfish.ProbeReport{} // empty manufacturer
+			yaml := report.StarterProfile()
+			Expect(strings.Contains(yaml, "name: custom")).To(BeTrue())
+
+			profile, err := redfish.ParseProfile([]byte(yaml))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(profile.Name).To(Equal("custom"))
+			Expect(profile.Match).To(BeNil())
+		})
+	})
+})

--- a/pkg/redfish/quirkprofile.go
+++ b/pkg/redfish/quirkprofile.go
@@ -1,0 +1,340 @@
+package redfish
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stmcginnis/gofish/schemas"
+	"gopkg.in/yaml.v3"
+)
+
+// This file is the second PRODUCER of a quirks value (the first being the in-tree
+// Go profiles in quirks_vendor.go): a compiler from a declarative YAML profile to
+// the same hook closures, working ONLY through the safe Views (quirkviews.go).
+//
+// A profile is inert data with a bounded blast radius (design §0/§7): it can
+// reorder/filter media, pick a MediaType, prefer a ResetType (re-validated by the
+// core), and sparse-patch an allowlisted set of InsertMedia fields. It can NEVER
+// set the image URL, force an unsupported ResetType, or touch sessions/TLS/system
+// selection. That is what makes a community-authored profile safe to run against a
+// BMC we hold admin credentials for.
+//
+// Validation is strict and happens at load (ParseProfile): unknown keys, bad
+// enums, and non-allowlisted insert-param fields (notably Image, any casing) are
+// rejected with a clear error before any hook is compiled.
+
+// QuirkProfile is the parsed, validated representation of a YAML quirk profile. It
+// is compiled into a quirks value by Compile. The struct mirrors the schema in the
+// RFC/design §4.1.
+type QuirkProfile struct {
+	// Name identifies the profile (required). Compiled into quirks.name.
+	Name string `yaml:"name"`
+	// Match is an optional selection hint (e.g. which vendor this profile targets).
+	// It is informational in P1; P3 wires it to selection.
+	Match *ProfileMatch `yaml:"match,omitempty"`
+	// MediaSearch optionally reorders the media candidates by location.
+	MediaSearch *ProfileMediaSearch `yaml:"mediaSearch,omitempty"`
+	// MediaType optionally overrides the InsertMedia MediaType (CD|DVD|USBStick|Floppy).
+	MediaType string `yaml:"mediaType,omitempty"`
+	// ResetType is an optional ordered rule set; the first matching power-state rule
+	// wins. The chosen type is still re-validated by the core.
+	ResetType []ProfileResetRule `yaml:"resetType,omitempty"`
+	// TuneInsertParams is an optional sparse patch over an allowlisted field set.
+	TuneInsertParams *ProfileTuneInsertParams `yaml:"tuneInsertParams,omitempty"`
+	// ValidatedFirmware is informational (tier labelling, P3/P4): the firmware the
+	// profile+mockup pair was validated against. Not interpreted in P1.
+	ValidatedFirmware string `yaml:"validatedFirmware,omitempty"`
+}
+
+// ProfileMatch is the optional selection hint.
+type ProfileMatch struct {
+	Vendor string `yaml:"vendor,omitempty"`
+}
+
+// ProfileMediaSearch declares a media-candidate ordering. Each Order entry is one
+// of "system", "manager", or "manager:<id>"; candidates whose Location matches an
+// entry are emitted in that order (earlier entries first), and unmatched
+// candidates are dropped — exactly the index-ordering closure over []MediaView.
+type ProfileMediaSearch struct {
+	Order []string `yaml:"order"`
+}
+
+// ProfileResetRule is one first-match-wins reset rule. When.PowerState is one of
+// "On", "Off", or "*"; Then is the ResetType to prefer (re-validated by the core).
+type ProfileResetRule struct {
+	When ProfileResetWhen `yaml:"when"`
+	Then string           `yaml:"then"`
+}
+
+// ProfileResetWhen is the condition of a reset rule.
+type ProfileResetWhen struct {
+	PowerState string `yaml:"powerState"`
+}
+
+// ProfileTuneInsertParams is the sparse InsertMedia patch. Clear names fields to
+// drop; Set names fields to set. Keys are restricted to the allowlist
+// {MediaType, TransferProtocolType, Inserted, WriteProtected}; Image (any casing)
+// is explicitly rejected.
+type ProfileTuneInsertParams struct {
+	Clear []string       `yaml:"clear,omitempty"`
+	Set   map[string]any `yaml:"set,omitempty"`
+}
+
+// Allowed enum/allowlist sets, defined once so validation and documentation stay
+// in sync.
+var (
+	allowedMediaTypes = map[string]schemas.VirtualMediaType{
+		"CD":       schemas.CDVirtualMediaType,
+		"DVD":      schemas.DVDVirtualMediaType,
+		"USBStick": schemas.USBStickVirtualMediaType,
+		"Floppy":   schemas.FloppyVirtualMediaType,
+	}
+	allowedPowerStates = map[string]bool{"On": true, "Off": true, "*": true}
+	// insertParamAllowlist is the ONLY set of InsertMedia fields a profile may
+	// patch. Image is deliberately absent and is rejected with a specific error.
+	insertParamAllowlist = map[string]bool{
+		"MediaType":            true,
+		"TransferProtocolType": true,
+		"Inserted":             true,
+		"WriteProtected":       true,
+	}
+)
+
+// ParseProfile decodes and strictly validates a YAML quirk profile. Unknown keys
+// are rejected (KnownFields), as are bad enums and non-allowlisted insert-param
+// fields. A malformed profile is a load-time error; it disables only itself.
+func ParseProfile(data []byte) (*QuirkProfile, error) {
+	var p QuirkProfile
+	dec := yaml.NewDecoder(strings.NewReader(string(data)))
+	dec.KnownFields(true)
+	if err := dec.Decode(&p); err != nil {
+		return nil, fmt.Errorf("parsing quirk profile: %w", err)
+	}
+	if err := p.validate(); err != nil {
+		return nil, fmt.Errorf("validating quirk profile: %w", err)
+	}
+	return &p, nil
+}
+
+// LoadProfile parses and compiles a YAML quirk profile in one step.
+func LoadProfile(data []byte) (quirks, error) {
+	p, err := ParseProfile(data)
+	if err != nil {
+		return quirks{}, err
+	}
+	return p.Compile()
+}
+
+// validate checks the parsed profile against the schema's enums and allowlists.
+func (p *QuirkProfile) validate() error {
+	if strings.TrimSpace(p.Name) == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	if p.MediaType != "" {
+		if _, ok := allowedMediaTypes[p.MediaType]; !ok {
+			return fmt.Errorf("mediaType %q is not one of CD, DVD, USBStick, Floppy", p.MediaType)
+		}
+	}
+
+	if p.MediaSearch != nil {
+		for _, entry := range p.MediaSearch.Order {
+			if err := validateMediaSearchEntry(entry); err != nil {
+				return err
+			}
+		}
+	}
+
+	for i, rule := range p.ResetType {
+		if !allowedPowerStates[rule.When.PowerState] {
+			return fmt.Errorf("resetType[%d].when.powerState %q is not one of On, Off, *", i, rule.When.PowerState)
+		}
+		if strings.TrimSpace(rule.Then) == "" {
+			return fmt.Errorf("resetType[%d].then is required", i)
+		}
+		if !knownResetType(rule.Then) {
+			return fmt.Errorf("resetType[%d].then %q is not a known Redfish ResetType", i, rule.Then)
+		}
+	}
+
+	if p.TuneInsertParams != nil {
+		if err := validateTuneInsertParams(p.TuneInsertParams); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateMediaSearchEntry checks one mediaSearch.order entry: "system",
+// "manager", or "manager:<id>".
+func validateMediaSearchEntry(entry string) error {
+	if entry == "system" || entry == "manager" {
+		return nil
+	}
+	if id, ok := strings.CutPrefix(entry, "manager:"); ok && id != "" {
+		return nil
+	}
+	return fmt.Errorf("mediaSearch.order entry %q is not one of system, manager, manager:<id>", entry)
+}
+
+// validateTuneInsertParams enforces the field allowlist on both clear and set,
+// rejecting Image (any casing) with a specific, actionable error.
+func validateTuneInsertParams(t *ProfileTuneInsertParams) error {
+	for _, field := range t.Clear {
+		if err := checkInsertParamField(field); err != nil {
+			return fmt.Errorf("tuneInsertParams.clear: %w", err)
+		}
+	}
+	for field := range t.Set {
+		if err := checkInsertParamField(field); err != nil {
+			return fmt.Errorf("tuneInsertParams.set: %w", err)
+		}
+	}
+	return nil
+}
+
+// checkInsertParamField rejects any field outside the InsertMedia allowlist, with
+// a dedicated message for Image (the SSRF-sensitive, core-owned URL) regardless of
+// casing.
+func checkInsertParamField(field string) error {
+	if strings.EqualFold(field, "Image") {
+		return fmt.Errorf("the Image field is core-owned and SSRF-validated; a profile must never set or clear it")
+	}
+	if !insertParamAllowlist[field] {
+		return fmt.Errorf("field %q is not in the allowlist (MediaType, TransferProtocolType, Inserted, WriteProtected)", field)
+	}
+	return nil
+}
+
+// knownResetType reports whether s names a Redfish ResetType the core understands.
+func knownResetType(s string) bool {
+	switch schemas.ResetType(s) {
+	case schemas.OnResetType,
+		schemas.ForceOnResetType,
+		schemas.ForceOffResetType,
+		schemas.GracefulShutdownResetType,
+		schemas.ForceRestartResetType,
+		schemas.GracefulRestartResetType,
+		schemas.NmiResetType,
+		schemas.PauseResetType,
+		schemas.ResumeResetType,
+		schemas.SuspendResetType,
+		schemas.PowerCycleResetType:
+		return true
+	default:
+		return false
+	}
+}
+
+// Compile turns the validated profile into a quirks value. Each omitted section
+// compiles to a nil hook, so an empty profile (just a name) yields the zero-value
+// quirks (plus name) — byte-for-byte the generic/default behaviour.
+func (p *QuirkProfile) Compile() (quirks, error) {
+	if err := p.validate(); err != nil {
+		return quirks{}, fmt.Errorf("validating quirk profile: %w", err)
+	}
+
+	q := quirks{name: p.Name}
+
+	if p.MediaSearch != nil && len(p.MediaSearch.Order) > 0 {
+		q.mediaSearch = compileMediaSearch(p.MediaSearch.Order)
+	}
+	if p.MediaType != "" {
+		mt := allowedMediaTypes[p.MediaType]
+		q.mediaType = func(MediaView) schemas.VirtualMediaType { return mt }
+	}
+	if len(p.ResetType) > 0 {
+		q.resetType = compileResetType(p.ResetType)
+	}
+	if p.TuneInsertParams != nil {
+		q.tuneInsertParams = compileTuneInsertParams(p.TuneInsertParams)
+	}
+
+	return q, nil
+}
+
+// compileMediaSearch builds the index-ordering closure: for each Location selector
+// in order, emit the indexes of the matching MediaViews; drop unmatched. An entry
+// "system" matches Location "system"; "manager" matches any "manager:<id>";
+// "manager:<id>" matches that exact manager.
+func compileMediaSearch(order []string) func([]MediaView) []int {
+	return func(media []MediaView) []int {
+		var out []int
+		for _, sel := range order {
+			for _, m := range media {
+				if locationMatches(sel, m.Location) {
+					out = append(out, m.Index)
+				}
+			}
+		}
+		return out
+	}
+}
+
+// locationMatches reports whether a MediaView Location satisfies a mediaSearch
+// selector.
+func locationMatches(sel, location string) bool {
+	switch sel {
+	case "system":
+		return location == "system"
+	case "manager":
+		return strings.HasPrefix(location, "manager:")
+	default:
+		// "manager:<id>" — exact match.
+		return location == sel
+	}
+}
+
+// compileResetType builds the first-match-wins reset closure. PowerState matching
+// is case-insensitive; "*" matches all. The returned type is still re-validated by
+// the core's firstSupported, so a rule can prefer but not force an unsupported type.
+func compileResetType(rules []ProfileResetRule) func(ResetView) schemas.ResetType {
+	return func(view ResetView) schemas.ResetType {
+		for _, rule := range rules {
+			if rule.When.PowerState == "*" || strings.EqualFold(rule.When.PowerState, view.PowerState) {
+				return schemas.ResetType(rule.Then)
+			}
+		}
+		// No rule matched: keep the core default.
+		return schemas.ResetType(view.Default)
+	}
+}
+
+// compileTuneInsertParams builds the sparse-patch closure from the validated
+// clear/set maps. The allowlist was enforced at validation, so this only needs to
+// translate field names to the InsertParamsPatch.
+func compileTuneInsertParams(t *ProfileTuneInsertParams) func(InsertParamsView) InsertParamsPatch {
+	return func(InsertParamsView) InsertParamsPatch {
+		var patch InsertParamsPatch
+		for _, field := range t.Clear {
+			switch field {
+			case "TransferProtocolType":
+				patch.ClearTransferProtocolType = true
+			case "MediaType":
+				patch.SetMediaType = ""
+			}
+		}
+		for field, val := range t.Set {
+			switch field {
+			case "MediaType":
+				if s, ok := val.(string); ok {
+					patch.SetMediaType = s
+				}
+			case "TransferProtocolType":
+				if s, ok := val.(string); ok {
+					patch.SetTransferProtocolType = s
+				}
+			case "Inserted":
+				if b, ok := val.(bool); ok {
+					patch.SetInserted, patch.SetInsertedSet = b, true
+				}
+			case "WriteProtected":
+				if b, ok := val.(bool); ok {
+					patch.SetWriteProtected, patch.SetWriteProtectedSet = b, true
+				}
+			}
+		}
+		return patch
+	}
+}

--- a/pkg/redfish/quirkprofile_internal_test.go
+++ b/pkg/redfish/quirkprofile_internal_test.go
@@ -1,0 +1,172 @@
+package redfish
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stmcginnis/gofish/schemas"
+)
+
+// TestEmptyProfileEqualsGeneric is the regression guard for the YAML producer: an
+// empty profile (just a name) must compile to the zero-value quirks — every hook
+// nil — so its behaviour is byte-for-byte identical to genericQuirks(). This is
+// the same contract TestGenericProfileHasNoHooks guards for the Go producer.
+func TestEmptyProfileEqualsGeneric(t *testing.T) {
+	q, err := LoadProfile([]byte("name: empty\n"))
+	if err != nil {
+		t.Fatalf("compiling empty profile: %v", err)
+	}
+	if q.mediaSearch != nil || q.mediaType != nil || q.resetType != nil ||
+		q.tuneInsertParams != nil || q.pushMedia != nil {
+		t.Fatal("empty profile compiled to non-nil hooks; it must equal the generic zero-value quirks")
+	}
+	// genericQuirks is the reference zero value (plus a name); the only difference
+	// from an empty profile is the name.
+	gen := genericQuirks()
+	if gen.mediaSearch != nil || gen.mediaType != nil || gen.resetType != nil ||
+		gen.tuneInsertParams != nil || gen.pushMedia != nil {
+		t.Fatal("genericQuirks must remain all-nil-hook for this equivalence to hold")
+	}
+}
+
+// TestProfileValidationMatrix covers the strict load-time validation: unknown
+// keys, the Image rejection, and bad enums are all errors with actionable messages.
+func TestProfileValidationMatrix(t *testing.T) {
+	cases := []struct {
+		name     string
+		yaml     string
+		wantErr  string // substring the error must contain
+		wantPass bool
+	}{
+		{
+			name:    "missing name",
+			yaml:    "mediaType: CD\n",
+			wantErr: "name is required",
+		},
+		{
+			name:    "unknown top-level key",
+			yaml:    "name: x\nbogusKey: true\n",
+			wantErr: "field bogusKey not found",
+		},
+		{
+			name:    "set Image is rejected",
+			yaml:    "name: x\ntuneInsertParams:\n  set:\n    Image: http://evil/iso\n",
+			wantErr: "Image",
+		},
+		{
+			name:    "clear Image (lowercase) is rejected",
+			yaml:    "name: x\ntuneInsertParams:\n  clear: [image]\n",
+			wantErr: "Image",
+		},
+		{
+			name:    "non-allowlisted insert field",
+			yaml:    "name: x\ntuneInsertParams:\n  set:\n    WriteOnce: true\n",
+			wantErr: "allowlist",
+		},
+		{
+			name:    "bad mediaType enum",
+			yaml:    "name: x\nmediaType: Tape\n",
+			wantErr: "not one of CD, DVD",
+		},
+		{
+			name:    "bad resetType then enum",
+			yaml:    "name: x\nresetType:\n  - { when: { powerState: \"*\" }, then: Explode }\n",
+			wantErr: "not a known Redfish ResetType",
+		},
+		{
+			name:    "bad powerState enum",
+			yaml:    "name: x\nresetType:\n  - { when: { powerState: Maybe }, then: On }\n",
+			wantErr: "not one of On, Off, *",
+		},
+		{
+			name:    "bad mediaSearch order entry",
+			yaml:    "name: x\nmediaSearch:\n  order: [galaxy]\n",
+			wantErr: "not one of system, manager",
+		},
+		{
+			name:     "valid full profile",
+			yaml:     "name: ilo\nmatch: { vendor: HPE }\nmediaSearch: { order: [manager, system] }\nmediaType: CD\nresetType:\n  - { when: { powerState: \"Off\" }, then: On }\n  - { when: { powerState: \"*\" }, then: ForceRestart }\ntuneInsertParams:\n  clear: [TransferProtocolType]\n  set: { WriteProtected: true }\nvalidatedFirmware: \"iLO5 2.44\"\n",
+			wantPass: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadProfile([]byte(tc.yaml))
+			if tc.wantPass {
+				if err != nil {
+					t.Fatalf("expected profile to load, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCompileMediaSearchOrder checks the index-ordering closure: selectors emit
+// matching candidate indexes in order, "manager" matches any manager:<id>, and
+// unmatched candidates are dropped.
+func TestCompileMediaSearchOrder(t *testing.T) {
+	q, err := LoadProfile([]byte("name: ilo\nmediaSearch: { order: [manager, system] }\n"))
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+	views := []MediaView{
+		{Index: 0, Location: "system"},
+		{Index: 1, Location: "manager:mgr-1"},
+		{Index: 2, Location: "manager:mgr-2"},
+	}
+	got := q.mediaSearch(views)
+	want := []int{1, 2, 0}
+	if len(got) != len(want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+
+	// A specific manager id selects only that manager.
+	q2, err := LoadProfile([]byte("name: x\nmediaSearch: { order: [\"manager:mgr-2\"] }\n"))
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+	got2 := q2.mediaSearch(views)
+	if len(got2) != 1 || got2[0] != 2 {
+		t.Fatalf("manager:mgr-2 order = %v, want [2]", got2)
+	}
+}
+
+// TestCompileResetTypeRules checks the first-match-wins reset closure and that a
+// non-matching power state falls back to the core default.
+func TestCompileResetTypeRules(t *testing.T) {
+	q, err := LoadProfile([]byte("name: x\nresetType:\n  - { when: { powerState: \"Off\" }, then: On }\n  - { when: { powerState: \"*\" }, then: ForceRestart }\n"))
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+
+	// Off -> On (case-insensitive match against the system's PowerState).
+	if got := q.resetType(ResetView{PowerState: "off", Default: "GracefulRestart"}); got != schemas.OnResetType {
+		t.Fatalf("Off rule = %q, want On", got)
+	}
+	// On -> ForceRestart via the "*" rule.
+	if got := q.resetType(ResetView{PowerState: "On", Default: "GracefulRestart"}); got != schemas.ForceRestartResetType {
+		t.Fatalf("On rule = %q, want ForceRestart", got)
+	}
+
+	// With no matching rule and no wildcard, fall back to the core default.
+	q2, err := LoadProfile([]byte("name: x\nresetType:\n  - { when: { powerState: \"Off\" }, then: On }\n"))
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+	if got := q2.resetType(ResetView{PowerState: "On", Default: "GracefulRestart"}); got != schemas.ResetType("GracefulRestart") {
+		t.Fatalf("non-matching rule = %q, want the default GracefulRestart", got)
+	}
+}

--- a/pkg/redfish/quirks.go
+++ b/pkg/redfish/quirks.go
@@ -15,26 +15,33 @@ type quirks struct {
 	// name identifies the profile (for diagnostics only).
 	name string
 
-	// mediaSearch returns the ordered list of VirtualMedia collections to search
-	// for a CD/DVD device. The core supplies the spec-default collections (System
-	// first, then each Manager). A profile may reorder or filter them — e.g. HPE
-	// iLO hosts virtual media under the Manager, so the iLO profile prefers the
-	// Manager collections. Returning nil falls back to the core default.
-	mediaSearch func(d *Deployer, system *schemas.ComputerSystem, def mediaCollections) mediaCollections
+	// mediaSearch reorders/filters the candidate VirtualMedia members. The core
+	// flattens the spec-default collections (System-hosted first, then each
+	// Manager's) into a read-only []MediaView and passes it in; the hook returns
+	// the Indexes it prefers, in order. Out-of-range or duplicate indexes are
+	// dropped by the core; a nil/empty return means "use the core default order".
+	// The hook never sees the *Deployer or any gofish object (design §2 boundary):
+	// e.g. HPE iLO hosts virtual media under the Manager, so the iLO profile emits
+	// the manager-located indexes first.
+	mediaSearch func(media []MediaView) []int
 
-	// mediaType selects the VirtualMedia MediaType sent on InsertMedia. nil uses
-	// the spec default (CD).
-	mediaType func(vm *schemas.VirtualMedia) schemas.VirtualMediaType
+	// mediaType selects the VirtualMedia MediaType sent on InsertMedia, given the
+	// chosen media's read-only MediaView. nil uses the spec default (CD).
+	mediaType func(media MediaView) schemas.VirtualMediaType
 
-	// resetType lets a profile override the chosen ResetType. It receives the
-	// spec-default choice (chooseResetType) and may return a different one. nil
-	// keeps the default.
-	resetType func(system *schemas.ComputerSystem, def schemas.ResetType) schemas.ResetType
+	// resetType lets a profile prefer a ResetType from the read-only ResetView
+	// (current power state, allowable values, and the core default). Whatever it
+	// returns is still re-validated by the core against the allowable values, so a
+	// profile can prefer but never force an unsupported type. nil keeps the
+	// default.
+	resetType func(view ResetView) schemas.ResetType
 
-	// tuneInsertParams adjusts the InsertMedia parameters after the core has built
-	// the spec-default set. A profile may, for example, drop TransferProtocolType
-	// or WriteProtected for BMCs that reject them. nil leaves the params untouched.
-	tuneInsertParams func(params *schemas.VirtualMediaInsertMediaParameters, req DeployRequest)
+	// tuneInsertParams returns a sparse patch over an allowlisted set of InsertMedia
+	// fields, given a read-only InsertParamsView (which never carries the image
+	// URL). The core applies the patch to the spec-default parameters. A profile
+	// may, for example, drop TransferProtocolType for BMCs that reject it. nil
+	// leaves the params untouched.
+	tuneInsertParams func(view InsertParamsView) InsertParamsPatch
 
 	// pushMedia is an optional hook point for a future multipart media push (some
 	// modern BMCs accept a multipart HTTP POST of the ISO bytes instead of a
@@ -64,6 +71,29 @@ func quirksFor(v VendorType) quirks {
 	default:
 		return genericQuirks()
 	}
+}
+
+// builtinQuirks is the registry of in-tree profiles keyed by their declared name.
+// It is the seam a later phase (P3) extends with operator-supplied/YAML profiles;
+// in P1 it only mirrors the named Go profiles. quirksFor's VendorType-switch
+// selection is intentionally NOT routed through this yet, so current selection
+// behaviour (typo ⇒ generic) is unchanged.
+var builtinQuirks = map[string]func() quirks{
+	"generic":    genericQuirks,
+	"ilo":        iloQuirks,
+	"supermicro": supermicroQuirks,
+}
+
+// quirksByName looks up a quirk profile by its declared name. It returns (profile,
+// true) for a known name and (zero, false) otherwise. It does NOT fall back to
+// generic itself — callers decide how an unknown name is handled — so it can be
+// composed with operator/YAML profiles in a later phase without changing the
+// VendorType-driven selection in quirksFor.
+func quirksByName(name string) (quirks, bool) {
+	if producer, ok := builtinQuirks[name]; ok {
+		return producer(), true
+	}
+	return quirks{}, false
 }
 
 // genericQuirks is the spec-default profile: all hooks nil. DMTF/sushy-tools/

--- a/pkg/redfish/quirks_internal_test.go
+++ b/pkg/redfish/quirks_internal_test.go
@@ -37,16 +37,40 @@ func TestVendorProfilesSelected(t *testing.T) {
 }
 
 // TestILOPrefersManagerMedia documents/locks the one safe iLO divergence at the
-// hook level: given Manager-hosted media it is searched ahead of System media.
+// hook level: given Manager-hosted media it is ordered ahead of System media, and
+// with no Manager media it abstains (nil) so the core uses the default order. The
+// hook now works purely over []MediaView (the §2 boundary), so we can exercise it
+// directly here; the end-to-end ordering is also asserted in the fake-BMC-driven
+// spec (deployer_test.go).
 func TestILOPrefersManagerMedia(t *testing.T) {
 	q := iloQuirks()
 	if q.mediaSearch == nil {
 		t.Fatal("iLO profile must define a mediaSearch hook")
 	}
-	// The hook needs a *Deployer to read managers; we cannot easily fake the
-	// gofish service here, so the end-to-end ordering is asserted in the
-	// fake-BMC-driven spec (deployer_test.go). This test just guards the hook's
-	// presence and the supermicro profile's deliberate absence of hooks.
+
+	// Manager-hosted media present: manager indexes come first, then system.
+	views := []MediaView{
+		{Index: 0, ID: "Cd", Location: "system"},
+		{Index: 1, ID: "Cd", Location: "manager:mgr-1"},
+		{Index: 2, ID: "Floppy", Location: "manager:mgr-1"},
+	}
+	got := q.mediaSearch(views)
+	want := []int{1, 2, 0}
+	if len(got) != len(want) {
+		t.Fatalf("mediaSearch order = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("mediaSearch order = %v, want %v", got, want)
+		}
+	}
+
+	// No Manager-hosted media: the hook abstains (nil) so the core keeps the
+	// default order — i.e. behaviour identical to the generic/default path.
+	if got := q.mediaSearch([]MediaView{{Index: 0, ID: "Cd", Location: "system"}}); got != nil {
+		t.Fatalf("mediaSearch with no manager media must abstain (nil), got %v", got)
+	}
+
 	if iloQuirks().tuneInsertParams != nil {
 		t.Fatal("iLO must not silently tweak InsertMedia params (no verified need)")
 	}

--- a/pkg/redfish/quirks_vendor.go
+++ b/pkg/redfish/quirks_vendor.go
@@ -1,6 +1,6 @@
 package redfish
 
-import "github.com/stmcginnis/gofish/schemas"
+import "strings"
 
 // This file holds the conservative, documented per-vendor quirk profiles. Every
 // quirk here is derived from public Redfish/vendor documentation, NOT from
@@ -38,26 +38,37 @@ import "github.com/stmcginnis/gofish/schemas"
 // one-time Cd boot override drives the install boot as expected.
 func iloQuirks() quirks {
 	return quirks{
-		name: "ilo",
-		mediaSearch: func(d *Deployer, system *schemas.ComputerSystem, def mediaCollections) mediaCollections {
-			// Prefer Manager-hosted media first, then fall back to whatever the
-			// System exposed (defensive: some iLO firmware also surfaces it on the
-			// System). We rebuild the order rather than dropping the System
-			// collections entirely so a future/unexpected layout still works.
-			managerMedia := d.managerMediaCollections()
-			if len(managerMedia) == 0 {
-				// Nothing under the Manager — behave exactly like the default.
-				return def
-			}
-			systemMedia := d.systemMediaCollections(system)
-			ordered := make(mediaCollections, 0, len(managerMedia)+len(systemMedia))
-			ordered = append(ordered, managerMedia...)
-			ordered = append(ordered, systemMedia...)
-			return ordered
-		},
+		name:        "ilo",
+		mediaSearch: managerFirstMediaSearch,
 		// iLO accepts the spec-default MediaType (CD) and the URL-pull params, so we
 		// leave mediaType/tuneInsertParams/resetType at spec default.
 	}
+}
+
+// managerFirstMediaSearch is the iLO media-ordering hook: prefer Manager-hosted
+// media, then fall back to whatever the System exposed (defensive: some iLO
+// firmware also surfaces it on the System). It works purely over the read-only
+// []MediaView the core supplies — it has no *Deployer and issues no requests.
+//
+// It preserves the exact semantics of the original hook: when there is no
+// Manager-hosted media it returns nil, which the core reads as "use the default
+// order" — i.e. behaviour identical to the generic/default path. Otherwise it
+// emits the manager-located member indexes first, then the system-located ones,
+// dropping nothing.
+func managerFirstMediaSearch(media []MediaView) []int {
+	var managerIdx, systemIdx []int
+	for _, m := range media {
+		if strings.HasPrefix(m.Location, "manager:") {
+			managerIdx = append(managerIdx, m.Index)
+		} else {
+			systemIdx = append(systemIdx, m.Index)
+		}
+	}
+	if len(managerIdx) == 0 {
+		// Nothing under the Manager — behave exactly like the default.
+		return nil
+	}
+	return append(managerIdx, systemIdx...)
 }
 
 // supermicroQuirks is the Supermicro (X11/X12/H12 BMC) profile.

--- a/pkg/redfish/quirkviews.go
+++ b/pkg/redfish/quirkviews.go
@@ -1,0 +1,98 @@
+package redfish
+
+// This file defines the safe boundary between the spec-correct core flow and a
+// quirk profile. A quirk hook NEVER sees a live gofish object, the *Deployer, the
+// Redfish client, credentials, or the image URL. Instead the core projects the
+// gofish resources it needs into these plain, read-only value structs ("Views"),
+// passes them to the hook, and accepts back a constrained answer (an ordering of
+// indices, an enum pick, a sparse field patch) which the core re-validates before
+// it ever touches the BMC.
+//
+// This is the load-bearing decision of the quirk system (design §2): it is what
+// makes a declaratively-compiled, possibly community-authored profile safe to run
+// against a BMC we hold admin credentials for. The same Views are used by the
+// in-tree Go profiles (quirks_vendor.go) and by the YAML profile compiler
+// (quirkprofile.go), so there is exactly one boundary shape to reason about.
+//
+// All Views are value copies built at the call sites; mutating an input changes
+// nothing in the core. None of them carries the ISO image URL — that is
+// core-owned and SSRF-validated, and a profile must never be able to set it.
+
+// MediaView is the read-only projection of one VirtualMedia member handed to the
+// mediaSearch hook. The hook receives the flattened, spec-default-ordered list of
+// candidate media (System-hosted first, then each Manager's) and returns an
+// ordering/filter over their Index values.
+type MediaView struct {
+	// Index is the member's position in the flat candidate list the hook received.
+	// A mediaSearch hook returns a slice of these to express its preferred order.
+	Index int
+	// ID is the VirtualMedia Redfish Id (e.g. "Cd"), for diagnostics/matching.
+	ID string
+	// Location records where the media is hosted: "system" for ComputerSystem-
+	// hosted media, or "manager:<managerId>" for Manager-hosted media (e.g. HPE
+	// iLO exposes virtual media under the Manager). A profile selects by this.
+	Location string
+	// MediaTypes is the advertised media-type set (e.g. ["CD","DVD"]). May be empty
+	// when the BMC omits the field.
+	MediaTypes []string
+	// ConnectedVia is the VirtualMedia ConnectedVia value when advertised (e.g.
+	// "NotConnected", "URI"), best-effort and informational.
+	ConnectedVia string
+	// Inserted reports whether media is currently inserted in this device.
+	Inserted bool
+}
+
+// ResetView is the read-only projection handed to the resetType hook. The hook may
+// prefer a ResetType from AllowableResetTypes; whatever it returns is still
+// re-validated by the core (firstSupported) against the system's advertised
+// allowable values, so a profile can prefer but never force an unsupported type.
+type ResetView struct {
+	// PowerState is the system's current Redfish PowerState (e.g. "On", "Off").
+	PowerState string
+	// AllowableResetTypes is the system's advertised ResetType allowable values.
+	AllowableResetTypes []string
+	// Default is the ResetType the core chose by default (chooseResetType), offered
+	// so a hook can fall back to it.
+	Default string
+}
+
+// InsertParamsView is the read-only projection of the InsertMedia parameters
+// handed to the tuneInsertParams hook. It deliberately carries NO image URL: the
+// URL is core-owned and SSRF-validated, and a profile must never be able to read
+// or rewrite it. HasImage reports merely that the core set an image, without
+// exposing its value.
+type InsertParamsView struct {
+	// MediaType is the chosen VirtualMedia MediaType (e.g. "CD").
+	MediaType string
+	// TransferProtocolType is the chosen transfer protocol (e.g. "HTTP", "HTTPS"),
+	// empty when the core did not set one.
+	TransferProtocolType string
+	// Inserted / WriteProtected are the boolean params the core set, with their
+	// "was it set" flags so a hook can distinguish false from unset.
+	Inserted          bool
+	InsertedSet       bool
+	WriteProtected    bool
+	WriteProtectedSet bool
+	// HasImage reports that the core set an image URL — never the URL itself.
+	HasImage bool
+}
+
+// InsertParamsPatch is the constrained answer a tuneInsertParams hook returns: a
+// sparse patch over an allowlisted set of InsertMedia fields. The core applies it
+// to the spec-default parameters. Fields NOT named are left untouched; the image
+// URL is structurally absent and can never be patched.
+type InsertParamsPatch struct {
+	// SetMediaType, when non-empty, overrides the MediaType.
+	SetMediaType string
+	// ClearTransferProtocolType drops the TransferProtocolType (some firmware
+	// rejects an explicit one).
+	ClearTransferProtocolType bool
+	// SetTransferProtocolType, when non-empty, overrides the TransferProtocolType.
+	SetTransferProtocolType string
+	// SetInserted / SetWriteProtected override the respective booleans when their
+	// "...Set" flag is true (so a patch can set false explicitly).
+	SetInserted          bool
+	SetInsertedSet       bool
+	SetWriteProtected    bool
+	SetWriteProtectedSet bool
+}

--- a/pkg/redfish/registry.go
+++ b/pkg/redfish/registry.go
@@ -62,13 +62,13 @@ const (
 )
 
 // deriveTier is the single place the project assigns a support tier. Keeping it in
-// one small function is deliberate: P4 flips the in-tree+mockup case to TierB by
-// changing only the `hasMockup` branch here.
+// one small function is deliberate: the in-tree+mockup case (the C->B promotion) is
+// driven entirely by the `hasMockup` argument, which builtinHasMockup supplies.
 //
 // Rules (design §4b):
 //   - operator-supplied profile        => always C (we have no evidence for it).
-//   - in-tree profile WITH a mockup     => B  (TODO(P4): no mockups exist yet, so
-//     hasMockup is always false today; P4 records them and flips these to B).
+//   - in-tree profile WITH a mockup     => B  (P4: a recorded, sanitized mockup is
+//     replayed by the §4a golden test in every-PR CI — builtinHasMockup reports it).
 //   - in-tree profile WITHOUT a mockup  => C, EXCEPT the spec-default "generic"
 //     profile, which is the core-tested path and is therefore A.
 func deriveTier(name string, src origin, hasMockup bool) Tier {
@@ -77,8 +77,8 @@ func deriveTier(name string, src origin, hasMockup bool) Tier {
 	}
 	// In-tree from here on.
 	if hasMockup {
-		// TODO(P4): unreachable until recorded mockups land; this is the C->B
-		// promotion seam (add a sanitized mockup => the profile reaches tier B).
+		// A recorded, sanitized mockup exists for this built-in and is replayed by
+		// the golden test, so it is community-validated against that firmware.
 		return TierB
 	}
 	if name == "generic" {
@@ -86,12 +86,6 @@ func deriveTier(name string, src origin, hasMockup bool) Tier {
 	}
 	return TierC
 }
-
-// builtinHasMockup reports whether an in-tree profile carries a recorded mockup.
-// P4 adds the testdata/mockups/<vendor>/ trees and turns this into a real lookup;
-// until then no in-tree profile has evidence, so every built-in except generic is
-// tier C. Routed through deriveTier so the promotion is a one-line change.
-func builtinHasMockup(string) bool { return false }
 
 // registryEntry is one resolvable profile: its compiled quirks, declared name,
 // derived tier, and origin.

--- a/pkg/redfish/registry.go
+++ b/pkg/redfish/registry.go
@@ -1,0 +1,303 @@
+package redfish
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// This file is P3's profile registry: it loads operator-supplied YAML quirk
+// profiles from a directory and folds them into the built-in (in-tree) profiles,
+// with an explicit, project-derived support tier and a name-first selection seam
+// the CLI and fleet server share.
+//
+// The boundary guarantees from P1/P2 are unchanged: a profile is still inert data
+// compiled through the safe Views (it can never set the Image URL, force an
+// unsupported ResetType, or touch sessions/TLS/system selection). P3 only adds
+// WHERE a profile comes from and HOW it is selected and labelled.
+
+// Tier is the project-derived support level of a quirk profile. A profile never
+// asserts its own tier; the registry derives it from where the profile came from
+// and whether it carries recorded hardware evidence (a sanitized mockup, added in
+// P4). See design §4b.
+type Tier string
+
+const (
+	// TierA — core-tested. The spec-default generic path and whatever the
+	// fake-BMC/sushy CI exercises. Project guarantee; breakage blocks merge.
+	TierA Tier = "A"
+	// TierB — community-validated. An in-tree profile WITH a recorded sanitized
+	// mockup replayed by the golden test. P4 adds the mockups; until then no
+	// profile reaches B (deriveTier has the rule but no mockup evidence yet).
+	TierB Tier = "B"
+	// TierC — unverified. A bare profile with no recorded mockup, whether in-tree
+	// or operator-supplied. Loaded fine, but logged as UNVERIFIED.
+	TierC Tier = "C"
+)
+
+// describe returns the human-readable tier annotation used in load/override log
+// lines, e.g. "tier C: UNVERIFIED — no recorded mockup".
+func (t Tier) describe() string {
+	switch t {
+	case TierA:
+		return "tier A: core-tested"
+	case TierB:
+		return "tier B: community-validated"
+	default:
+		return "tier C: UNVERIFIED — no recorded mockup"
+	}
+}
+
+// origin records where a registered profile came from, which drives tier
+// derivation and the override-precedence log line.
+type origin int
+
+const (
+	originBuiltin  origin = iota // compiled in-tree (quirks_vendor.go)
+	originOperator               // loaded from --quirks-dir / --redfish-quirks-dir
+)
+
+// deriveTier is the single place the project assigns a support tier. Keeping it in
+// one small function is deliberate: P4 flips the in-tree+mockup case to TierB by
+// changing only the `hasMockup` branch here.
+//
+// Rules (design §4b):
+//   - operator-supplied profile        => always C (we have no evidence for it).
+//   - in-tree profile WITH a mockup     => B  (TODO(P4): no mockups exist yet, so
+//     hasMockup is always false today; P4 records them and flips these to B).
+//   - in-tree profile WITHOUT a mockup  => C, EXCEPT the spec-default "generic"
+//     profile, which is the core-tested path and is therefore A.
+func deriveTier(name string, src origin, hasMockup bool) Tier {
+	if src == originOperator {
+		return TierC
+	}
+	// In-tree from here on.
+	if hasMockup {
+		// TODO(P4): unreachable until recorded mockups land; this is the C->B
+		// promotion seam (add a sanitized mockup => the profile reaches tier B).
+		return TierB
+	}
+	if name == "generic" {
+		return TierA
+	}
+	return TierC
+}
+
+// builtinHasMockup reports whether an in-tree profile carries a recorded mockup.
+// P4 adds the testdata/mockups/<vendor>/ trees and turns this into a real lookup;
+// until then no in-tree profile has evidence, so every built-in except generic is
+// tier C. Routed through deriveTier so the promotion is a one-line change.
+func builtinHasMockup(string) bool { return false }
+
+// registryEntry is one resolvable profile: its compiled quirks, declared name,
+// derived tier, and origin.
+type registryEntry struct {
+	quirks quirks
+	name   string
+	tier   Tier
+	origin origin
+}
+
+// ProfileLoadResult records the outcome of loading one operator profile file. A
+// malformed profile disables only itself: Err is set, Name/Tier are best-effort,
+// and the load of the rest of the directory continues. Callers (the CLI/server)
+// log these; the registry has already logged a line per profile too.
+type ProfileLoadResult struct {
+	// Path is the file the result is for.
+	Path string
+	// Name is the profile's declared name (empty when parsing failed before the
+	// name was read).
+	Name string
+	// Tier is the derived support tier (always TierC for operator profiles).
+	Tier Tier
+	// Overrode is true when this operator profile replaced a built-in of the same
+	// name in the registry.
+	Overrode bool
+	// Err is non-nil when the file could not be parsed/compiled; that single
+	// profile is skipped and every other profile in the directory still loads.
+	Err error
+}
+
+// Registry holds the resolvable quirk profiles: the built-in (in-tree) profiles
+// plus any operator-supplied profiles loaded from a directory. It is built once at
+// process/server start (load-at-start, NOT hot-reloaded: an in-flight deploy must
+// never have its profile swapped — design §5) and is then read-only.
+type Registry struct {
+	byName map[string]registryEntry
+}
+
+// newRegistry builds a Registry seeded with the built-in profiles, each at its
+// project-derived tier.
+func newRegistry() *Registry {
+	r := &Registry{byName: make(map[string]registryEntry)}
+	for name, produce := range builtinQuirks {
+		r.byName[name] = registryEntry{
+			quirks: produce(),
+			name:   name,
+			tier:   deriveTier(name, originBuiltin, builtinHasMockup(name)),
+			origin: originBuiltin,
+		}
+	}
+	return r
+}
+
+// add inserts (or overrides) a profile, logging a load line and, on a name
+// collision with a built-in, a loud override line. Mirrors the audit-log-the-
+// override pattern used by the eject fallback / settings precedence.
+func (r *Registry) add(e registryEntry) (overrode bool) {
+	if prev, ok := r.byName[e.name]; ok && prev.origin == originBuiltin && e.origin == originOperator {
+		overrode = true
+		log.Printf("redfish: operator quirk profile %q overrides the built-in [%s]", e.name, e.tier.describe())
+	}
+	r.byName[e.name] = e
+	log.Printf("redfish: loaded quirk profile %q [%s]", e.name, e.tier.describe())
+	return overrode
+}
+
+// quirksForName resolves a profile by name first, then falls back to the
+// VendorType mapping, then to generic. This is the selection seam the CLI and
+// server share. A typo / unknown name MUST resolve to generic so a mistake can
+// never silently enable the wrong vendor workaround (the P1 invariant). The bool
+// reports whether the lookup matched a registered profile by name (false means it
+// fell through to the VendorType/generic path).
+func (r *Registry) quirksForName(name string) (quirks, Tier, bool) {
+	if e, ok := r.byName[strings.TrimSpace(name)]; ok {
+		return e.quirks, e.tier, true
+	}
+	// Not a registered profile name: fall back to the VendorType mapping (which
+	// itself resolves unknown vendors to generic), and report the built-in's tier.
+	q := quirksFor(VendorType(name))
+	if e, ok := r.byName[q.name]; ok {
+		return q, e.tier, false
+	}
+	return q, deriveTier(q.name, originBuiltin, builtinHasMockup(q.name)), false
+}
+
+// LoadProfileDir reads every *.yaml / *.yml file in dir, parses and compiles each
+// into the registry, and returns one ProfileLoadResult per file. A single bad
+// profile is a logged error that disables ONLY that profile (design "malformed
+// profile disables only itself"): it never fails the whole load. An empty or
+// missing dir is not an error (the registry keeps only its built-ins). The
+// returned error is reserved for a directory-read failure.
+//
+// The returned Registry is ready for selection via quirksForName and must be
+// treated as read-only thereafter (load-at-start, no hot-reload).
+func LoadProfileDir(dir string) (*Registry, []ProfileLoadResult, error) {
+	r := newRegistry()
+
+	if strings.TrimSpace(dir) == "" {
+		return r, nil, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("redfish: quirks dir %q does not exist; using built-in profiles only", dir)
+			return r, nil, nil
+		}
+		return r, nil, fmt.Errorf("reading quirks dir %q: %w", dir, err)
+	}
+
+	// Deterministic order so override logging and results are stable.
+	files := make([]string, 0, len(entries))
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		if !isProfileFile(ent.Name()) {
+			continue
+		}
+		files = append(files, ent.Name())
+	}
+	sort.Strings(files)
+
+	var results []ProfileLoadResult
+	for _, fname := range files {
+		path := filepath.Join(dir, fname)
+		res := ProfileLoadResult{Path: path, Tier: TierC}
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			res.Err = fmt.Errorf("reading quirk profile %q: %w", path, readErr)
+			log.Printf("redfish: skipping quirk profile %q: %v", path, res.Err)
+			results = append(results, res)
+			continue
+		}
+
+		profile, parseErr := ParseProfile(data)
+		if parseErr != nil {
+			res.Err = fmt.Errorf("loading quirk profile %q: %w", path, parseErr)
+			log.Printf("redfish: skipping quirk profile %q: %v", path, res.Err)
+			results = append(results, res)
+			continue
+		}
+
+		q, compileErr := profile.Compile()
+		if compileErr != nil {
+			res.Err = fmt.Errorf("compiling quirk profile %q: %w", path, compileErr)
+			log.Printf("redfish: skipping quirk profile %q: %v", path, res.Err)
+			results = append(results, res)
+			continue
+		}
+
+		// Operator profiles are ALWAYS tier C (design §4b): we have no recorded
+		// evidence for them, regardless of any tier the file might imply.
+		res.Name = profile.Name
+		res.Tier = deriveTier(profile.Name, originOperator, false)
+		res.Overrode = r.add(registryEntry{
+			quirks: q,
+			name:   profile.Name,
+			tier:   res.Tier,
+			origin: originOperator,
+		})
+		results = append(results, res)
+	}
+
+	return r, results, nil
+}
+
+// isProfileFile reports whether a filename is a YAML quirk profile by extension.
+func isProfileFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// defaultRegistry is the process-wide registry consulted by NewDeployer when no
+// per-Deployer registry is supplied. It holds only the built-in profiles until
+// SetDefaultRegistry installs an operator-loaded one at start. It is guarded by a
+// mutex purely for the load-at-start write; reads after start are effectively
+// read-only.
+var (
+	defaultRegistryMu sync.RWMutex
+	defaultRegistry   = newRegistry()
+)
+
+// SetDefaultRegistry installs the process-wide registry (load-at-start). The CLI
+// and fleet server call it once, after LoadProfileDir, so every subsequent
+// NewDeployer resolves names/vendors against the loaded operator profiles. A nil
+// argument is ignored (keeps the built-in-only registry).
+func SetDefaultRegistry(r *Registry) {
+	if r == nil {
+		return
+	}
+	defaultRegistryMu.Lock()
+	defaultRegistry = r
+	defaultRegistryMu.Unlock()
+}
+
+// resolveQuirks selects the quirks for a profile name / vendor string using the
+// process-wide registry: name-first, then the VendorType mapping, then generic.
+// NewDeployer uses it so the operator dir is honoured everywhere a Deployer is
+// built (CLI and fleet server) without threading a registry through every call
+// site.
+func resolveQuirks(name string) quirks {
+	defaultRegistryMu.RLock()
+	r := defaultRegistry
+	defaultRegistryMu.RUnlock()
+	q, _, _ := r.quirksForName(name)
+	return q
+}

--- a/pkg/redfish/registry.go
+++ b/pkg/redfish/registry.go
@@ -88,12 +88,56 @@ func deriveTier(name string, src origin, hasMockup bool) Tier {
 }
 
 // registryEntry is one resolvable profile: its compiled quirks, declared name,
-// derived tier, and origin.
+// derived tier, origin, and the informational firmware label a profile may carry.
 type registryEntry struct {
-	quirks quirks
-	name   string
-	tier   Tier
-	origin origin
+	quirks            quirks
+	name              string
+	tier              Tier
+	origin            origin
+	validatedFirmware string
+}
+
+// ProfileInfo is a read-only description of one registered quirk profile, for
+// listing (e.g. the fleet server's quirk-profiles endpoint that populates the UI
+// vendor selector with tier badges). It carries no quirks/closures — purely the
+// labelling an operator needs to pick a profile.
+type ProfileInfo struct {
+	// Name is the profile's selection name (what a BMCTarget.Vendor matches).
+	Name string
+	// Tier is the project-derived support tier (A/B/C); a profile never asserts it.
+	Tier Tier
+	// TierDescription is the human-readable annotation, e.g.
+	// "tier C: UNVERIFIED — no recorded mockup".
+	TierDescription string
+	// Origin is "builtin" for in-tree profiles or "operator" for ones loaded from
+	// the quirks directory.
+	Origin string
+	// ValidatedFirmware is the informational firmware label the profile declared,
+	// when any (empty for built-ins without recorded evidence).
+	ValidatedFirmware string
+}
+
+// Profiles returns every registered profile as a read-only ProfileInfo, sorted by
+// name. It is the listing seam the fleet server exposes so the UI can populate the
+// vendor selector from the profiles actually loaded (built-in + operator) instead
+// of a hardcoded list, and surface each profile's support tier.
+func (r *Registry) Profiles() []ProfileInfo {
+	infos := make([]ProfileInfo, 0, len(r.byName))
+	for _, e := range r.byName {
+		o := "builtin"
+		if e.origin == originOperator {
+			o = "operator"
+		}
+		infos = append(infos, ProfileInfo{
+			Name:              e.name,
+			Tier:              e.tier,
+			TierDescription:   e.tier.describe(),
+			Origin:            o,
+			ValidatedFirmware: e.validatedFirmware,
+		})
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+	return infos
 }
 
 // ProfileLoadResult records the outcome of loading one operator profile file. A
@@ -243,10 +287,11 @@ func LoadProfileDir(dir string) (*Registry, []ProfileLoadResult, error) {
 		res.Name = profile.Name
 		res.Tier = deriveTier(profile.Name, originOperator, false)
 		res.Overrode = r.add(registryEntry{
-			quirks: q,
-			name:   profile.Name,
-			tier:   res.Tier,
-			origin: originOperator,
+			quirks:            q,
+			name:              profile.Name,
+			tier:              res.Tier,
+			origin:            originOperator,
+			validatedFirmware: profile.ValidatedFirmware,
 		})
 		results = append(results, res)
 	}
@@ -281,6 +326,16 @@ func SetDefaultRegistry(r *Registry) {
 	defaultRegistryMu.Lock()
 	defaultRegistry = r
 	defaultRegistryMu.Unlock()
+}
+
+// DefaultRegistry returns the process-wide registry installed at start (built-in
+// profiles, plus any operator profiles loaded via SetDefaultRegistry). The fleet
+// server uses it to list the loaded profiles for the UI. The returned Registry is
+// read-only after start; callers must only read it (e.g. via Profiles).
+func DefaultRegistry() *Registry {
+	defaultRegistryMu.RLock()
+	defer defaultRegistryMu.RUnlock()
+	return defaultRegistry
 }
 
 // resolveQuirks selects the quirks for a profile name / vendor string using the

--- a/pkg/redfish/registry_internal_test.go
+++ b/pkg/redfish/registry_internal_test.go
@@ -149,9 +149,15 @@ func TestLoadProfileDirOverridesBuiltin(t *testing.T) {
 func TestQuirksForNameFallback(t *testing.T) {
 	r := newRegistry()
 
+	// ilo now ships a recorded mockup (P4), so the built-in resolves at tier B.
 	q, tier, ok := r.quirksForName("ilo")
-	if !ok || q.name != "ilo" || tier != TierC {
+	if !ok || q.name != "ilo" || tier != TierB {
 		t.Fatalf("ilo: name=%q tier=%q ok=%v", q.name, tier, ok)
+	}
+
+	// supermicro has no mockup, so it stays tier C.
+	if _, tier, ok := r.quirksForName("supermicro"); !ok || tier != TierC {
+		t.Fatalf("supermicro must stay tier C: tier=%q ok=%v", tier, ok)
 	}
 
 	// Unknown name MUST resolve to generic, reported as not a name match.

--- a/pkg/redfish/registry_internal_test.go
+++ b/pkg/redfish/registry_internal_test.go
@@ -237,3 +237,52 @@ func TestExampleProfilesParse(t *testing.T) {
 		t.Fatal("expected at least one example profile in examples/redfish/quirks")
 	}
 }
+
+// TestRegistryProfiles locks the listing seam the fleet server exposes for the UI
+// vendor selector: every registered profile is returned, sorted by name, with its
+// project-derived tier, origin, and (for operator profiles) the declared firmware
+// label. Built-ins carry no validatedFirmware.
+func TestRegistryProfiles(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "acme.yaml",
+		"name: acme\nmatch: { vendor: Acme }\nmediaSearch: { order: [manager, system] }\nvalidatedFirmware: \"FW 1.23\"\n")
+
+	r, _, err := LoadProfileDir(dir)
+	if err != nil {
+		t.Fatalf("LoadProfileDir: %v", err)
+	}
+
+	infos := r.Profiles()
+
+	// Sorted by name.
+	for i := 1; i < len(infos); i++ {
+		if infos[i-1].Name > infos[i].Name {
+			t.Fatalf("Profiles() not sorted by name: %q before %q", infos[i-1].Name, infos[i].Name)
+		}
+	}
+
+	byName := make(map[string]ProfileInfo, len(infos))
+	for _, p := range infos {
+		byName[p.Name] = p
+	}
+
+	// generic is the core-tested built-in (tier A, no firmware label).
+	if g, ok := byName["generic"]; !ok || g.Tier != TierA || g.Origin != "builtin" || g.ValidatedFirmware != "" {
+		t.Fatalf("generic: %+v (ok=%v)", byName["generic"], ok)
+	}
+
+	// The operator profile is tier C, origin operator, and surfaces its firmware.
+	c, ok := byName["acme"]
+	if !ok {
+		t.Fatal("acme operator profile missing from Profiles()")
+	}
+	if c.Tier != TierC || c.Origin != "operator" {
+		t.Fatalf("acme tier/origin: %+v", c)
+	}
+	if c.ValidatedFirmware != "FW 1.23" {
+		t.Fatalf("acme validatedFirmware not surfaced: %q", c.ValidatedFirmware)
+	}
+	if c.TierDescription == "" || c.TierDescription != TierC.describe() {
+		t.Fatalf("acme tierDescription: %q", c.TierDescription)
+	}
+}

--- a/pkg/redfish/registry_internal_test.go
+++ b/pkg/redfish/registry_internal_test.go
@@ -1,0 +1,233 @@
+package redfish
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeProfile is a tiny helper: write a profile file into dir and return nothing.
+func writeProfile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}
+
+// TestDeriveTier locks the project-derived tier rules (design §4b). Operator
+// profiles are always C; in-tree generic is A; other in-tree without a mockup is
+// C; in-tree WITH a mockup is B (the P4 promotion seam).
+func TestDeriveTier(t *testing.T) {
+	cases := []struct {
+		name      string
+		src       origin
+		hasMockup bool
+		want      Tier
+	}{
+		{"generic", originBuiltin, false, TierA},
+		{"ilo", originBuiltin, false, TierC},
+		{"supermicro", originBuiltin, false, TierC},
+		{"ilo", originBuiltin, true, TierB},       // P4: in-tree + mockup => B
+		{"generic", originOperator, false, TierC}, // operator dir is ALWAYS C
+		{"anything", originOperator, true, TierC}, // even a (hypothetical) operator mockup stays C
+	}
+	for _, c := range cases {
+		if got := deriveTier(c.name, c.src, c.hasMockup); got != c.want {
+			t.Fatalf("deriveTier(%q, %v, %v) = %q, want %q", c.name, c.src, c.hasMockup, got, c.want)
+		}
+	}
+}
+
+// TestLoadProfileDirEmptyAndMissing confirms an empty/missing/blank dir is not an
+// error and yields a built-in-only registry.
+func TestLoadProfileDirEmptyAndMissing(t *testing.T) {
+	r, results, err := LoadProfileDir("")
+	if err != nil || results != nil {
+		t.Fatalf("blank dir: err=%v results=%v", err, results)
+	}
+	if _, _, ok := r.quirksForName("ilo"); !ok {
+		t.Fatal("built-in ilo must resolve in a blank-dir registry")
+	}
+
+	if _, _, err := LoadProfileDir(filepath.Join(t.TempDir(), "does-not-exist")); err != nil {
+		t.Fatalf("missing dir must not error: %v", err)
+	}
+
+	empty := t.TempDir()
+	r, results, err = LoadProfileDir(empty)
+	if err != nil {
+		t.Fatalf("empty dir: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("empty dir should yield no results, got %v", results)
+	}
+	if got, tier, ok := r.quirksForName("generic"); !ok || got.name != "generic" || tier != TierA {
+		t.Fatalf("generic in empty-dir registry: name=%q tier=%q ok=%v", got.name, tier, ok)
+	}
+}
+
+// TestLoadProfileDirLoadsAndSkips loads a directory with one valid and one
+// malformed profile: the valid one loads, the bad one is skipped+reported, and the
+// rest of the load is unaffected.
+func TestLoadProfileDirLoadsAndSkips(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "good.yaml", "name: good\nmediaType: DVD\n")
+	// Bad: Image is a rejected (SSRF-owned) field.
+	writeProfile(t, dir, "bad.yaml", "name: bad\ntuneInsertParams:\n  set:\n    Image: http://evil\n")
+	// Non-profile extension must be ignored entirely.
+	writeProfile(t, dir, "notes.txt", "this is not a profile")
+
+	r, results, err := LoadProfileDir(dir)
+	if err != nil {
+		t.Fatalf("LoadProfileDir: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (good+bad, .txt ignored), got %d: %v", len(results), results)
+	}
+
+	var good, bad *ProfileLoadResult
+	for i := range results {
+		switch filepath.Base(results[i].Path) {
+		case "good.yaml":
+			good = &results[i]
+		case "bad.yaml":
+			bad = &results[i]
+		}
+	}
+	if good == nil || good.Err != nil || good.Name != "good" || good.Tier != TierC {
+		t.Fatalf("good.yaml result wrong: %+v", good)
+	}
+	if bad == nil || bad.Err == nil {
+		t.Fatalf("bad.yaml must report an error: %+v", bad)
+	}
+
+	// The valid profile resolves; the malformed one did NOT register.
+	if q, tier, ok := r.quirksForName("good"); !ok || q.name != "good" || tier != TierC {
+		t.Fatalf("good not resolvable: name=%q tier=%q ok=%v", q.name, tier, ok)
+	}
+	if _, _, ok := r.quirksForName("bad"); ok {
+		t.Fatal("malformed profile must not register; a skip must disable only itself")
+	}
+}
+
+// TestLoadProfileDirOverridesBuiltin is the precedence test: an operator profile
+// named the same as a built-in overrides it, the result reports Overrode, and the
+// resolved quirks are the operator's (proved by a hook the built-in lacks).
+func TestLoadProfileDirOverridesBuiltin(t *testing.T) {
+	// Sanity: the built-in supermicro profile has NO mediaType hook.
+	if quirksFor(VendorSuperMicro).mediaType != nil {
+		t.Fatal("precondition: built-in supermicro must have no mediaType hook")
+	}
+
+	dir := t.TempDir()
+	// Operator "supermicro" that sets a mediaType — a hook the built-in lacks.
+	writeProfile(t, dir, "supermicro.yaml", "name: supermicro\nmediaType: DVD\n")
+
+	r, results, err := LoadProfileDir(dir)
+	if err != nil {
+		t.Fatalf("LoadProfileDir: %v", err)
+	}
+	if len(results) != 1 || !results[0].Overrode {
+		t.Fatalf("expected the operator supermicro to report Overrode, got %+v", results)
+	}
+	if results[0].Tier != TierC {
+		t.Fatalf("operator override must be tier C, got %q", results[0].Tier)
+	}
+
+	q, tier, ok := r.quirksForName("supermicro")
+	if !ok || tier != TierC {
+		t.Fatalf("override resolution: ok=%v tier=%q", ok, tier)
+	}
+	if q.mediaType == nil {
+		t.Fatal("override must return the OPERATOR profile (with its mediaType hook), not the built-in")
+	}
+}
+
+// TestQuirksForNameFallback confirms the selection invariants: a known built-in
+// name resolves with its tier; an unknown name falls back to generic (never a
+// silent wrong workaround); a VendorType string still resolves through quirksFor.
+func TestQuirksForNameFallback(t *testing.T) {
+	r := newRegistry()
+
+	q, tier, ok := r.quirksForName("ilo")
+	if !ok || q.name != "ilo" || tier != TierC {
+		t.Fatalf("ilo: name=%q tier=%q ok=%v", q.name, tier, ok)
+	}
+
+	// Unknown name MUST resolve to generic, reported as not a name match.
+	q, tier, ok = r.quirksForName("totally-unknown-vendor")
+	if ok {
+		t.Fatal("unknown name must report ok=false (fell through to vendor/generic)")
+	}
+	if q.name != "generic" || tier != TierA {
+		t.Fatalf("unknown name must resolve to generic [A]: name=%q tier=%q", q.name, tier)
+	}
+
+	// "dmtf" is a VendorType that maps to generic — name miss, generic result.
+	q, _, ok = r.quirksForName("dmtf")
+	if ok || q.name != "generic" {
+		t.Fatalf("dmtf must fall through to generic: name=%q ok=%v", q.name, ok)
+	}
+}
+
+// TestSetDefaultRegistryRoutesDeployer confirms the process-wide registry is what
+// NewDeployer resolves against: after installing an operator override, a Deployer
+// built for that vendor gets the operator quirks. It also confirms nil is ignored.
+func TestSetDefaultRegistryRoutesDeployer(t *testing.T) {
+	// Restore the default registry after the test so other tests see built-ins.
+	defaultRegistryMu.RLock()
+	saved := defaultRegistry
+	defaultRegistryMu.RUnlock()
+	t.Cleanup(func() { SetDefaultRegistry(saved) })
+
+	SetDefaultRegistry(nil) // ignored: must not nil out the registry
+	if resolveQuirks("generic").name != "generic" {
+		t.Fatal("SetDefaultRegistry(nil) must be a no-op")
+	}
+
+	dir := t.TempDir()
+	writeProfile(t, dir, "ilo.yaml", "name: ilo\nmediaType: DVD\n")
+	r, _, err := LoadProfileDir(dir)
+	if err != nil {
+		t.Fatalf("LoadProfileDir: %v", err)
+	}
+	SetDefaultRegistry(r)
+
+	d := NewDeployer(Config{Endpoint: "https://bmc.example", Vendor: VendorHPE})
+	if d.quirks.mediaType == nil {
+		t.Fatal("NewDeployer(VendorHPE) must pick up the operator ilo override via the default registry")
+	}
+
+	// An unknown vendor still resolves to generic (zero-value) through the registry.
+	d = NewDeployer(Config{Endpoint: "https://bmc.example", Vendor: "nope"})
+	if d.quirks.name != "generic" || d.quirks.mediaType != nil {
+		t.Fatalf("unknown vendor must resolve to generic zero-value, got name=%q", d.quirks.name)
+	}
+}
+
+// TestExampleProfilesParse walks examples/redfish/quirks and asserts every shipped
+// example profile parses cleanly (they double as load tests and copy-paste seeds).
+func TestExampleProfilesParse(t *testing.T) {
+	dir := filepath.Join("..", "..", "examples", "redfish", "quirks")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading examples dir: %v", err)
+	}
+	var seen int
+	for _, ent := range entries {
+		if ent.IsDir() || !isProfileFile(ent.Name()) {
+			continue
+		}
+		seen++
+		data, err := os.ReadFile(filepath.Join(dir, ent.Name()))
+		if err != nil {
+			t.Fatalf("reading %s: %v", ent.Name(), err)
+		}
+		if _, err := ParseProfile(data); err != nil {
+			t.Fatalf("example profile %s must parse cleanly: %v", ent.Name(), err)
+		}
+	}
+	if seen == 0 {
+		t.Fatal("expected at least one example profile in examples/redfish/quirks")
+	}
+}

--- a/pkg/redfish/testdata/mockups/README.md
+++ b/pkg/redfish/testdata/mockups/README.md
@@ -1,0 +1,83 @@
+# Recorded BMC mockups (tier-B evidence)
+
+This directory holds **recorded, sanitized DMTF mockups** of real BMCs. Each mockup
+is the no-hardware fidelity substitute for metal: CI replays a vendor's recorded GET
+responses against the Redfish deploy flow on **every PR** (pure Go, blocking), so a
+per-vendor quirk profile is golden-tested against that vendor's REAL responses with
+no hardware in the project's CI.
+
+A built-in profile that ships a mockup here is promoted to **tier B**
+("community-validated against the recorded firmware") — see `../../mockups.go`,
+`deriveTier` in `../../registry.go`, and the golden test in
+`../../mockup_golden_test.go`. This is the entire C→B promotion incentive (design
+§4a/§4b, RFC 0001 P4).
+
+## Layout (DMTF `redfish-mockup-creator` format)
+
+```
+testdata/mockups/<vendor>/<model-or-firmware>/
+  redfish/v1/index.json                         # ServiceRoot
+  redfish/v1/Systems/index.json                 # ComputerSystem collection
+  redfish/v1/Systems/<id>/index.json            # the member (model/mfr/Boot/Reset action)
+  redfish/v1/Systems/<id>/VirtualMedia/...       # System-hosted media (if any)
+  redfish/v1/Managers/index.json
+  redfish/v1/Managers/<id>/index.json
+  redfish/v1/Managers/<id>/VirtualMedia/...      # Manager-hosted media (iLO lives here)
+  redfish/v1/TaskService/index.json
+```
+
+The tree mirrors the Redfish URI hierarchy: **each resource is a directory whose
+`index.json` is the GET body for that URI** (e.g. a GET of
+`/redfish/v1/Systems/1` is served from `.../Systems/1/index.json`). The replay
+harness (`../../mockupbmc_test.go`) serves these recorded GETs and keeps the
+synthesized POST/PATCH action handlers a static mockup cannot record (InsertMedia →
+202 + Task, Reset → 204/Task, Task → Completed, session create/DELETE).
+
+## Prune list (keep mockups small — cap a few hundred KB)
+
+Record only the **deploy-relevant subtree**:
+
+- ServiceRoot (`redfish/v1/index.json`), with `SessionService`/`Links.Sessions`.
+- The `Systems` collection and the target member, including:
+  - `Manufacturer` / `Model` (used for vendor identification),
+  - `MemorySummary.TotalSystemMemoryGiB` and `ProcessorSummary.Count`,
+  - the `Boot` object (and `BootSourceOverrideMode@Redfish.AllowableValues` if the
+    BMC advertises it),
+  - the `#ComputerSystem.Reset` action **with its `ResetType@Redfish.AllowableValues`**.
+- `VirtualMedia` collections + the CD/DVD member, on the System and/or the Managers —
+  whichever the BMC actually exposes (iLO exposes it under the Manager only).
+- The `Managers` collection + the target Manager.
+- `TaskService/index.json`.
+
+Drop everything else (Chassis, Sensors, EthernetInterfaces, BIOS attribute
+registries, etc.): the golden test never touches them.
+
+## Sanitization (required, by construction)
+
+Recorded trees from real hardware contain serials, MACs, IPs, asset tags, and UUIDs.
+**Mockups committed here must be sanitized**: replace any such value with an obvious
+placeholder (`PLACEHOLDER-SERIAL`, `00000000-0000-0000-0000-000000000000`, etc.).
+The hand-authored iLO mockups here are sanitized by construction. A contributor PRing
+a recorded mockup must attest to the sanitization pass (see
+`../../../../docs/CONTRIBUTING-vendor-profiles.md` and the vendor-profile PR
+template).
+
+## Adding the next vendor (one golden-test row)
+
+1. Record/author `testdata/mockups/<vendor>/<fw>/` per the layout + prune list above,
+   sanitized.
+2. Add the vendor's name to `../../mockups.manifest` **iff** it is a built-in
+   profile (this is what makes the runtime report tier B; an internal test keeps the
+   manifest in exact sync with the committed trees).
+3. Add a `goldenCase` row in `../../mockup_golden_test.go` selecting that vendor's
+   profile against the new tree, asserting: the discovered SystemID + VirtualMedia
+   member, the InsertMedia body (`Image` equals the served URL — the profile must
+   never rewrite it), the boot PATCH, the Reset `ResetType` (validated against the
+   recorded allowable values), and the session DELETE on teardown.
+
+## Current mockups
+
+| Vendor | Tree | Shape | Profile | Tier |
+|---|---|---|---|---|
+| HPE iLO | `ilo/gen10-ilo5-fw2.44` | Manager-hosted CD only (member 2 CD/DVD, member 1 Floppy/USB); ProLiant DL360 Gen10 / iLO 5 | `ilo` | B |
+| HPE iLO | `ilo/system-and-manager-cd` | CD on **both** System and Manager — the negative-guard tree proving `ilo` (manager-first) and `generic` (system-first) pick **different** media | `ilo` / `generic` | (test fixture) |

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/1/VirtualMedia/1/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/1/VirtualMedia/1/index.json
@@ -1,0 +1,19 @@
+{
+  "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/1",
+  "@odata.type": "#VirtualMedia.v1_3_0.VirtualMedia",
+  "Id": "1",
+  "Name": "VirtualMedia",
+  "MediaTypes": [ "Floppy", "USBStick" ],
+  "Image": null,
+  "Inserted": false,
+  "WriteProtected": false,
+  "ConnectedVia": "NotConnected",
+  "Actions": {
+    "#VirtualMedia.InsertMedia": {
+      "target": "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.InsertMedia"
+    },
+    "#VirtualMedia.EjectMedia": {
+      "target": "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.EjectMedia"
+    }
+  }
+}

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/1/VirtualMedia/2/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/1/VirtualMedia/2/index.json
@@ -1,0 +1,19 @@
+{
+  "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/2",
+  "@odata.type": "#VirtualMedia.v1_3_0.VirtualMedia",
+  "Id": "2",
+  "Name": "VirtualMedia",
+  "MediaTypes": [ "CD", "DVD" ],
+  "Image": null,
+  "Inserted": false,
+  "WriteProtected": true,
+  "ConnectedVia": "NotConnected",
+  "Actions": {
+    "#VirtualMedia.InsertMedia": {
+      "target": "/redfish/v1/Managers/1/VirtualMedia/2/Actions/VirtualMedia.InsertMedia"
+    },
+    "#VirtualMedia.EjectMedia": {
+      "target": "/redfish/v1/Managers/1/VirtualMedia/2/Actions/VirtualMedia.EjectMedia"
+    }
+  }
+}

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/1/VirtualMedia/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/1/VirtualMedia/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.id": "/redfish/v1/Managers/1/VirtualMedia",
+  "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+  "Name": "Virtual Media Services",
+  "Members@odata.count": 2,
+  "Members": [
+    { "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/1" },
+    { "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/2" }
+  ]
+}

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/1/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/1/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.id": "/redfish/v1/Managers/1",
+  "@odata.type": "#Manager.v1_5_1.Manager",
+  "Id": "1",
+  "Name": "Manager",
+  "ManagerType": "BMC",
+  "Model": "iLO 5",
+  "FirmwareVersion": "iLO 5 v2.44",
+  "VirtualMedia": { "@odata.id": "/redfish/v1/Managers/1/VirtualMedia" }
+}

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Managers/index.json
@@ -1,0 +1,9 @@
+{
+  "@odata.id": "/redfish/v1/Managers",
+  "@odata.type": "#ManagerCollection.ManagerCollection",
+  "Name": "Manager Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    { "@odata.id": "/redfish/v1/Managers/1" }
+  ]
+}

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Systems/1/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Systems/1/index.json
@@ -1,0 +1,45 @@
+{
+  "@odata.id": "/redfish/v1/Systems/1",
+  "@odata.type": "#ComputerSystem.v1_10_0.ComputerSystem",
+  "Id": "1",
+  "Name": "Computer System",
+  "Manufacturer": "HPE",
+  "Model": "ProLiant DL360 Gen10",
+  "SerialNumber": "PLACEHOLDER-SERIAL",
+  "SKU": "PLACEHOLDER-SKU",
+  "AssetTag": "PLACEHOLDER-ASSET-TAG",
+  "UUID": "00000000-0000-0000-0000-000000000000",
+  "BiosVersion": "U32 v2.44 (placeholder)",
+  "PowerState": "On",
+  "MemorySummary": {
+    "TotalSystemMemoryGiB": 128
+  },
+  "ProcessorSummary": {
+    "Count": 2,
+    "Model": "Intel Xeon (placeholder)"
+  },
+  "Boot": {
+    "BootSourceOverrideEnabled": "Disabled",
+    "BootSourceOverrideTarget": "None",
+    "BootSourceOverrideMode": "UEFI",
+    "BootSourceOverrideTarget@Redfish.AllowableValues": [
+      "None", "Pxe", "Cd", "Usb", "Hdd", "BiosSetup", "UefiTarget", "UefiHttp"
+    ],
+    "BootSourceOverrideMode@Redfish.AllowableValues": [
+      "Legacy", "UEFI"
+    ]
+  },
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+      "ResetType@Redfish.AllowableValues": [
+        "On",
+        "ForceOff",
+        "GracefulShutdown",
+        "ForceRestart",
+        "Nmi",
+        "PushPowerButton"
+      ]
+    }
+  }
+}

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Systems/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/Systems/index.json
@@ -1,0 +1,9 @@
+{
+  "@odata.id": "/redfish/v1/Systems",
+  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+  "Name": "Computer System Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    { "@odata.id": "/redfish/v1/Systems/1" }
+  ]
+}

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/TaskService/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/TaskService/index.json
@@ -1,0 +1,8 @@
+{
+  "@odata.id": "/redfish/v1/TaskService",
+  "@odata.type": "#TaskService.v1_1_4.TaskService",
+  "Id": "TaskService",
+  "Name": "Task Service",
+  "ServiceEnabled": true,
+  "Tasks": { "@odata.id": "/redfish/v1/TaskService/Tasks" }
+}

--- a/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/gen10-ilo5-fw2.44/redfish/v1/index.json
@@ -1,0 +1,15 @@
+{
+  "@odata.id": "/redfish/v1/",
+  "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+  "Id": "RootService",
+  "Name": "HPE RESTful Root Service",
+  "RedfishVersion": "1.6.0",
+  "Vendor": "HPE",
+  "Systems": { "@odata.id": "/redfish/v1/Systems" },
+  "Managers": { "@odata.id": "/redfish/v1/Managers" },
+  "Tasks": { "@odata.id": "/redfish/v1/TaskService" },
+  "SessionService": { "@odata.id": "/redfish/v1/SessionService" },
+  "Links": {
+    "Sessions": { "@odata.id": "/redfish/v1/SessionService/Sessions" }
+  }
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/1/VirtualMedia/1/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/1/VirtualMedia/1/index.json
@@ -1,0 +1,16 @@
+{
+  "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/1",
+  "@odata.type": "#VirtualMedia.v1_3_0.VirtualMedia",
+  "Id": "1",
+  "Name": "VirtualMedia",
+  "MediaTypes": [ "Floppy", "USBStick" ],
+  "Image": null,
+  "Inserted": false,
+  "WriteProtected": false,
+  "ConnectedVia": "NotConnected",
+  "Actions": {
+    "#VirtualMedia.InsertMedia": {
+      "target": "/redfish/v1/Managers/1/VirtualMedia/1/Actions/VirtualMedia.InsertMedia"
+    }
+  }
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/1/VirtualMedia/2/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/1/VirtualMedia/2/index.json
@@ -1,0 +1,16 @@
+{
+  "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/2",
+  "@odata.type": "#VirtualMedia.v1_3_0.VirtualMedia",
+  "Id": "2",
+  "Name": "VirtualMedia",
+  "MediaTypes": [ "CD", "DVD" ],
+  "Image": null,
+  "Inserted": false,
+  "WriteProtected": true,
+  "ConnectedVia": "NotConnected",
+  "Actions": {
+    "#VirtualMedia.InsertMedia": {
+      "target": "/redfish/v1/Managers/1/VirtualMedia/2/Actions/VirtualMedia.InsertMedia"
+    }
+  }
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/1/VirtualMedia/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/1/VirtualMedia/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.id": "/redfish/v1/Managers/1/VirtualMedia",
+  "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+  "Name": "Virtual Media Services",
+  "Members@odata.count": 2,
+  "Members": [
+    { "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/1" },
+    { "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/2" }
+  ]
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/1/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/1/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.id": "/redfish/v1/Managers/1",
+  "@odata.type": "#Manager.v1_5_1.Manager",
+  "Id": "1",
+  "Name": "Manager",
+  "ManagerType": "BMC",
+  "Model": "iLO 5",
+  "FirmwareVersion": "iLO 5 v2.44",
+  "VirtualMedia": { "@odata.id": "/redfish/v1/Managers/1/VirtualMedia" }
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Managers/index.json
@@ -1,0 +1,9 @@
+{
+  "@odata.id": "/redfish/v1/Managers",
+  "@odata.type": "#ManagerCollection.ManagerCollection",
+  "Name": "Manager Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    { "@odata.id": "/redfish/v1/Managers/1" }
+  ]
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Systems/1/VirtualMedia/Cd/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Systems/1/VirtualMedia/Cd/index.json
@@ -1,0 +1,19 @@
+{
+  "@odata.id": "/redfish/v1/Systems/1/VirtualMedia/Cd",
+  "@odata.type": "#VirtualMedia.v1_3_0.VirtualMedia",
+  "Id": "Cd",
+  "Name": "VirtualMedia",
+  "MediaTypes": [ "CD", "DVD" ],
+  "Image": null,
+  "Inserted": false,
+  "WriteProtected": true,
+  "ConnectedVia": "NotConnected",
+  "Actions": {
+    "#VirtualMedia.InsertMedia": {
+      "target": "/redfish/v1/Systems/1/VirtualMedia/Cd/Actions/VirtualMedia.InsertMedia"
+    },
+    "#VirtualMedia.EjectMedia": {
+      "target": "/redfish/v1/Systems/1/VirtualMedia/Cd/Actions/VirtualMedia.EjectMedia"
+    }
+  }
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Systems/1/VirtualMedia/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Systems/1/VirtualMedia/index.json
@@ -1,0 +1,9 @@
+{
+  "@odata.id": "/redfish/v1/Systems/1/VirtualMedia",
+  "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+  "Name": "Virtual Media Services",
+  "Members@odata.count": 1,
+  "Members": [
+    { "@odata.id": "/redfish/v1/Systems/1/VirtualMedia/Cd" }
+  ]
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Systems/1/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Systems/1/index.json
@@ -1,0 +1,29 @@
+{
+  "@odata.id": "/redfish/v1/Systems/1",
+  "@odata.type": "#ComputerSystem.v1_10_0.ComputerSystem",
+  "Id": "1",
+  "Name": "Computer System",
+  "Manufacturer": "HPE",
+  "Model": "ProLiant DL360 Gen10",
+  "SerialNumber": "PLACEHOLDER-SERIAL",
+  "UUID": "00000000-0000-0000-0000-000000000000",
+  "BiosVersion": "U32 v2.44 (placeholder)",
+  "PowerState": "On",
+  "MemorySummary": { "TotalSystemMemoryGiB": 128 },
+  "ProcessorSummary": { "Count": 2 },
+  "Boot": {
+    "BootSourceOverrideEnabled": "Disabled",
+    "BootSourceOverrideTarget": "None",
+    "BootSourceOverrideMode": "UEFI",
+    "BootSourceOverrideMode@Redfish.AllowableValues": [ "Legacy", "UEFI" ]
+  },
+  "VirtualMedia": { "@odata.id": "/redfish/v1/Systems/1/VirtualMedia" },
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+      "ResetType@Redfish.AllowableValues": [
+        "On", "ForceOff", "GracefulShutdown", "ForceRestart", "Nmi", "PushPowerButton"
+      ]
+    }
+  }
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Systems/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/Systems/index.json
@@ -1,0 +1,9 @@
+{
+  "@odata.id": "/redfish/v1/Systems",
+  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+  "Name": "Computer System Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    { "@odata.id": "/redfish/v1/Systems/1" }
+  ]
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/TaskService/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/TaskService/index.json
@@ -1,0 +1,8 @@
+{
+  "@odata.id": "/redfish/v1/TaskService",
+  "@odata.type": "#TaskService.v1_1_4.TaskService",
+  "Id": "TaskService",
+  "Name": "Task Service",
+  "ServiceEnabled": true,
+  "Tasks": { "@odata.id": "/redfish/v1/TaskService/Tasks" }
+}

--- a/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/index.json
+++ b/pkg/redfish/testdata/mockups/ilo/system-and-manager-cd/redfish/v1/index.json
@@ -1,0 +1,15 @@
+{
+  "@odata.id": "/redfish/v1/",
+  "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+  "Id": "RootService",
+  "Name": "HPE RESTful Root Service",
+  "RedfishVersion": "1.6.0",
+  "Vendor": "HPE",
+  "Systems": { "@odata.id": "/redfish/v1/Systems" },
+  "Managers": { "@odata.id": "/redfish/v1/Managers" },
+  "Tasks": { "@odata.id": "/redfish/v1/TaskService" },
+  "SessionService": { "@odata.id": "/redfish/v1/SessionService" },
+  "Links": {
+    "Sessions": { "@odata.id": "/redfish/v1/SessionService/Sessions" }
+  }
+}

--- a/pkg/redfish/types.go
+++ b/pkg/redfish/types.go
@@ -120,6 +120,14 @@ type FinalizeRequest struct {
 	// Progress, when non-nil, is invoked at each finalize stage with a short step
 	// label and a monotonically increasing percentage (0..100). nil disables it.
 	Progress func(step string, percent int)
+	// PowerCycle, when true, switches Finalize to the power-cycle path: power the
+	// system OFF, eject the media while it is off, steer the next boot to disk, then
+	// power it back ON. This is the robust mode for BMCs/emulators (observed with
+	// sushy-tools on libvirt) that report a media eject on a *running* machine but do
+	// not actually apply it — the live machine keeps booting the ISO until a power
+	// transition. On real hardware live eject usually works, so the default is false
+	// (the in-place eject, unchanged). The eject is still load-bearing in either mode.
+	PowerCycle bool
 }
 
 // DeployResult is the outcome of a deployment.

--- a/pkg/redfish/types.go
+++ b/pkg/redfish/types.go
@@ -98,14 +98,27 @@ type DeployRequest struct {
 	// The v1 default is HTTP-on-trusted-L2; integrity is delegated to the Kairos
 	// image signature, so HTTP is the unset default.
 	TransferProtocolHTTPS bool
-	// EjectAfter ejects the media once the deployment task reaches a terminal
-	// state. Most flows want the media to stay mounted across the install reboot,
-	// so this defaults to false.
+	// EjectAfter is DEPRECATED and no longer honoured by Deploy. Ejecting the media
+	// right after the deploy Task completes is the WRONG time: on BMCs that ignore a
+	// one-time boot override the post-install reboot then re-runs the installer (the
+	// "install loop"). Eject is now a separate, signal-driven step — call Finalize
+	// when the OS is actually up. The field is retained only so old callers still
+	// compile; setting it has no effect.
 	EjectAfter bool
 	// Progress, when non-nil, is invoked at each deploy stage with a short step
 	// label and a monotonically increasing percentage (0..100). It lets callers
 	// surface live progress (e.g. onto a Deployment row). It must be cheap and is
 	// always called synchronously from Deploy's goroutine. nil disables reporting.
+	Progress func(step string, percent int)
+}
+
+// FinalizeRequest describes a post-install finalize: eject the virtual media and
+// (best-effort) steer the next boot to disk. It carries no image URL — finalize
+// never inserts media. The connection parameters live on the Config the Deployer
+// was built with (Endpoint/SystemID/etc.); FinalizeRequest only tunes the flow.
+type FinalizeRequest struct {
+	// Progress, when non-nil, is invoked at each finalize stage with a short step
+	// label and a monotonically increasing percentage (0..100). nil disables it.
 	Progress func(step string, percent int)
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -143,8 +143,25 @@ func New(cfg Config) *echo.Echo {
 		return c.HTML(http.StatusOK, swaggerUIPage)
 	})
 
+	// Build the deploy handler first (when a deployment store is wired) so its auto
+	// eject-on-phone-home hook can be handed to the node handler below. The same
+	// instance is reused for the deploy routes in the cfg.DeploymentStore block.
+	var deployHandler *handlers.DeployHandler
+	if cfg.DeploymentStore != nil {
+		deployHandler = handlers.NewDeployHandler(cfg.ArtifactStore, cfg.DeploymentStore, cfg.BMCTargetStore, cfg.NetbootManager, cfg.ArtifactsDir, cfg.ISOServe, hub).
+			WithBaseContext(cfg.BaseContext).
+			WithSettings(cfg.SettingsStore)
+	}
+
 	// Create handlers
 	nodeHandler := handlers.NewNodeHandler(cfg.NodeStore, cfg.CommandStore, cfg.GroupStore, hub, regToken, cfg.AuroraBootURL)
+	// Wire the auto eject-on-phone-home hook so a freshly-installed node's
+	// Register/Heartbeat ejects its pending-eject Redfish deployment's media. The
+	// hook lives on the deploy handler (it holds the deployment + BMC stores and the
+	// Deployer factory); the node handler only invokes it off-request.
+	if deployHandler != nil {
+		nodeHandler.WithFinalizer(deployHandler.MaybeFinalizeForNode, cfg.BaseContext)
+	}
 	cmdHandler := handlers.NewCommandHandler(cfg.CommandStore, cfg.NodeStore, hub)
 	artifactHandler := handlers.NewArtifactHandler(cfg.Builder, cfg.ArtifactStore, cfg.GroupStore, cfg.SecureBootKeySetStore, cfg.ArtifactsDir, regToken, cfg.AuroraBootURL)
 	groupHandler := handlers.NewGroupHandler(cfg.GroupStore)
@@ -252,11 +269,9 @@ func New(cfg Config) *echo.Echo {
 	adminGroup.POST("/secureboot-keys/import", sbHandler.ImportKeys)
 	adminGroup.DELETE("/secureboot-keys/:id", sbHandler.DeleteKeys)
 
-	// Deploy hub
-	if cfg.DeploymentStore != nil {
-		deployHandler := handlers.NewDeployHandler(cfg.ArtifactStore, cfg.DeploymentStore, cfg.BMCTargetStore, cfg.NetbootManager, cfg.ArtifactsDir, cfg.ISOServe, hub).
-			WithBaseContext(cfg.BaseContext).
-			WithSettings(cfg.SettingsStore)
+	// Deploy hub. deployHandler was constructed above so its eject hook could be
+	// wired into the node handler; here we register its routes.
+	if deployHandler != nil {
 		adminGroup.POST("/netboot/start", deployHandler.StartNetboot)
 		adminGroup.POST("/netboot/stop", deployHandler.StopNetboot)
 		adminGroup.GET("/netboot/status", deployHandler.NetbootStatus)
@@ -268,8 +283,10 @@ func New(cfg Config) *echo.Echo {
 		adminGroup.POST("/bmc-targets/:id/inspect", deployHandler.InspectHardware)
 		adminGroup.GET("/bmc-targets/:id/status", deployHandler.PingBMCTarget)
 		adminGroup.POST("/bmc-targets/refresh-all", deployHandler.RefreshAllBMCTargets)
+		adminGroup.POST("/bmc-targets/:id/eject", deployHandler.EjectBMCTarget)
 		adminGroup.GET("/deployments", deployHandler.ListDeployments)
 		adminGroup.GET("/deployments/:id", deployHandler.GetDeployment)
+		adminGroup.POST("/deployments/:id/finalize", deployHandler.FinalizeDeployment)
 	}
 
 	// SPA static files - serve from embedded UI assets

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -174,6 +174,13 @@ func New(cfg Config) *echo.Echo {
 		Nodes:    cfg.NodeStore,
 		Commands: cfg.CommandStore,
 	}
+	// A WS heartbeat is an "OS is up" signal like the REST one, so it triggers the
+	// same auto eject-on-phone-home hook — a node that reports liveness only over
+	// the agent channel must still get its pending-eject media ejected.
+	if deployHandler != nil {
+		agentWSHandler.Finalize = deployHandler.MaybeFinalizeForNode
+		agentWSHandler.BaseCtx = cfg.BaseContext
+	}
 	uiWSHandler := &ws.UIHandler{Hub: hub}
 
 	// Public endpoints

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -276,6 +276,7 @@ func New(cfg Config) *echo.Echo {
 		adminGroup.POST("/netboot/stop", deployHandler.StopNetboot)
 		adminGroup.GET("/netboot/status", deployHandler.NetbootStatus)
 		adminGroup.POST("/artifacts/:id/deploy/redfish", deployHandler.DeployRedfish)
+		adminGroup.GET("/redfish/quirk-profiles", deployHandler.ListQuirkProfiles)
 		adminGroup.POST("/bmc-targets", deployHandler.CreateBMCTarget)
 		adminGroup.GET("/bmc-targets", deployHandler.ListBMCTargets)
 		adminGroup.PUT("/bmc-targets/:id", deployHandler.UpdateBMCTarget)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,6 +32,7 @@ type Config struct {
 	NetbootManager        *netbootpkg.Manager
 	DeploymentStore       store.DeploymentStore
 	BMCTargetStore        store.BMCTargetStore
+	SettingsStore         store.SettingsStore
 	Builder               builder.ArtifactBuilder
 	AdminPassword         string
 	RegToken              string
@@ -44,6 +45,11 @@ type Config struct {
 	// for Redfish virtual-media deployments. Optional; when nil the Redfish
 	// deploy path requires an explicit imageUrl.
 	ISOServe *isoserve.Server
+	// RedfishServeURL is the advertised base URL the BMC fetches the served ISO
+	// from, as set by the launch --redfish-serve-url flag. It seeds the
+	// image-source settings' advertised URL until an operator overrides it at
+	// runtime.
+	RedfishServeURL string
 	// BaseContext, when non-nil, is the parent context for background deploy
 	// goroutines so a server shutdown cancels in-flight Redfish deploys. Defaults
 	// to context.Background().
@@ -142,7 +148,8 @@ func New(cfg Config) *echo.Echo {
 	cmdHandler := handlers.NewCommandHandler(cfg.CommandStore, cfg.NodeStore, hub)
 	artifactHandler := handlers.NewArtifactHandler(cfg.Builder, cfg.ArtifactStore, cfg.GroupStore, cfg.SecureBootKeySetStore, cfg.ArtifactsDir, regToken, cfg.AuroraBootURL)
 	groupHandler := handlers.NewGroupHandler(cfg.GroupStore)
-	settingsHandler := handlers.NewSettingsHandler(&regToken, cfg.RegTokenFile)
+	settingsHandler := handlers.NewSettingsHandler(&regToken, cfg.RegTokenFile).
+		WithImageSource(cfg.SettingsStore, cfg.ISOServe, cfg.RedfishServeURL)
 
 	// WebSocket handlers
 	agentWSHandler := &ws.AgentHandler{
@@ -234,6 +241,8 @@ func New(cfg Config) *echo.Echo {
 	// Settings
 	adminGroup.GET("/settings/registration-token", settingsHandler.GetRegistrationToken)
 	adminGroup.POST("/settings/registration-token/rotate", settingsHandler.RotateRegistrationToken)
+	adminGroup.GET("/settings/image-source", settingsHandler.GetImageSource)
+	adminGroup.PUT("/settings/image-source", settingsHandler.UpdateImageSource)
 
 	// SecureBoot key management
 	sbHandler := handlers.NewSecureBootHandler(cfg.SecureBootKeySetStore, cfg.KeysDir)
@@ -246,7 +255,8 @@ func New(cfg Config) *echo.Echo {
 	// Deploy hub
 	if cfg.DeploymentStore != nil {
 		deployHandler := handlers.NewDeployHandler(cfg.ArtifactStore, cfg.DeploymentStore, cfg.BMCTargetStore, cfg.NetbootManager, cfg.ArtifactsDir, cfg.ISOServe, hub).
-			WithBaseContext(cfg.BaseContext)
+			WithBaseContext(cfg.BaseContext).
+			WithSettings(cfg.SettingsStore)
 		adminGroup.POST("/netboot/start", deployHandler.StartNetboot)
 		adminGroup.POST("/netboot/stop", deployHandler.StopNetboot)
 		adminGroup.GET("/netboot/status", deployHandler.NetbootStatus)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -266,6 +266,8 @@ func New(cfg Config) *echo.Echo {
 		adminGroup.PUT("/bmc-targets/:id", deployHandler.UpdateBMCTarget)
 		adminGroup.DELETE("/bmc-targets/:id", deployHandler.DeleteBMCTarget)
 		adminGroup.POST("/bmc-targets/:id/inspect", deployHandler.InspectHardware)
+		adminGroup.GET("/bmc-targets/:id/status", deployHandler.PingBMCTarget)
+		adminGroup.POST("/bmc-targets/refresh-all", deployHandler.RefreshAllBMCTargets)
 		adminGroup.GET("/deployments", deployHandler.ListDeployments)
 		adminGroup.GET("/deployments/:id", deployHandler.GetDeployment)
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -234,8 +234,27 @@ type BMCTarget struct {
 	// HTTP(S) URL this BMC pulls the ISO from (model a, operator-hosted). When set
 	// it takes precedence over the global default but is still overridden by a
 	// per-deploy imageUrl. SSRF-validated on write and again at deploy time.
-	ImageURL  string    `json:"imageUrl,omitempty"`
-	NodeID    string    `json:"nodeId,omitempty" gorm:"index"`
+	ImageURL string `json:"imageUrl,omitempty"`
+	NodeID   string `json:"nodeId,omitempty" gorm:"index"`
+
+	// --- Status cache (P4) ---
+	//
+	// These fields are server-owned denormalized snapshots of the last inspect /
+	// reachability ping so the BMC page can render status without contacting the
+	// BMC on load. Clients MUST NOT write them: CreateBMCTarget/UpdateBMCTarget
+	// never copy them from the request body. They are populated only by the
+	// inspect, status-ping and refresh-all handlers.
+	LastStatus       string     `json:"lastStatus,omitempty"` // "", "reachable", "unreachable"
+	LastError        string     `json:"lastError,omitempty"`
+	LastInspectAt    *time.Time `json:"lastInspectAt,omitempty"`
+	LastPingAt       *time.Time `json:"lastPingAt,omitempty"`
+	LastModel        string     `json:"lastModel,omitempty"`
+	LastManufacturer string     `json:"lastManufacturer,omitempty"`
+	LastSerial       string     `json:"lastSerial,omitempty"`
+	LastMemoryGiB    int        `json:"lastMemoryGiB,omitempty"`
+	LastCPUCount     int        `json:"lastCpuCount,omitempty"`
+	LastFeatures     []string   `json:"lastFeatures,omitempty" gorm:"serializer:json"`
+
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -236,6 +236,12 @@ type BMCTarget struct {
 	// per-deploy imageUrl. SSRF-validated on write and again at deploy time.
 	ImageURL string `json:"imageUrl,omitempty"`
 	NodeID   string `json:"nodeId,omitempty" gorm:"index"`
+	// EjectAfterInstall is the durable default eject policy for deployments made
+	// against this BMC: when true, AuroraBoot ejects the virtual media (and steers
+	// the next boot to disk) once the freshly-installed node phones home, breaking
+	// the post-install install loop on BMCs that ignore the one-time boot override.
+	// Default false (opt-in). A per-deploy request may override it.
+	EjectAfterInstall bool `json:"ejectAfterInstall,omitempty"`
 
 	// --- Status cache (P4) ---
 	//
@@ -279,6 +285,26 @@ type Deployment struct {
 	Progress    int        `json:"progress"`
 	StartedAt   time.Time  `json:"startedAt"`
 	CompletedAt *time.Time `json:"completedAt,omitempty"`
+
+	// --- Eject / finalize (P5) ---
+	//
+	// NodeID links this deployment to the node that phoned home from it, so an
+	// auto eject-on-phone-home can correlate node -> deployment. It is set lazily
+	// when the finalize path picks this deployment for a node.
+	NodeID string `json:"nodeId,omitempty" gorm:"index"`
+	// EjectPolicy records the resolved policy at deploy completion: "" / "off"
+	// (no eject), "on-phone-home" (auto eject when the node registers/heartbeats),
+	// or "manual" (operator-only).
+	EjectPolicy string `json:"ejectPolicy,omitempty"`
+	// EjectState is the CAS idempotency key for the finalize lifecycle:
+	// "" (not applicable) -> "pending" -> "ejecting" -> "ejected" | "eject-failed".
+	// The pending->ejecting transition is a compare-and-set so exactly one finalize
+	// attempt (auto or manual) wins.
+	EjectState string `json:"ejectState,omitempty"`
+	// EjectError carries a scrubbed failure reason when EjectState == "eject-failed".
+	EjectError string `json:"ejectError,omitempty"`
+	// EjectedAt is set when the media was successfully ejected.
+	EjectedAt *time.Time `json:"ejectedAt,omitempty"`
 }
 
 // Deployment statuses.
@@ -286,6 +312,22 @@ const (
 	DeployActive    = "Active"
 	DeployCompleted = "Completed"
 	DeployFailed    = "Failed"
+)
+
+// Eject policies (Deployment.EjectPolicy).
+const (
+	EjectPolicyOff         = "off"
+	EjectPolicyOnPhoneHome = "on-phone-home"
+	EjectPolicyManual      = "manual"
+)
+
+// Eject states (Deployment.EjectState). EjectStatePending is the entry point the
+// deploy path sets when the policy is not off; the rest are driven by Finalize.
+const (
+	EjectStatePending  = "pending"
+	EjectStateEjecting = "ejecting"
+	EjectStateEjected  = "ejected"
+	EjectStateFailed   = "eject-failed"
 )
 
 // DeploymentStore manages deployment records.
@@ -296,6 +338,13 @@ type DeploymentStore interface {
 	ListByArtifact(ctx context.Context, artifactID string) ([]*Deployment, error)
 	Update(ctx context.Context, dep *Deployment) error
 	Delete(ctx context.Context, id string) error
+	// CASEjectState atomically transitions a deployment's EjectState from `from`
+	// to `to`, returning true only if this call performed the transition. It is the
+	// idempotency guard for finalize: when an auto eject-on-phone-home and a manual
+	// finalize (or two concurrent phone-homes) target the same deployment, exactly
+	// one observes the still-`from` row and wins; the losers see (false, nil). A
+	// missing deployment or a mismatched current state yields (false, nil).
+	CASEjectState(ctx context.Context, id, from, to string) (bool, error)
 }
 
 // Setting is a single opaque key/value row backing runtime-configurable server

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -242,6 +242,13 @@ type BMCTarget struct {
 	// the post-install install loop on BMCs that ignore the one-time boot override.
 	// Default false (opt-in). A per-deploy request may override it.
 	EjectAfterInstall bool `json:"ejectAfterInstall,omitempty"`
+	// EjectPowerCycle, when true, makes the finalize/eject for this BMC power the
+	// machine OFF before ejecting and back ON afterwards, instead of ejecting in
+	// place on the running machine. It is the robust mode for BMCs/emulators (e.g.
+	// sushy-tools on libvirt) that report a live eject but keep the running machine
+	// booting the ISO. Default false (in-place eject), correct for hardware that
+	// ejects live. It applies to every Finalize path for this BMC (auto and manual).
+	EjectPowerCycle bool `json:"ejectPowerCycle,omitempty"`
 
 	// --- Status cache (P4) ---
 	//

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -229,7 +229,12 @@ type BMCTarget struct {
 	// empty when the BMC exposes exactly one system; it is required when the BMC
 	// exposes more than one, or the deploy/inspect flow refuses to guess and fails
 	// with the list of available system Ids. Mirrors the CLI's --system-id.
-	SystemID  string    `json:"systemId,omitempty"`
+	SystemID string `json:"systemId,omitempty"`
+	// ImageURL optionally overrides the global default image URL for this BMC: the
+	// HTTP(S) URL this BMC pulls the ISO from (model a, operator-hosted). When set
+	// it takes precedence over the global default but is still overridden by a
+	// per-deploy imageUrl. SSRF-validated on write and again at deploy time.
+	ImageURL  string    `json:"imageUrl,omitempty"`
 	NodeID    string    `json:"nodeId,omitempty" gorm:"index"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
@@ -272,4 +277,25 @@ type DeploymentStore interface {
 	ListByArtifact(ctx context.Context, artifactID string) ([]*Deployment, error)
 	Update(ctx context.Context, dep *Deployment) error
 	Delete(ctx context.Context, id string) error
+}
+
+// Setting is a single opaque key/value row backing runtime-configurable server
+// settings (e.g. the image-source defaults). Values are stored as plain strings;
+// the consuming handler owns typing and any SSRF/validation of the value. Keys are
+// namespaced (e.g. "imageSource.defaultImageURL").
+type Setting struct {
+	Key       string    `json:"key" gorm:"primaryKey"`
+	Value     string    `json:"value"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// SettingsStore manages opaque key/value settings.
+type SettingsStore interface {
+	// Get returns the value for key. found reports whether the key exists; a
+	// missing key is (", false, nil), not an error.
+	Get(ctx context.Context, key string) (value string, found bool, err error)
+	// Set upserts key to value.
+	Set(ctx context.Context, key, value string) error
+	// GetAll returns every setting as a key→value map.
+	GetAll(ctx context.Context) (map[string]string, error)
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -218,13 +218,18 @@ type SecureBootKeySetStore interface {
 
 // BMCTarget stores saved RedFish/IPMI credentials for a baseboard management controller.
 type BMCTarget struct {
-	ID        string    `json:"id" gorm:"primaryKey"`
-	Name      string    `json:"name"`
-	Endpoint  string    `json:"endpoint"`
-	Vendor    string    `json:"vendor"`
-	Username  string    `json:"username"`
-	Password  string    `json:"-"`
-	VerifySSL bool      `json:"verifySSL"`
+	ID        string `json:"id" gorm:"primaryKey"`
+	Name      string `json:"name"`
+	Endpoint  string `json:"endpoint"`
+	Vendor    string `json:"vendor"`
+	Username  string `json:"username"`
+	Password  string `json:"-"`
+	VerifySSL bool   `json:"verifySSL"`
+	// SystemID optionally pins the target ComputerSystem by its Redfish Id. Leave
+	// empty when the BMC exposes exactly one system; it is required when the BMC
+	// exposes more than one, or the deploy/inspect flow refuses to guess and fails
+	// with the list of available system Ids. Mirrors the CLI's --system-id.
+	SystemID  string    `json:"systemId,omitempty"`
 	NodeID    string    `json:"nodeId,omitempty" gorm:"index"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`

--- a/pkg/ws/handler.go
+++ b/pkg/ws/handler.go
@@ -44,11 +44,43 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
+// finalizeTimeout bounds one auto eject-on-phone-home attempt fired from a WS
+// heartbeat, mirroring the REST handlers' budget (pkg/handlers/finalize.go).
+const finalizeTimeout = 2 * time.Minute
+
 // AgentHandler handles WebSocket connections from agents.
 type AgentHandler struct {
 	Hub      *Hub
 	Nodes    store.NodeStore
 	Commands store.CommandStore
+
+	// Finalize, when set, is the auto eject-on-phone-home hook (the same
+	// MaybeFinalizeForNode wired into the REST Register/Heartbeat handlers). A WS
+	// heartbeat is just as much an "OS is up" signal as a REST one, so it must
+	// trigger the pending-eject finalize too — otherwise a node that reports
+	// liveness only over the agent channel never gets its media ejected.
+	Finalize func(ctx context.Context, nodeID string)
+	// BaseCtx is the server lifecycle context the finalize goroutine derives from
+	// (cancelled on shutdown). Nil means context.Background().
+	BaseCtx context.Context
+}
+
+// triggerFinalize fires the auto eject-on-phone-home hook off the WS read loop so
+// it never blocks message handling. Nil-safe; the hook's per-deployment CAS makes
+// repeated heartbeats harmless no-ops.
+func (h *AgentHandler) triggerFinalize(nodeID string) {
+	if h.Finalize == nil || nodeID == "" {
+		return
+	}
+	base := h.BaseCtx
+	if base == nil {
+		base = context.Background()
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(base, finalizeTimeout)
+		defer cancel()
+		h.Finalize(ctx, nodeID)
+	}()
 }
 
 // HandleAgentWS handles GET /api/v1/ws?token=<apiKey>.
@@ -134,6 +166,9 @@ func (h *AgentHandler) handleHeartbeat(nodeID string, data json.RawMessage) {
 	if err := h.Nodes.UpdatePhase(ctx, nodeID, store.PhaseOnline); err != nil {
 		log.Printf("ws: failed to update node phase: %v", err)
 	}
+	// A WS heartbeat is an "OS is up" signal exactly like the REST heartbeat:
+	// attempt the auto eject-on-phone-home (nil-safe, off this goroutine).
+	h.triggerFinalize(nodeID)
 }
 
 // handleCommandStatus applies a command_status report from the agent. The

--- a/pkg/ws/handler_test.go
+++ b/pkg/ws/handler_test.go
@@ -73,13 +73,14 @@ func readMsg(conn *websocket.Conn) (*wsMessage, error) {
 
 var _ = Describe("WebSocket Handler", func() {
 	var (
-		hub      *ws.Hub
-		gormDB   *gormstore.Store
-		nodes    store.NodeStore
-		commands store.CommandStore
-		server   *httptest.Server
-		nodeID   string
-		apiKey   string
+		hub       *ws.Hub
+		gormDB    *gormstore.Store
+		nodes     store.NodeStore
+		commands  store.CommandStore
+		server    *httptest.Server
+		nodeID    string
+		apiKey    string
+		finalized chan string
 	)
 
 	bg := context.Background()
@@ -116,10 +117,14 @@ var _ = Describe("WebSocket Handler", func() {
 		Expect(nodeID).NotTo(BeEmpty())
 		Expect(apiKey).NotTo(BeEmpty())
 
+		// Record auto eject-on-phone-home invocations: a WS heartbeat must fire
+		// the same finalize hook as the REST register/heartbeat path.
+		finalized = make(chan string, 8)
 		agentHandler := &ws.AgentHandler{
 			Hub:      hub,
 			Nodes:    nodes,
 			Commands: commands,
+			Finalize: func(_ context.Context, id string) { finalized <- id },
 		}
 		uiHandler := &ws.UIHandler{Hub: hub}
 
@@ -214,6 +219,22 @@ var _ = Describe("WebSocket Handler", func() {
 				}
 				return node.AgentVersion
 			}, 10*time.Second, 100*time.Millisecond).Should(Equal("2.0.0"))
+		})
+
+		It("should trigger the auto eject-on-phone-home finalizer on heartbeat", func() {
+			conn, _, err := dialWS(server, "/api/v1/ws?token="+apiKey)
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close()
+
+			Eventually(func() bool {
+				return hub.IsOnline(nodeID)
+			}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			Expect(sendMsg(conn, "heartbeat", heartbeatData{AgentVersion: "2.0.0"})).To(Succeed())
+
+			// The hook fires off the read loop with the node this connection
+			// authenticated as — never an agent-chosen id.
+			Eventually(finalized, 10*time.Second).Should(Receive(Equal(nodeID)))
 		})
 
 		It("should handle command_status and update command", func() {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,6 +10,7 @@ import { Artifacts } from "./pages/Artifacts";
 import { ArtifactBuilder } from "./pages/ArtifactBuilder";
 import { ArtifactDetail } from "./pages/ArtifactDetail";
 import { Deployments } from "./pages/Deployments";
+import { BMCRegistration } from "./pages/BMCRegistration";
 import { Certificates } from "./pages/Certificates";
 import { Import } from "./pages/Import";
 import { Settings } from "./pages/Settings";
@@ -42,6 +43,7 @@ export default function App() {
         <Route path="artifacts" element={<Artifacts />} />
         <Route path="artifacts/new" element={<ArtifactBuilder />} />
         <Route path="artifacts/:id" element={<ArtifactDetail />} />
+        <Route path="bmc" element={<BMCRegistration />} />
         <Route path="deployments" element={<Deployments />} />
         <Route path="certificates" element={<Certificates />} />
         <Route path="import" element={<Import />} />

--- a/ui/src/api/deployments.ts
+++ b/ui/src/api/deployments.ts
@@ -47,6 +47,10 @@ export interface BMCTarget {
   // AuroraBoot ejects the virtual media (and boots to disk) once the freshly
   // installed node phones home, breaking the install loop. Default false (opt-in).
   ejectAfterInstall?: boolean;
+  // ejectPowerCycle, when true, makes the eject for this BMC power the machine off
+  // before ejecting and back on after, for BMCs/emulators that do not apply a live
+  // eject. Default false (in-place eject), correct for hardware that ejects live.
+  ejectPowerCycle?: boolean;
   // --- Status cache (server-owned, read-only). Populated by inspect / ping /
   // refresh-all; never sent on create/update. "" means "unknown" (never checked).
   lastStatus?: "" | "reachable" | "unreachable";
@@ -121,6 +125,7 @@ export const createBMCTarget = (t: {
   systemId?: string;
   imageUrl?: string;
   ejectAfterInstall?: boolean;
+  ejectPowerCycle?: boolean;
 }) => apiFetch<BMCTarget>("/api/v1/bmc-targets", { method: "POST", body: JSON.stringify(t) });
 
 // updateBMCTarget mirrors createBMCTarget but PUTs to an existing target. Leave
@@ -138,6 +143,7 @@ export const updateBMCTarget = (
     systemId?: string;
     imageUrl?: string;
     ejectAfterInstall?: boolean;
+    ejectPowerCycle?: boolean;
   }
 ) =>
   apiFetch<BMCTarget>(`/api/v1/bmc-targets/${id}`, {

--- a/ui/src/api/deployments.ts
+++ b/ui/src/api/deployments.ts
@@ -71,6 +71,25 @@ export const createBMCTarget = (t: {
   verifySSL: boolean;
 }) => apiFetch<BMCTarget>("/api/v1/bmc-targets", { method: "POST", body: JSON.stringify(t) });
 
+// updateBMCTarget mirrors createBMCTarget but PUTs to an existing target. Leave
+// `password` unset (or empty) to keep the stored credential — the backend treats
+// a blank password as "no change".
+export const updateBMCTarget = (
+  id: string,
+  t: {
+    name: string;
+    endpoint: string;
+    vendor: string;
+    username: string;
+    password?: string;
+    verifySSL: boolean;
+  }
+) =>
+  apiFetch<BMCTarget>(`/api/v1/bmc-targets/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(t),
+  });
+
 export const deleteBMCTarget = (id: string) =>
   apiFetch(`/api/v1/bmc-targets/${id}`, { method: "DELETE" });
 

--- a/ui/src/api/deployments.ts
+++ b/ui/src/api/deployments.ts
@@ -19,6 +19,10 @@ export interface BMCTarget {
   vendor: string;
   username: string;
   verifySSL: boolean;
+  // systemId optionally pins the target ComputerSystem by its Redfish Id. Leave
+  // blank for single-system BMCs; required when the BMC exposes more than one,
+  // mirroring the CLI's --system-id.
+  systemId?: string;
   nodeId?: string;
   createdAt: string;
 }
@@ -69,6 +73,7 @@ export const createBMCTarget = (t: {
   username: string;
   password: string;
   verifySSL: boolean;
+  systemId?: string;
 }) => apiFetch<BMCTarget>("/api/v1/bmc-targets", { method: "POST", body: JSON.stringify(t) });
 
 // updateBMCTarget mirrors createBMCTarget but PUTs to an existing target. Leave
@@ -83,6 +88,7 @@ export const updateBMCTarget = (
     username: string;
     password?: string;
     verifySSL: boolean;
+    systemId?: string;
   }
 ) =>
   apiFetch<BMCTarget>(`/api/v1/bmc-targets/${id}`, {
@@ -105,6 +111,7 @@ export const deployRedfish = (
     password?: string;
     vendor?: string;
     verifySSL?: boolean;
+    systemId?: string;
   }
 ) =>
   apiFetch<Deployment>(`/api/v1/artifacts/${artifactId}/deploy/redfish`, {

--- a/ui/src/api/deployments.ts
+++ b/ui/src/api/deployments.ts
@@ -27,7 +27,29 @@ export interface BMCTarget {
   // HTTP(S) URL the BMC pulls the ISO from). Blank to use the global default.
   imageUrl?: string;
   nodeId?: string;
+  // --- Status cache (server-owned, read-only). Populated by inspect / ping /
+  // refresh-all; never sent on create/update. "" means "unknown" (never checked).
+  lastStatus?: "" | "reachable" | "unreachable";
+  lastError?: string;
+  lastInspectAt?: string;
+  lastPingAt?: string;
+  lastModel?: string;
+  lastManufacturer?: string;
+  lastSerial?: string;
+  lastMemoryGiB?: number;
+  lastCpuCount?: number;
+  lastFeatures?: string[];
   createdAt: string;
+}
+
+// BMCStatus is the per-target reachability payload returned by the ping
+// (GET /bmc-targets/:id/status) and refresh-all endpoints. `id` is present only in
+// the refresh-all array (the single-target ping omits it; it is implicit in the URL).
+export interface BMCStatus {
+  id?: string;
+  status: "reachable" | "unreachable";
+  lastPingAt?: string;
+  error?: string;
 }
 
 // InspectResult mirrors the server's inspectResponse (POST
@@ -106,6 +128,18 @@ export const deleteBMCTarget = (id: string) =>
 
 export const inspectHardware = (id: string) =>
   apiFetch<InspectResult>(`/api/v1/bmc-targets/${id}/inspect`, { method: "POST" });
+
+// pingBMCTarget runs a session-free reachability check against one BMC's Redfish
+// ServiceRoot and returns the freshly-persisted status. It never creates a BMC
+// session, so it is cheap to call on demand.
+export const pingBMCTarget = (id: string) =>
+  apiFetch<BMCStatus>(`/api/v1/bmc-targets/${id}/status`);
+
+// refreshAllBMCTargets pings every saved BMC sequentially (throttled, single
+// in-flight server-side) and returns the per-target results. A concurrent call
+// while one is already running is rejected by the server with 409.
+export const refreshAllBMCTargets = () =>
+  apiFetch<BMCStatus[]>("/api/v1/bmc-targets/refresh-all", { method: "POST" });
 
 export const deployRedfish = (
   artifactId: string,

--- a/ui/src/api/deployments.ts
+++ b/ui/src/api/deployments.ts
@@ -1,5 +1,15 @@
 import { apiFetch } from "./client";
 
+// EjectState is the finalize/eject lifecycle of a deployment. "" means the
+// deployment is not armed for eject (policy off); the rest track the auto/manual
+// eject through to a terminal ejected / eject-failed.
+export type EjectState =
+  | ""
+  | "pending"
+  | "ejecting"
+  | "ejected"
+  | "eject-failed";
+
 export interface Deployment {
   id: string;
   artifactId: string;
@@ -10,6 +20,12 @@ export interface Deployment {
   progress: number;
   startedAt: string;
   completedAt?: string;
+  // --- Eject / finalize (P5). Present only on Redfish deployments armed for eject.
+  nodeId?: string;
+  ejectPolicy?: "off" | "on-phone-home" | "manual";
+  ejectState?: EjectState;
+  ejectError?: string;
+  ejectedAt?: string;
 }
 
 export interface BMCTarget {
@@ -27,6 +43,10 @@ export interface BMCTarget {
   // HTTP(S) URL the BMC pulls the ISO from). Blank to use the global default.
   imageUrl?: string;
   nodeId?: string;
+  // ejectAfterInstall is the durable default eject policy for this BMC: when true,
+  // AuroraBoot ejects the virtual media (and boots to disk) once the freshly
+  // installed node phones home, breaking the install loop. Default false (opt-in).
+  ejectAfterInstall?: boolean;
   // --- Status cache (server-owned, read-only). Populated by inspect / ping /
   // refresh-all; never sent on create/update. "" means "unknown" (never checked).
   lastStatus?: "" | "reachable" | "unreachable";
@@ -100,6 +120,7 @@ export const createBMCTarget = (t: {
   verifySSL: boolean;
   systemId?: string;
   imageUrl?: string;
+  ejectAfterInstall?: boolean;
 }) => apiFetch<BMCTarget>("/api/v1/bmc-targets", { method: "POST", body: JSON.stringify(t) });
 
 // updateBMCTarget mirrors createBMCTarget but PUTs to an existing target. Leave
@@ -116,6 +137,7 @@ export const updateBMCTarget = (
     verifySSL: boolean;
     systemId?: string;
     imageUrl?: string;
+    ejectAfterInstall?: boolean;
   }
 ) =>
   apiFetch<BMCTarget>(`/api/v1/bmc-targets/${id}`, {
@@ -125,6 +147,17 @@ export const updateBMCTarget = (
 
 export const deleteBMCTarget = (id: string) =>
   apiFetch(`/api/v1/bmc-targets/${id}`, { method: "DELETE" });
+
+// finalizeDeployment ejects the media and best-effort boots to disk for one
+// deployment, regardless of its eject policy (operator override). Returns the
+// updated deployment with the new EjectState.
+export const finalizeDeployment = (id: string) =>
+  apiFetch<Deployment>(`/api/v1/deployments/${id}/finalize`, { method: "POST" });
+
+// ejectBMCTarget is the deployment-less operator escape hatch: eject the virtual
+// media of a BMC directly with no eject-state bookkeeping.
+export const ejectBMCTarget = (id: string) =>
+  apiFetch<{ status: string }>(`/api/v1/bmc-targets/${id}/eject`, { method: "POST" });
 
 export const inspectHardware = (id: string) =>
   apiFetch<InspectResult>(`/api/v1/bmc-targets/${id}/inspect`, { method: "POST" });
@@ -151,6 +184,7 @@ export const deployRedfish = (
     vendor?: string;
     verifySSL?: boolean;
     systemId?: string;
+    ejectAfterInstall?: boolean;
   }
 ) =>
   apiFetch<Deployment>(`/api/v1/artifacts/${artifactId}/deploy/redfish`, {

--- a/ui/src/api/deployments.ts
+++ b/ui/src/api/deployments.ts
@@ -23,6 +23,9 @@ export interface BMCTarget {
   // blank for single-system BMCs; required when the BMC exposes more than one,
   // mirroring the CLI's --system-id.
   systemId?: string;
+  // imageUrl optionally overrides the global default image URL for this BMC (the
+  // HTTP(S) URL the BMC pulls the ISO from). Blank to use the global default.
+  imageUrl?: string;
   nodeId?: string;
   createdAt: string;
 }
@@ -74,6 +77,7 @@ export const createBMCTarget = (t: {
   password: string;
   verifySSL: boolean;
   systemId?: string;
+  imageUrl?: string;
 }) => apiFetch<BMCTarget>("/api/v1/bmc-targets", { method: "POST", body: JSON.stringify(t) });
 
 // updateBMCTarget mirrors createBMCTarget but PUTs to an existing target. Leave
@@ -89,6 +93,7 @@ export const updateBMCTarget = (
     password?: string;
     verifySSL: boolean;
     systemId?: string;
+    imageUrl?: string;
   }
 ) =>
   apiFetch<BMCTarget>(`/api/v1/bmc-targets/${id}`, {

--- a/ui/src/api/redfish.ts
+++ b/ui/src/api/redfish.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "./client";
+
+// QuirkProfile mirrors one entry of the server's GET
+// /api/v1/redfish/quirk-profiles response: a Redfish vendor quirk profile loaded
+// at server start (built-in or operator-supplied via --redfish-quirks-dir), with
+// its project-derived support tier. The UI uses these to populate the BMC vendor
+// selector — so an operator's own profile is selectable — instead of a hardcoded
+// list, and to show each profile's support tier.
+export interface QuirkProfile {
+  // name is the selection name a BMCTarget's vendor matches.
+  name: string;
+  // tier is the support tier letter: "A" (core-tested), "B" (community-validated),
+  // or "C" (unverified). A profile never asserts its own tier; the server derives
+  // it.
+  tier: string;
+  // tierDescription is the human-readable annotation, e.g.
+  // "tier C: UNVERIFIED — no recorded mockup".
+  tierDescription: string;
+  // origin is "builtin" or "operator".
+  origin: string;
+  // validatedFirmware is the informational firmware label the profile declared, if
+  // any (operator profiles typically; empty for built-ins without evidence).
+  validatedFirmware?: string;
+}
+
+// listQuirkProfiles returns the Redfish quirk profiles loaded into the server,
+// sorted by name.
+export function listQuirkProfiles(): Promise<QuirkProfile[]> {
+  return apiFetch<QuirkProfile[]>("/api/v1/redfish/quirk-profiles");
+}

--- a/ui/src/api/settings.ts
+++ b/ui/src/api/settings.ts
@@ -14,3 +14,43 @@ export function rotateRegistrationToken(): Promise<RegistrationToken> {
     { method: "POST" }
   );
 }
+
+// ImageSourceSettings mirrors the server's GET /api/v1/settings/image-source
+// response: the runtime-configurable image source for Redfish deploys.
+export interface ImageSourceSettings {
+  // defaultImageURL is the global default URL the BMC pulls the ISO from (model
+  // a) when neither a per-deploy nor a per-BMC override is set.
+  defaultImageURL: string;
+  localServe: {
+    // configured reports whether a local ISO-serve listener was set at launch
+    // (--redfish-serve-addr). Without it, local serving cannot be enabled.
+    configured: boolean;
+    // enabled is the runtime gate for serving the built artifact ISO (model b).
+    enabled: boolean;
+    // advertisedURL is the base URL the BMC reaches the served ISO at.
+    advertisedURL: string;
+    // usesTLS reports whether the listener serves over HTTPS.
+    usesTLS: boolean;
+  };
+}
+
+// UpdateImageSourcePayload is the PUT body. Omitted fields are left unchanged; an
+// explicit empty string clears a URL value.
+export interface UpdateImageSourcePayload {
+  defaultImageURL?: string;
+  localServeEnabled?: boolean;
+  localServeAdvertisedURL?: string;
+}
+
+export function getImageSourceSettings(): Promise<ImageSourceSettings> {
+  return apiFetch<ImageSourceSettings>("/api/v1/settings/image-source");
+}
+
+export function updateImageSourceSettings(
+  payload: UpdateImageSourcePayload
+): Promise<ImageSourceSettings> {
+  return apiFetch<ImageSourceSettings>("/api/v1/settings/image-source", {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+}

--- a/ui/src/components/DeployDialog.tsx
+++ b/ui/src/components/DeployDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   Dialog,
   DialogContent,
@@ -236,7 +237,16 @@ export function DeployDialog({
             <TabsContent value="redfish" className="space-y-4">
               {/* Target selector */}
               <div className="space-y-2">
-                <Label>BMC Target</Label>
+                <div className="flex items-center justify-between">
+                  <Label>BMC Target</Label>
+                  <Link
+                    to="/bmc"
+                    className="text-xs text-[#EE5007] hover:underline"
+                    onClick={onClose}
+                  >
+                    Manage BMCs →
+                  </Link>
+                </div>
                 <Select value={selectedTarget} onValueChange={setSelectedTarget}>
                   <SelectTrigger>
                     <SelectValue placeholder="Select a BMC target..." />

--- a/ui/src/components/DeployDialog.tsx
+++ b/ui/src/components/DeployDialog.tsx
@@ -32,6 +32,7 @@ import {
   startNetboot,
   stopNetboot,
 } from "@/api/deployments";
+import { type QuirkProfile, listQuirkProfiles } from "@/api/redfish";
 
 // Minimum hardware AuroraBoot wants before deploying. Kept deliberately simple
 // and visible: a node below either threshold raises a warning that the operator
@@ -78,7 +79,7 @@ export function DeployDialog({
   const [newTarget, setNewTarget] = useState({
     name: "",
     endpoint: "",
-    vendor: "dell",
+    vendor: "generic",
     username: "",
     password: "",
     verifySSL: false,
@@ -86,12 +87,17 @@ export function DeployDialog({
   });
   const [creatingTarget, setCreatingTarget] = useState(false);
 
+  // Quirk profiles loaded by the server (built-in + operator), for the vendor
+  // selector — same source as the BMC Registration page.
+  const [profiles, setProfiles] = useState<QuirkProfile[]>([]);
+
   useEffect(() => {
     if (hasNetboot) {
       getNetbootStatus().then(setNetbootStatus).catch(() => {});
     }
     if (hasIso) {
       listBMCTargets().then(setBmcTargets).catch(() => {});
+      listQuirkProfiles().then(setProfiles).catch(() => {});
     }
   }, [hasNetboot, hasIso]);
 
@@ -176,7 +182,7 @@ export function DeployDialog({
       setBmcTargets((prev) => [...prev, created]);
       setSelectedTarget(created.id);
       setShowNewTarget(false);
-      setNewTarget({ name: "", endpoint: "", vendor: "dell", username: "", password: "", verifySSL: false, systemId: "" });
+      setNewTarget({ name: "", endpoint: "", vendor: "generic", username: "", password: "", verifySSL: false, systemId: "" });
     } catch {
       // ignore
     } finally {
@@ -407,7 +413,7 @@ export function DeployDialog({
                       />
                     </div>
                     <div className="space-y-1">
-                      <Label className="text-xs">Vendor</Label>
+                      <Label className="text-xs">Vendor profile</Label>
                       <Select
                         value={newTarget.vendor}
                         onValueChange={(v) => setNewTarget({ ...newTarget, vendor: v })}
@@ -416,10 +422,11 @@ export function DeployDialog({
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="dell">Dell</SelectItem>
-                          <SelectItem value="hp">HP</SelectItem>
-                          <SelectItem value="supermicro">Supermicro</SelectItem>
-                          <SelectItem value="lenovo">Lenovo</SelectItem>
+                          {profiles.map((p) => (
+                            <SelectItem key={p.name} value={p.name}>
+                              {p.name} (tier {p.tier})
+                            </SelectItem>
+                          ))}
                         </SelectContent>
                       </Select>
                     </div>

--- a/ui/src/components/DeployDialog.tsx
+++ b/ui/src/components/DeployDialog.tsx
@@ -82,6 +82,7 @@ export function DeployDialog({
     username: "",
     password: "",
     verifySSL: false,
+    systemId: "",
   });
   const [creatingTarget, setCreatingTarget] = useState(false);
 
@@ -175,7 +176,7 @@ export function DeployDialog({
       setBmcTargets((prev) => [...prev, created]);
       setSelectedTarget(created.id);
       setShowNewTarget(false);
-      setNewTarget({ name: "", endpoint: "", vendor: "dell", username: "", password: "", verifySSL: false });
+      setNewTarget({ name: "", endpoint: "", vendor: "dell", username: "", password: "", verifySSL: false, systemId: "" });
     } catch {
       // ignore
     } finally {
@@ -421,6 +422,18 @@ export function DeployDialog({
                           <SelectItem value="lenovo">Lenovo</SelectItem>
                         </SelectContent>
                       </Select>
+                    </div>
+                    <div className="space-y-1 col-span-2">
+                      <Label className="text-xs">System ID</Label>
+                      <Input
+                        value={newTarget.systemId}
+                        onChange={(e) => setNewTarget({ ...newTarget, systemId: e.target.value })}
+                        placeholder="optional"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Leave blank for single-system BMCs; required when the BMC
+                        exposes multiple ComputerSystems.
+                      </p>
                     </div>
                   </div>
                   <Button type="submit" size="sm" disabled={creatingTarget} className="w-full">

--- a/ui/src/components/DeployDialog.tsx
+++ b/ui/src/components/DeployDialog.tsx
@@ -88,8 +88,20 @@ export function DeployDialog({
   const [creatingTarget, setCreatingTarget] = useState(false);
 
   // Quirk profiles loaded by the server (built-in + operator), for the vendor
-  // selector — same source as the BMC Registration page.
+  // selector — same source as the BMC Registration page. Until the fetch
+  // resolves (or if it fails), fall back to the spec-default generic profile so
+  // the selector is never empty/unusable: generic always exists server-side.
   const [profiles, setProfiles] = useState<QuirkProfile[]>([]);
+  const vendorOptions: QuirkProfile[] = profiles.length
+    ? profiles
+    : [
+        {
+          name: "generic",
+          tier: "A",
+          tierDescription: "tier A: core-tested",
+          origin: "builtin",
+        },
+      ];
 
   useEffect(() => {
     if (hasNetboot) {
@@ -422,7 +434,7 @@ export function DeployDialog({
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          {profiles.map((p) => (
+                          {vendorOptions.map((p) => (
                             <SelectItem key={p.name} value={p.name}>
                               {p.name} (tier {p.tier})
                             </SelectItem>

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import {
   Server,
   Package,
   Rocket,
+  ServerCog,
   KeyRound,
   Download,
   Settings,
@@ -53,6 +54,7 @@ const navSections: NavSection[] = [
   {
     label: "Deploy",
     items: [
+      { to: "/bmc", icon: ServerCog, label: "BMC Registration" },
       { to: "/deployments", icon: Rocket, label: "Deployments" },
       { to: "/import", icon: Download, label: "Import" },
     ],

--- a/ui/src/pages/BMCRegistration.tsx
+++ b/ui/src/pages/BMCRegistration.tsx
@@ -1,0 +1,521 @@
+import { Fragment, useEffect, useState } from "react";
+import { PageHeader } from "@/components/PageHeader";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Cpu,
+  MemoryStick,
+  Loader2,
+  Pencil,
+  Trash2,
+  Search,
+  Plus,
+  ServerCog,
+} from "lucide-react";
+import {
+  type BMCTarget,
+  type InspectResult,
+  listBMCTargets,
+  createBMCTarget,
+  updateBMCTarget,
+  deleteBMCTarget,
+  inspectHardware,
+} from "@/api/deployments";
+import { toast } from "@/hooks/useToast";
+
+// Vendor options match the inline "new target" form in DeployDialog so a target
+// created here behaves identically to one created mid-deploy.
+const VENDORS = [
+  { value: "dell", label: "Dell" },
+  { value: "hp", label: "HP" },
+  { value: "supermicro", label: "Supermicro" },
+  { value: "lenovo", label: "Lenovo" },
+];
+
+type FormState = {
+  name: string;
+  endpoint: string;
+  vendor: string;
+  username: string;
+  password: string;
+  verifySSL: boolean;
+};
+
+const EMPTY_FORM: FormState = {
+  name: "",
+  endpoint: "",
+  vendor: "dell",
+  username: "",
+  password: "",
+  verifySSL: false,
+};
+
+function vendorLabel(vendor: string): string {
+  return VENDORS.find((v) => v.value === vendor)?.label ?? vendor;
+}
+
+export function BMCRegistration() {
+  const [targets, setTargets] = useState<BMCTarget[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Add/edit modal. `editing` holds the target being edited, or null for "add".
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<BMCTarget | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+
+  // Delete confirmation.
+  const [deleteTarget, setDeleteTarget] = useState<BMCTarget | null>(null);
+
+  // Per-row inspect state, keyed by target id. Inspect is on-demand only.
+  const [inspectingId, setInspectingId] = useState<string | null>(null);
+  const [inspectResults, setInspectResults] = useState<
+    Record<string, InspectResult>
+  >({});
+  const [inspectErrors, setInspectErrors] = useState<Record<string, string>>({});
+
+  function fetchTargets() {
+    listBMCTargets()
+      .then(setTargets)
+      .catch((err) =>
+        toast(`Failed to load BMC targets: ${(err as Error).message}`, "error")
+      )
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    fetchTargets();
+  }, []);
+
+  function openAdd() {
+    setEditing(null);
+    setForm(EMPTY_FORM);
+    setFormOpen(true);
+  }
+
+  function openEdit(t: BMCTarget) {
+    setEditing(t);
+    // Password is never returned by the API; leave it blank to keep existing.
+    setForm({
+      name: t.name,
+      endpoint: t.endpoint,
+      vendor: t.vendor,
+      username: t.username,
+      password: "",
+      verifySSL: t.verifySSL,
+    });
+    setFormOpen(true);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      if (editing) {
+        const payload: FormState = { ...form };
+        // Omit a blank password so the backend keeps the stored credential.
+        const updated = await updateBMCTarget(
+          editing.id,
+          payload.password
+            ? payload
+            : {
+                name: payload.name,
+                endpoint: payload.endpoint,
+                vendor: payload.vendor,
+                username: payload.username,
+                verifySSL: payload.verifySSL,
+              }
+        );
+        setTargets((prev) =>
+          prev.map((t) => (t.id === updated.id ? updated : t))
+        );
+        toast(`Updated BMC "${updated.name}"`, "success");
+      } else {
+        const created = await createBMCTarget(form);
+        setTargets((prev) => [...prev, created]);
+        toast(`Added BMC "${created.name}"`, "success");
+      }
+      setFormOpen(false);
+    } catch (err) {
+      toast(
+        `Failed to save BMC: ${(err as Error).message}`,
+        "error"
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    const t = deleteTarget;
+    try {
+      await deleteBMCTarget(t.id);
+      setTargets((prev) => prev.filter((x) => x.id !== t.id));
+      // Drop any inspect state we held for this target.
+      setInspectResults((prev) => {
+        const next = { ...prev };
+        delete next[t.id];
+        return next;
+      });
+      setInspectErrors((prev) => {
+        const next = { ...prev };
+        delete next[t.id];
+        return next;
+      });
+      toast(`Deleted BMC "${t.name}"`, "success");
+    } catch (err) {
+      toast(`Failed to delete BMC: ${(err as Error).message}`, "error");
+    }
+  }
+
+  async function handleInspect(t: BMCTarget) {
+    setInspectingId(t.id);
+    setInspectErrors((prev) => {
+      const next = { ...prev };
+      delete next[t.id];
+      return next;
+    });
+    try {
+      const result = await inspectHardware(t.id);
+      setInspectResults((prev) => ({ ...prev, [t.id]: result }));
+    } catch (err) {
+      setInspectErrors((prev) => ({
+        ...prev,
+        [t.id]: err instanceof Error ? err.message : "Inspection failed",
+      }));
+    } finally {
+      setInspectingId(null);
+    }
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="BMC Registration"
+        description="Register and manage baseboard management controllers for RedFish deployments"
+      >
+        <Button
+          className="bg-[#EE5007] hover:bg-[#FF7442] text-white"
+          onClick={openAdd}
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          Add BMC
+        </Button>
+      </PageHeader>
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="flex items-center justify-center py-16 text-muted-foreground">
+              Loading...
+            </div>
+          ) : targets.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+              <ServerCog className="h-12 w-12 mb-3 text-muted-foreground/30" />
+              <div className="text-center">
+                <p className="font-medium text-foreground">
+                  No BMCs registered yet
+                </p>
+                <p className="text-sm mt-1">
+                  Add a baseboard management controller to deploy artifacts over
+                  RedFish.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Endpoint</TableHead>
+                  <TableHead>Vendor</TableHead>
+                  <TableHead>TLS verify</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {targets.map((t) => {
+                  const result = inspectResults[t.id];
+                  const error = inspectErrors[t.id];
+                  const busy = inspectingId === t.id;
+                  return (
+                    <Fragment key={t.id}>
+                      <TableRow>
+                        <TableCell className="font-medium">{t.name}</TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {t.endpoint}
+                        </TableCell>
+                        <TableCell>{vendorLabel(t.vendor)}</TableCell>
+                        <TableCell>
+                          <Badge variant={t.verifySSL ? "default" : "secondary"}>
+                            {t.verifySSL ? "Enabled" : "Disabled"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center justify-end gap-1">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="gap-1.5 text-xs"
+                              onClick={() => handleInspect(t)}
+                              disabled={busy}
+                            >
+                              {busy ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                              ) : (
+                                <Search className="h-3.5 w-3.5" />
+                              )}
+                              Inspect
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              aria-label={`Edit ${t.name}`}
+                              onClick={() => openEdit(t)}
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-destructive hover:text-destructive"
+                              aria-label={`Delete ${t.name}`}
+                              onClick={() => setDeleteTarget(t)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+
+                      {/* Inspect error row */}
+                      {error && (
+                        <TableRow>
+                          <TableCell colSpan={5} className="pt-0">
+                            <div className="bg-red-500/10 border border-red-500/25 text-red-700 rounded-md p-3 text-sm whitespace-pre-wrap">
+                              {error}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      )}
+
+                      {/* Inspect result row — same rendering style as DeployDialog */}
+                      {result && (
+                        <TableRow>
+                          <TableCell colSpan={5} className="pt-0">
+                            <div className="rounded-md border p-4 space-y-3">
+                              <div className="text-sm font-medium">
+                                Hardware inspection
+                              </div>
+                              <div className="grid grid-cols-2 gap-2 text-xs max-w-md">
+                                <div className="text-muted-foreground">Model</div>
+                                <div className="font-mono">
+                                  {result.model || "-"}
+                                </div>
+                                <div className="text-muted-foreground">
+                                  Manufacturer
+                                </div>
+                                <div className="font-mono">
+                                  {result.manufacturer || "-"}
+                                </div>
+                                <div className="text-muted-foreground">Serial</div>
+                                <div className="font-mono">
+                                  {result.serialNumber || "-"}
+                                </div>
+                                <div className="text-muted-foreground flex items-center gap-1">
+                                  <MemoryStick className="h-3.5 w-3.5" /> Memory
+                                </div>
+                                <div className="font-mono">
+                                  {result.memoryGiB} GiB
+                                </div>
+                                <div className="text-muted-foreground flex items-center gap-1">
+                                  <Cpu className="h-3.5 w-3.5" /> Processors
+                                </div>
+                                <div className="font-mono">
+                                  {result.processorCount}
+                                </div>
+                              </div>
+                              {result.supportedFeatures.length > 0 && (
+                                <div className="space-y-1">
+                                  <div className="text-xs text-muted-foreground">
+                                    Supported features
+                                  </div>
+                                  <div className="flex flex-wrap gap-1">
+                                    {result.supportedFeatures.map((f) => (
+                                      <span
+                                        key={f}
+                                        className="rounded bg-secondary px-1.5 py-0.5 text-xs font-mono"
+                                      >
+                                        {f}
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Add / Edit modal */}
+      <Dialog open={formOpen} onOpenChange={setFormOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{editing ? "Edit BMC" : "Add BMC"}</DialogTitle>
+            <DialogDescription>
+              {editing
+                ? "Update the connection details for this baseboard management controller."
+                : "Register a baseboard management controller for RedFish deployments."}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label className="text-xs">Name</Label>
+                <Input
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  placeholder="my-server"
+                  required
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Endpoint</Label>
+                <Input
+                  value={form.endpoint}
+                  onChange={(e) =>
+                    setForm({ ...form, endpoint: e.target.value })
+                  }
+                  placeholder="https://10.0.0.1"
+                  required
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Vendor</Label>
+                <Select
+                  value={form.vendor}
+                  onValueChange={(v) => setForm({ ...form, vendor: v })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VENDORS.map((v) => (
+                      <SelectItem key={v.value} value={v.value}>
+                        {v.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Username</Label>
+                <Input
+                  value={form.username}
+                  onChange={(e) =>
+                    setForm({ ...form, username: e.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div className="space-y-1 col-span-2">
+                <Label className="text-xs">Password</Label>
+                <Input
+                  type="password"
+                  value={form.password}
+                  onChange={(e) =>
+                    setForm({ ...form, password: e.target.value })
+                  }
+                  placeholder={
+                    editing ? "Leave blank to keep existing" : undefined
+                  }
+                  // Password is required on create only; on edit a blank value
+                  // keeps the stored credential.
+                  required={!editing}
+                />
+                {editing && (
+                  <p className="text-xs text-muted-foreground">
+                    Leave blank to keep the existing password.
+                  </p>
+                )}
+              </div>
+            </div>
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="checkbox"
+                checked={form.verifySSL}
+                onChange={(e) =>
+                  setForm({ ...form, verifySSL: e.target.checked })
+                }
+              />
+              Verify TLS certificate
+            </label>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setFormOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                {editing ? "Save changes" : "Add BMC"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        title="Delete BMC"
+        description={
+          deleteTarget
+            ? `Delete BMC "${deleteTarget.name}" (${deleteTarget.endpoint})? This cannot be undone.`
+            : ""
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={handleDelete}
+      />
+    </div>
+  );
+}

--- a/ui/src/pages/BMCRegistration.tsx
+++ b/ui/src/pages/BMCRegistration.tsx
@@ -56,16 +56,29 @@ import {
   getImageSourceSettings,
   updateImageSourceSettings,
 } from "@/api/settings";
+import { type QuirkProfile, listQuirkProfiles } from "@/api/redfish";
 import { toast } from "@/hooks/useToast";
 
-// Vendor options match the inline "new target" form in DeployDialog so a target
-// created here behaves identically to one created mid-deploy.
-const VENDORS = [
-  { value: "dell", label: "Dell" },
-  { value: "hp", label: "HP" },
-  { value: "supermicro", label: "Supermicro" },
-  { value: "lenovo", label: "Lenovo" },
-];
+// Vendor options are no longer a hardcoded list: they come from the quirk profiles
+// the server actually loaded (built-in + operator-supplied via --redfish-quirks-dir),
+// fetched from GET /api/v1/redfish/quirk-profiles. This is what makes an operator's
+// own profile selectable here. "generic" always exists (the spec-default path) and
+// is the safe default.
+const DEFAULT_VENDOR = "generic";
+
+// tierVariant maps a profile's support tier to a Badge variant: A (core-tested)
+// reads as a positive default, B (community-validated) as secondary, C (unverified)
+// as a muted outline.
+function tierVariant(tier: string): "default" | "secondary" | "outline" {
+  switch (tier) {
+    case "A":
+      return "default";
+    case "B":
+      return "secondary";
+    default:
+      return "outline";
+  }
+}
 
 type FormState = {
   name: string;
@@ -83,7 +96,7 @@ type FormState = {
 const EMPTY_FORM: FormState = {
   name: "",
   endpoint: "",
-  vendor: "dell",
+  vendor: DEFAULT_VENDOR,
   username: "",
   password: "",
   verifySSL: false,
@@ -92,10 +105,6 @@ const EMPTY_FORM: FormState = {
   ejectAfterInstall: false,
   ejectPowerCycle: false,
 };
-
-function vendorLabel(vendor: string): string {
-  return VENDORS.find((v) => v.value === vendor)?.label ?? vendor;
-}
 
 // imageSourceBadge describes how a BMC row resolves its image source, given the
 // per-BMC override and the global image-source settings.
@@ -163,6 +172,11 @@ export function BMCRegistration() {
   const [targets, setTargets] = useState<BMCTarget[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // Quirk profiles the server loaded (built-in + operator). Drives the vendor
+  // selector and the per-row tier badge. Fetched once on mount; the registry is
+  // load-at-start on the server, so it never changes during a session.
+  const [profiles, setProfiles] = useState<QuirkProfile[]>([]);
+
   // Global image-source settings (model b): the top-of-page panel. `imgSource`
   // is null until the first fetch resolves.
   const [imgSource, setImgSource] = useState<ImageSourceSettings | null>(null);
@@ -218,9 +232,21 @@ export function BMCRegistration() {
       );
   }
 
+  function fetchProfiles() {
+    listQuirkProfiles()
+      .then(setProfiles)
+      .catch((err) =>
+        toast(
+          `Failed to load Redfish quirk profiles: ${(err as Error).message}`,
+          "error"
+        )
+      );
+  }
+
   useEffect(() => {
     fetchTargets();
     fetchImageSource();
+    fetchProfiles();
   }, []);
 
   async function handleSaveImageSource(e: React.FormEvent) {
@@ -571,7 +597,35 @@ export function BMCRegistration() {
                         <TableCell className="font-mono text-xs">
                           {t.endpoint}
                         </TableCell>
-                        <TableCell>{vendorLabel(t.vendor)}</TableCell>
+                        <TableCell>
+                          {(() => {
+                            const p = profiles.find(
+                              (pr) => pr.name === t.vendor
+                            );
+                            return (
+                              <span className="flex items-center gap-2">
+                                {t.vendor}
+                                {p ? (
+                                  <Badge
+                                    variant={tierVariant(p.tier)}
+                                    className="px-1 py-0 text-[10px]"
+                                    title={p.tierDescription}
+                                  >
+                                    Tier {p.tier}
+                                  </Badge>
+                                ) : (
+                                  <Badge
+                                    variant="outline"
+                                    className="px-1 py-0 text-[10px]"
+                                    title="No matching profile loaded; falls back to generic"
+                                  >
+                                    generic fallback
+                                  </Badge>
+                                )}
+                              </span>
+                            );
+                          })()}
+                        </TableCell>
                         <TableCell>
                           {t.systemId ? (
                             <span className="font-mono text-xs">{t.systemId}</span>
@@ -785,7 +839,7 @@ export function BMCRegistration() {
                 />
               </div>
               <div className="space-y-1">
-                <Label className="text-xs">Vendor</Label>
+                <Label className="text-xs">Vendor profile</Label>
                 <Select
                   value={form.vendor}
                   onValueChange={(v) => setForm({ ...form, vendor: v })}
@@ -794,13 +848,39 @@ export function BMCRegistration() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {VENDORS.map((v) => (
-                      <SelectItem key={v.value} value={v.value}>
-                        {v.label}
+                    {profiles.map((p) => (
+                      <SelectItem key={p.name} value={p.name}>
+                        <span className="flex items-center gap-2">
+                          {p.name}
+                          <Badge
+                            variant={tierVariant(p.tier)}
+                            className="px-1 py-0 text-[10px]"
+                          >
+                            Tier {p.tier}
+                          </Badge>
+                        </span>
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
+                {(() => {
+                  const sel = profiles.find((p) => p.name === form.vendor);
+                  if (!sel) {
+                    return (
+                      <p className="text-[11px] text-muted-foreground">
+                        No profile named “{form.vendor}” is loaded — this BMC will
+                        use the spec-default <code>generic</code> behaviour.
+                      </p>
+                    );
+                  }
+                  return (
+                    <p className="text-[11px] text-muted-foreground">
+                      {sel.tierDescription}
+                      {sel.validatedFirmware ? ` · ${sel.validatedFirmware}` : ""}
+                      {sel.origin === "operator" ? " · operator-supplied" : ""}
+                    </p>
+                  );
+                })()}
               </div>
               <div className="space-y-1">
                 <Label className="text-xs">Username</Label>

--- a/ui/src/pages/BMCRegistration.tsx
+++ b/ui/src/pages/BMCRegistration.tsx
@@ -65,6 +65,7 @@ type FormState = {
   username: string;
   password: string;
   verifySSL: boolean;
+  systemId: string;
 };
 
 const EMPTY_FORM: FormState = {
@@ -74,6 +75,7 @@ const EMPTY_FORM: FormState = {
   username: "",
   password: "",
   verifySSL: false,
+  systemId: "",
 };
 
 function vendorLabel(vendor: string): string {
@@ -129,6 +131,7 @@ export function BMCRegistration() {
       username: t.username,
       password: "",
       verifySSL: t.verifySSL,
+      systemId: t.systemId ?? "",
     });
     setFormOpen(true);
   }
@@ -150,6 +153,7 @@ export function BMCRegistration() {
                 vendor: payload.vendor,
                 username: payload.username,
                 verifySSL: payload.verifySSL,
+                systemId: payload.systemId,
               }
         );
         setTargets((prev) =>
@@ -256,6 +260,7 @@ export function BMCRegistration() {
                   <TableHead>Name</TableHead>
                   <TableHead>Endpoint</TableHead>
                   <TableHead>Vendor</TableHead>
+                  <TableHead>System ID</TableHead>
                   <TableHead>TLS verify</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
@@ -273,6 +278,15 @@ export function BMCRegistration() {
                           {t.endpoint}
                         </TableCell>
                         <TableCell>{vendorLabel(t.vendor)}</TableCell>
+                        <TableCell>
+                          {t.systemId ? (
+                            <span className="font-mono text-xs">{t.systemId}</span>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">
+                              auto
+                            </span>
+                          )}
+                        </TableCell>
                         <TableCell>
                           <Badge variant={t.verifySSL ? "default" : "secondary"}>
                             {t.verifySSL ? "Enabled" : "Disabled"}
@@ -319,7 +333,7 @@ export function BMCRegistration() {
                       {/* Inspect error row */}
                       {error && (
                         <TableRow>
-                          <TableCell colSpan={5} className="pt-0">
+                          <TableCell colSpan={6} className="pt-0">
                             <div className="bg-red-500/10 border border-red-500/25 text-red-700 rounded-md p-3 text-sm whitespace-pre-wrap">
                               {error}
                             </div>
@@ -330,7 +344,7 @@ export function BMCRegistration() {
                       {/* Inspect result row — same rendering style as DeployDialog */}
                       {result && (
                         <TableRow>
-                          <TableCell colSpan={5} className="pt-0">
+                          <TableCell colSpan={6} className="pt-0">
                             <div className="rounded-md border p-4 space-y-3">
                               <div className="text-sm font-medium">
                                 Hardware inspection
@@ -474,6 +488,20 @@ export function BMCRegistration() {
                     Leave blank to keep the existing password.
                   </p>
                 )}
+              </div>
+              <div className="space-y-1 col-span-2">
+                <Label className="text-xs">System ID</Label>
+                <Input
+                  value={form.systemId}
+                  onChange={(e) =>
+                    setForm({ ...form, systemId: e.target.value })
+                  }
+                  placeholder="optional"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Leave blank for single-system BMCs; required when the BMC
+                  exposes multiple ComputerSystems.
+                </p>
               </div>
             </div>
             <label className="flex items-center gap-2 cursor-pointer text-sm">

--- a/ui/src/pages/BMCRegistration.tsx
+++ b/ui/src/pages/BMCRegistration.tsx
@@ -37,6 +37,8 @@ import {
   Search,
   Plus,
   ServerCog,
+  RefreshCw,
+  Wifi,
 } from "lucide-react";
 import {
   type BMCTarget,
@@ -46,6 +48,8 @@ import {
   updateBMCTarget,
   deleteBMCTarget,
   inspectHardware,
+  pingBMCTarget,
+  refreshAllBMCTargets,
 } from "@/api/deployments";
 import {
   type ImageSourceSettings,
@@ -107,6 +111,50 @@ function imageSourceBadge(
   return { label: "Unset", variant: "outline" };
 }
 
+// statusBadge maps a target's cached LastStatus to a badge label/variant. The
+// empty status ("" / undefined) renders as "Unknown" — the target has never been
+// pinged or inspected, and we never auto-contact a BMC on page load.
+function statusBadge(status: BMCTarget["lastStatus"]): {
+  label: string;
+  variant: "default" | "secondary" | "destructive" | "outline";
+} {
+  switch (status) {
+    case "reachable":
+      return { label: "Reachable", variant: "default" };
+    case "unreachable":
+      return { label: "Unreachable", variant: "destructive" };
+    default:
+      return { label: "Unknown", variant: "outline" };
+  }
+}
+
+// relativeTime renders an ISO timestamp as a short, human relative string ("just
+// now", "5m ago", "2h ago", "3d ago"). Returns "" for a missing/invalid time so
+// the caller can omit it.
+function relativeTime(iso?: string): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 45) return "just now";
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+// lastCheckedLabel describes the most recent reachability signal for a target,
+// preferring the more-recent of the ping and inspect timestamps.
+function lastCheckedLabel(t: BMCTarget): string {
+  const ping = t.lastPingAt ? new Date(t.lastPingAt).getTime() : 0;
+  const inspect = t.lastInspectAt ? new Date(t.lastInspectAt).getTime() : 0;
+  if (!ping && !inspect) return "";
+  if (ping >= inspect) return `pinged ${relativeTime(t.lastPingAt)}`;
+  return `inspected ${relativeTime(t.lastInspectAt)}`;
+}
+
 export function BMCRegistration() {
   const [targets, setTargets] = useState<BMCTarget[]>([]);
   const [loading, setLoading] = useState(true);
@@ -133,6 +181,12 @@ export function BMCRegistration() {
     Record<string, InspectResult>
   >({});
   const [inspectErrors, setInspectErrors] = useState<Record<string, string>>({});
+
+  // Per-row ping state (the session-free reachability check) and the throttled
+  // "Refresh all" sweep. Both are opt-in: status is rendered from the cached
+  // fields the list endpoint returns, never auto-fetched on load.
+  const [pingingId, setPingingId] = useState<string | null>(null);
+  const [refreshingAll, setRefreshingAll] = useState(false);
 
   function fetchTargets() {
     listBMCTargets()
@@ -298,13 +352,65 @@ export function BMCRegistration() {
     try {
       const result = await inspectHardware(t.id);
       setInspectResults((prev) => ({ ...prev, [t.id]: result }));
+      // Inspect persists the result into the server-owned status cache. Re-read
+      // the list so the row's Status badge/timestamp reflect the fresh "reachable"
+      // facts rather than stale cached values.
+      fetchTargets();
     } catch (err) {
       setInspectErrors((prev) => ({
         ...prev,
         [t.id]: err instanceof Error ? err.message : "Inspection failed",
       }));
+      // The failed inspect also persisted "unreachable"; refresh so the badge
+      // reflects it.
+      fetchTargets();
     } finally {
       setInspectingId(null);
+    }
+  }
+
+  // handlePing runs the session-free reachability check for one target and folds
+  // the freshly-persisted status into the row in place (no full re-fetch).
+  async function handlePing(t: BMCTarget) {
+    setPingingId(t.id);
+    try {
+      const status = await pingBMCTarget(t.id);
+      setTargets((prev) =>
+        prev.map((x) =>
+          x.id === t.id
+            ? {
+                ...x,
+                lastStatus: status.status,
+                lastPingAt: status.lastPingAt,
+                lastError: status.error ?? "",
+              }
+            : x
+        )
+      );
+    } catch (err) {
+      toast(`Ping failed: ${(err as Error).message}`, "error");
+    } finally {
+      setPingingId(null);
+    }
+  }
+
+  // handleRefreshAll triggers the throttled, single-in-flight server sweep and
+  // re-reads the list so every row reflects its new cached status. A concurrent
+  // sweep is rejected by the server with 409, surfaced here as a toast.
+  async function handleRefreshAll() {
+    setRefreshingAll(true);
+    try {
+      const results = await refreshAllBMCTargets();
+      fetchTargets();
+      const reachable = results.filter((r) => r.status === "reachable").length;
+      toast(
+        `Refreshed ${results.length} BMC${results.length === 1 ? "" : "s"}: ${reachable} reachable`,
+        "success"
+      );
+    } catch (err) {
+      toast(`Refresh all failed: ${(err as Error).message}`, "error");
+    } finally {
+      setRefreshingAll(false);
     }
   }
 
@@ -314,6 +420,18 @@ export function BMCRegistration() {
         title="BMC Registration"
         description="Register and manage baseboard management controllers for RedFish deployments"
       >
+        <Button
+          variant="outline"
+          onClick={handleRefreshAll}
+          disabled={refreshingAll || targets.length === 0}
+        >
+          {refreshingAll ? (
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4 mr-2" />
+          )}
+          Refresh all
+        </Button>
         <Button
           className="bg-[#EE5007] hover:bg-[#FF7442] text-white"
           onClick={openAdd}
@@ -428,6 +546,7 @@ export function BMCRegistration() {
                   <TableHead>Vendor</TableHead>
                   <TableHead>System ID</TableHead>
                   <TableHead>Image source</TableHead>
+                  <TableHead>Status</TableHead>
                   <TableHead>TLS verify</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
@@ -464,6 +583,43 @@ export function BMCRegistration() {
                               >
                                 {badge.label}
                               </Badge>
+                            );
+                          })()}
+                        </TableCell>
+                        <TableCell>
+                          {(() => {
+                            const badge = statusBadge(t.lastStatus);
+                            const checked = lastCheckedLabel(t);
+                            const pinging = pingingId === t.id;
+                            return (
+                              <div className="flex items-center gap-1.5">
+                                <Badge
+                                  variant={badge.variant}
+                                  title={t.lastError || undefined}
+                                >
+                                  {badge.label}
+                                </Badge>
+                                {checked && (
+                                  <span className="text-xs text-muted-foreground">
+                                    {checked}
+                                  </span>
+                                )}
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-6 w-6"
+                                  aria-label={`Ping ${t.name}`}
+                                  title="Reachability ping (no BMC session)"
+                                  onClick={() => handlePing(t)}
+                                  disabled={pinging}
+                                >
+                                  {pinging ? (
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                  ) : (
+                                    <Wifi className="h-3.5 w-3.5" />
+                                  )}
+                                </Button>
+                              </div>
                             );
                           })()}
                         </TableCell>
@@ -513,7 +669,7 @@ export function BMCRegistration() {
                       {/* Inspect error row */}
                       {error && (
                         <TableRow>
-                          <TableCell colSpan={7} className="pt-0">
+                          <TableCell colSpan={8} className="pt-0">
                             <div className="bg-red-500/10 border border-red-500/25 text-red-700 rounded-md p-3 text-sm whitespace-pre-wrap">
                               {error}
                             </div>
@@ -524,7 +680,7 @@ export function BMCRegistration() {
                       {/* Inspect result row — same rendering style as DeployDialog */}
                       {result && (
                         <TableRow>
-                          <TableCell colSpan={7} className="pt-0">
+                          <TableCell colSpan={8} className="pt-0">
                             <div className="rounded-md border p-4 space-y-3">
                               <div className="text-sm font-medium">
                                 Hardware inspection

--- a/ui/src/pages/BMCRegistration.tsx
+++ b/ui/src/pages/BMCRegistration.tsx
@@ -76,6 +76,7 @@ type FormState = {
   verifySSL: boolean;
   systemId: string;
   imageUrl: string;
+  ejectAfterInstall: boolean;
 };
 
 const EMPTY_FORM: FormState = {
@@ -87,6 +88,7 @@ const EMPTY_FORM: FormState = {
   verifySSL: false,
   systemId: "",
   imageUrl: "",
+  ejectAfterInstall: false,
 };
 
 function vendorLabel(vendor: string): string {
@@ -274,6 +276,7 @@ export function BMCRegistration() {
       verifySSL: t.verifySSL,
       systemId: t.systemId ?? "",
       imageUrl: t.imageUrl ?? "",
+      ejectAfterInstall: t.ejectAfterInstall ?? false,
     });
     setFormOpen(true);
   }
@@ -297,6 +300,7 @@ export function BMCRegistration() {
                 verifySSL: payload.verifySSL,
                 systemId: payload.systemId,
                 imageUrl: payload.imageUrl,
+                ejectAfterInstall: payload.ejectAfterInstall,
               }
         );
         setTargets((prev) =>
@@ -864,6 +868,23 @@ export function BMCRegistration() {
               />
               Verify TLS certificate
             </label>
+            <div className="space-y-1">
+              <label className="flex items-center gap-2 cursor-pointer text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.ejectAfterInstall}
+                  onChange={(e) =>
+                    setForm({ ...form, ejectAfterInstall: e.target.checked })
+                  }
+                />
+                Eject media after install
+              </label>
+              <p className="text-xs text-muted-foreground">
+                When the freshly-installed node phones home, AuroraBoot ejects the
+                virtual media and boots from disk — breaking the install loop on
+                BMCs that ignore the one-time boot override. Opt-in.
+              </p>
+            </div>
             <div className="flex justify-end gap-2 pt-2">
               <Button
                 type="button"

--- a/ui/src/pages/BMCRegistration.tsx
+++ b/ui/src/pages/BMCRegistration.tsx
@@ -77,6 +77,7 @@ type FormState = {
   systemId: string;
   imageUrl: string;
   ejectAfterInstall: boolean;
+  ejectPowerCycle: boolean;
 };
 
 const EMPTY_FORM: FormState = {
@@ -89,6 +90,7 @@ const EMPTY_FORM: FormState = {
   systemId: "",
   imageUrl: "",
   ejectAfterInstall: false,
+  ejectPowerCycle: false,
 };
 
 function vendorLabel(vendor: string): string {
@@ -277,6 +279,7 @@ export function BMCRegistration() {
       systemId: t.systemId ?? "",
       imageUrl: t.imageUrl ?? "",
       ejectAfterInstall: t.ejectAfterInstall ?? false,
+      ejectPowerCycle: t.ejectPowerCycle ?? false,
     });
     setFormOpen(true);
   }
@@ -301,6 +304,7 @@ export function BMCRegistration() {
                 systemId: payload.systemId,
                 imageUrl: payload.imageUrl,
                 ejectAfterInstall: payload.ejectAfterInstall,
+                ejectPowerCycle: payload.ejectPowerCycle,
               }
         );
         setTargets((prev) =>
@@ -883,6 +887,23 @@ export function BMCRegistration() {
                 When the freshly-installed node phones home, AuroraBoot ejects the
                 virtual media and boots from disk — breaking the install loop on
                 BMCs that ignore the one-time boot override. Opt-in.
+              </p>
+            </div>
+            <div className="space-y-1">
+              <label className="flex items-center gap-2 cursor-pointer text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.ejectPowerCycle}
+                  onChange={(e) =>
+                    setForm({ ...form, ejectPowerCycle: e.target.checked })
+                  }
+                />
+                Power-cycle on eject
+              </label>
+              <p className="text-xs text-muted-foreground">
+                Power the machine off before ejecting and back on after — needed for
+                BMCs/emulators that don't apply media eject to a running machine.
+                Leave off for hardware that ejects live.
               </p>
             </div>
             <div className="flex justify-end gap-2 pt-2">

--- a/ui/src/pages/BMCRegistration.tsx
+++ b/ui/src/pages/BMCRegistration.tsx
@@ -174,8 +174,21 @@ export function BMCRegistration() {
 
   // Quirk profiles the server loaded (built-in + operator). Drives the vendor
   // selector and the per-row tier badge. Fetched once on mount; the registry is
-  // load-at-start on the server, so it never changes during a session.
+  // load-at-start on the server, so it never changes during a session. Until
+  // the fetch resolves (or if it fails), the selector falls back to the
+  // spec-default generic profile so the form is never left without options:
+  // generic always exists server-side.
   const [profiles, setProfiles] = useState<QuirkProfile[]>([]);
+  const vendorOptions: QuirkProfile[] = profiles.length
+    ? profiles
+    : [
+        {
+          name: DEFAULT_VENDOR,
+          tier: "A",
+          tierDescription: "tier A: core-tested",
+          origin: "builtin",
+        },
+      ];
 
   // Global image-source settings (model b): the top-of-page panel. `imgSource`
   // is null until the first fetch resolves.
@@ -848,7 +861,7 @@ export function BMCRegistration() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {profiles.map((p) => (
+                    {vendorOptions.map((p) => (
                       <SelectItem key={p.name} value={p.name}>
                         <span className="flex items-center gap-2">
                           {p.name}
@@ -864,7 +877,7 @@ export function BMCRegistration() {
                   </SelectContent>
                 </Select>
                 {(() => {
-                  const sel = profiles.find((p) => p.name === form.vendor);
+                  const sel = vendorOptions.find((p) => p.name === form.vendor);
                   if (!sel) {
                     return (
                       <p className="text-[11px] text-muted-foreground">

--- a/ui/src/pages/BMCRegistration.tsx
+++ b/ui/src/pages/BMCRegistration.tsx
@@ -47,6 +47,11 @@ import {
   deleteBMCTarget,
   inspectHardware,
 } from "@/api/deployments";
+import {
+  type ImageSourceSettings,
+  getImageSourceSettings,
+  updateImageSourceSettings,
+} from "@/api/settings";
 import { toast } from "@/hooks/useToast";
 
 // Vendor options match the inline "new target" form in DeployDialog so a target
@@ -66,6 +71,7 @@ type FormState = {
   password: string;
   verifySSL: boolean;
   systemId: string;
+  imageUrl: string;
 };
 
 const EMPTY_FORM: FormState = {
@@ -76,15 +82,41 @@ const EMPTY_FORM: FormState = {
   password: "",
   verifySSL: false,
   systemId: "",
+  imageUrl: "",
 };
 
 function vendorLabel(vendor: string): string {
   return VENDORS.find((v) => v.value === vendor)?.label ?? vendor;
 }
 
+// imageSourceBadge describes how a BMC row resolves its image source, given the
+// per-BMC override and the global image-source settings.
+function imageSourceBadge(
+  target: BMCTarget,
+  settings: ImageSourceSettings | null
+): { label: string; variant: "default" | "secondary" | "outline" } {
+  if (target.imageUrl) {
+    return { label: "Per-BMC URL", variant: "default" };
+  }
+  if (settings?.defaultImageURL) {
+    return { label: "Global default", variant: "secondary" };
+  }
+  if (settings?.localServe.configured && settings.localServe.enabled) {
+    return { label: "AuroraBoot-served", variant: "outline" };
+  }
+  return { label: "Unset", variant: "outline" };
+}
+
 export function BMCRegistration() {
   const [targets, setTargets] = useState<BMCTarget[]>([]);
   const [loading, setLoading] = useState(true);
+
+  // Global image-source settings (model b): the top-of-page panel. `imgSource`
+  // is null until the first fetch resolves.
+  const [imgSource, setImgSource] = useState<ImageSourceSettings | null>(null);
+  const [imgDefaultURL, setImgDefaultURL] = useState("");
+  const [imgAdvertisedURL, setImgAdvertisedURL] = useState("");
+  const [savingImgSource, setSavingImgSource] = useState(false);
 
   // Add/edit modal. `editing` holds the target being edited, or null for "add".
   const [formOpen, setFormOpen] = useState(false);
@@ -111,9 +143,64 @@ export function BMCRegistration() {
       .finally(() => setLoading(false));
   }
 
+  function applyImgSource(s: ImageSourceSettings) {
+    setImgSource(s);
+    setImgDefaultURL(s.defaultImageURL);
+    setImgAdvertisedURL(s.localServe.advertisedURL);
+  }
+
+  function fetchImageSource() {
+    getImageSourceSettings()
+      .then(applyImgSource)
+      .catch((err) =>
+        toast(
+          `Failed to load image-source settings: ${(err as Error).message}`,
+          "error"
+        )
+      );
+  }
+
   useEffect(() => {
     fetchTargets();
+    fetchImageSource();
   }, []);
+
+  async function handleSaveImageSource(e: React.FormEvent) {
+    e.preventDefault();
+    setSavingImgSource(true);
+    try {
+      const updated = await updateImageSourceSettings({
+        defaultImageURL: imgDefaultURL,
+        // advertisedURL is only meaningful when a listener is configured.
+        ...(imgSource?.localServe.configured
+          ? { localServeAdvertisedURL: imgAdvertisedURL }
+          : {}),
+      });
+      applyImgSource(updated);
+      toast("Saved image source settings", "success");
+    } catch (err) {
+      toast(
+        `Failed to save image-source settings: ${(err as Error).message}`,
+        "error"
+      );
+    } finally {
+      setSavingImgSource(false);
+    }
+  }
+
+  async function handleToggleLocalServe(enabled: boolean) {
+    try {
+      const updated = await updateImageSourceSettings({
+        localServeEnabled: enabled,
+      });
+      applyImgSource(updated);
+    } catch (err) {
+      toast(
+        `Failed to update local serving: ${(err as Error).message}`,
+        "error"
+      );
+    }
+  }
 
   function openAdd() {
     setEditing(null);
@@ -132,6 +219,7 @@ export function BMCRegistration() {
       password: "",
       verifySSL: t.verifySSL,
       systemId: t.systemId ?? "",
+      imageUrl: t.imageUrl ?? "",
     });
     setFormOpen(true);
   }
@@ -154,6 +242,7 @@ export function BMCRegistration() {
                 username: payload.username,
                 verifySSL: payload.verifySSL,
                 systemId: payload.systemId,
+                imageUrl: payload.imageUrl,
               }
         );
         setTargets((prev) =>
@@ -234,6 +323,83 @@ export function BMCRegistration() {
         </Button>
       </PageHeader>
 
+      {/* Image source panel (model b global): the default image URL every BMC
+          falls back to, plus — when a local-serve listener was configured at
+          launch — the toggle and advertised URL for AuroraBoot-served ISOs. */}
+      <Card className="mb-6">
+        <CardContent className="p-5 space-y-4">
+          <div>
+            <h2 className="text-sm font-semibold">Image source</h2>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Where BMCs pull the install ISO from. A per-BMC override (below)
+              takes precedence over the global default; a per-deploy URL takes
+              precedence over both.
+            </p>
+          </div>
+          <form onSubmit={handleSaveImageSource} className="space-y-4">
+            <div className="space-y-1">
+              <Label className="text-xs">Default image URL</Label>
+              <Input
+                value={imgDefaultURL}
+                onChange={(e) => setImgDefaultURL(e.target.value)}
+                placeholder="https://images.example.com/kairos.iso"
+              />
+              <p className="text-xs text-muted-foreground">
+                The URL every BMC pulls the ISO from unless it has its own
+                override. Leave blank to require a per-BMC or per-deploy URL.
+              </p>
+            </div>
+
+            {imgSource?.localServe.configured && (
+              <div className="rounded-md border p-4 space-y-3">
+                <label className="flex items-center gap-2 cursor-pointer text-sm font-medium">
+                  <input
+                    type="checkbox"
+                    checked={imgSource.localServe.enabled}
+                    onChange={(e) => handleToggleLocalServe(e.target.checked)}
+                  />
+                  AuroraBoot serves the built artifact ISO
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  When enabled, deploys with no operator-supplied URL serve the
+                  artifact's own ISO over a tokenized, BMC-reachable URL
+                  {imgSource.localServe.usesTLS ? " (HTTPS)." : " (HTTP)."}
+                </p>
+                <div className="space-y-1">
+                  <Label className="text-xs">Advertised URL</Label>
+                  <Input
+                    value={imgAdvertisedURL}
+                    onChange={(e) => setImgAdvertisedURL(e.target.value)}
+                    placeholder="http://10.0.0.5:8090"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    The base URL the BMC reaches the served ISO at (the bind
+                    address is fixed at launch via --redfish-serve-addr).
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {imgSource && !imgSource.localServe.configured && (
+              <p className="text-xs text-muted-foreground">
+                AuroraBoot-served ISOs are unavailable: no{" "}
+                <code className="font-mono">--redfish-serve-addr</code> was set
+                at launch. Use a default image URL or per-BMC override instead.
+              </p>
+            )}
+
+            <div className="flex justify-end">
+              <Button type="submit" disabled={savingImgSource}>
+                {savingImgSource && (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                )}
+                Save image source
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
       <Card>
         <CardContent className="p-0">
           {loading ? (
@@ -261,6 +427,7 @@ export function BMCRegistration() {
                   <TableHead>Endpoint</TableHead>
                   <TableHead>Vendor</TableHead>
                   <TableHead>System ID</TableHead>
+                  <TableHead>Image source</TableHead>
                   <TableHead>TLS verify</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
@@ -286,6 +453,19 @@ export function BMCRegistration() {
                               auto
                             </span>
                           )}
+                        </TableCell>
+                        <TableCell>
+                          {(() => {
+                            const badge = imageSourceBadge(t, imgSource);
+                            return (
+                              <Badge
+                                variant={badge.variant}
+                                title={t.imageUrl || undefined}
+                              >
+                                {badge.label}
+                              </Badge>
+                            );
+                          })()}
                         </TableCell>
                         <TableCell>
                           <Badge variant={t.verifySSL ? "default" : "secondary"}>
@@ -333,7 +513,7 @@ export function BMCRegistration() {
                       {/* Inspect error row */}
                       {error && (
                         <TableRow>
-                          <TableCell colSpan={6} className="pt-0">
+                          <TableCell colSpan={7} className="pt-0">
                             <div className="bg-red-500/10 border border-red-500/25 text-red-700 rounded-md p-3 text-sm whitespace-pre-wrap">
                               {error}
                             </div>
@@ -344,7 +524,7 @@ export function BMCRegistration() {
                       {/* Inspect result row — same rendering style as DeployDialog */}
                       {result && (
                         <TableRow>
-                          <TableCell colSpan={6} className="pt-0">
+                          <TableCell colSpan={7} className="pt-0">
                             <div className="rounded-md border p-4 space-y-3">
                               <div className="text-sm font-medium">
                                 Hardware inspection
@@ -501,6 +681,20 @@ export function BMCRegistration() {
                 <p className="text-xs text-muted-foreground">
                   Leave blank for single-system BMCs; required when the BMC
                   exposes multiple ComputerSystems.
+                </p>
+              </div>
+              <div className="space-y-1 col-span-2">
+                <Label className="text-xs">Image URL override</Label>
+                <Input
+                  value={form.imageUrl}
+                  onChange={(e) =>
+                    setForm({ ...form, imageUrl: e.target.value })
+                  }
+                  placeholder="https://images.example.com/kairos.iso"
+                />
+                <p className="text-xs text-muted-foreground">
+                  URL the BMC pulls the ISO from; overrides the global default.
+                  Leave blank to use the global default image source.
                 </p>
               </div>
             </div>

--- a/ui/src/pages/Deployments.tsx
+++ b/ui/src/pages/Deployments.tsx
@@ -100,6 +100,9 @@ export function Deployments() {
   }, [deployments]);
 
   async function handleFinalize(d: Deployment) {
+    // One finalize at a time: a second click while a request is in flight would
+    // overwrite the tracked id, re-enabling the first button mid-request.
+    if (finalizing) return;
     setFinalizing(d.id);
     try {
       const updated = await finalizeDeployment(d.id);
@@ -239,7 +242,10 @@ export function Deployments() {
                         <Button
                           variant="outline"
                           size="sm"
-                          disabled={finalizing === d.id}
+                          // Disable ALL finalize buttons while one is in flight
+                          // (not just the active row) so a click can't silently
+                          // no-op against the in-progress guard.
+                          disabled={finalizing !== null}
                           onClick={() => handleFinalize(d)}
                           title="Eject the virtual media and boot from disk"
                         >

--- a/ui/src/pages/Deployments.tsx
+++ b/ui/src/pages/Deployments.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { PageHeader } from "@/components/PageHeader";
 import { StatusBadge } from "@/components/StatusBadge";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
@@ -11,18 +13,54 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Wifi, Server, Rocket } from "lucide-react";
+import { Wifi, Server, Rocket, Disc } from "lucide-react";
 import {
   listDeployments,
+  finalizeDeployment,
   type Deployment,
   type DeployProgress,
+  type EjectState,
 } from "@/api/deployments";
 import { useUIWebSocket } from "@/hooks/useUIWebSocket";
+import { toast } from "@/hooks/useToast";
+
+// ejectBadge maps a deployment's EjectState to a badge. "" (not armed) renders
+// nothing — only deployments in the eject lifecycle get a badge.
+function ejectBadge(state: EjectState | undefined): {
+  label: string;
+  variant: "default" | "secondary" | "destructive" | "outline";
+} | null {
+  switch (state) {
+    case "pending":
+      return { label: "Eject pending", variant: "secondary" };
+    case "ejecting":
+      return { label: "Ejecting…", variant: "outline" };
+    case "ejected":
+      return { label: "Ejected", variant: "default" };
+    case "eject-failed":
+      return { label: "Eject failed", variant: "destructive" };
+    default:
+      return null;
+  }
+}
+
+// canFinalize reports whether the "Finalize" action should be offered: a Redfish
+// deployment with a BMC target that is not already mid-eject. It is offered even
+// for deployments whose policy was off, since manual finalize is an operator
+// override.
+function canFinalize(d: Deployment): boolean {
+  return (
+    d.method.toLowerCase() === "redfish" &&
+    !!d.bmcTargetId &&
+    d.ejectState !== "ejecting"
+  );
+}
 
 export function Deployments() {
   const [deployments, setDeployments] = useState<Deployment[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
+  const [finalizing, setFinalizing] = useState<string | null>(null);
 
   function fetchDeployments() {
     listDeployments()
@@ -60,6 +98,28 @@ export function Deployments() {
     const interval = setInterval(fetchDeployments, 15000);
     return () => clearInterval(interval);
   }, [deployments]);
+
+  async function handleFinalize(d: Deployment) {
+    setFinalizing(d.id);
+    try {
+      const updated = await finalizeDeployment(d.id);
+      setDeployments((prev) =>
+        prev.map((x) => (x.id === updated.id ? updated : x))
+      );
+      if (updated.ejectState === "eject-failed") {
+        toast(
+          `Eject failed: ${updated.ejectError || "unknown error"}`,
+          "error"
+        );
+      } else {
+        toast("Media ejected; node will boot from disk", "success");
+      }
+    } catch (err) {
+      toast(`Finalize failed: ${(err as Error).message}`, "error");
+    } finally {
+      setFinalizing(null);
+    }
+  }
 
   function methodIcon(method: string) {
     if (method.toLowerCase() === "pxe" || method.toLowerCase() === "netboot") {
@@ -119,6 +179,7 @@ export function Deployments() {
                   <TableHead>Status</TableHead>
                   <TableHead>Progress</TableHead>
                   <TableHead>Started</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -132,7 +193,17 @@ export function Deployments() {
                       {d.bmcTargetId ? d.bmcTargetId.slice(0, 12) : "-"}
                     </TableCell>
                     <TableCell>
-                      <StatusBadge status={d.status} />
+                      <div className="flex flex-col items-start gap-1">
+                        <StatusBadge status={d.status} />
+                        {(() => {
+                          const eb = ejectBadge(d.ejectState);
+                          return eb ? (
+                            <Badge variant={eb.variant} title={d.ejectError || undefined}>
+                              {eb.label}
+                            </Badge>
+                          ) : null;
+                        })()}
+                      </div>
                     </TableCell>
                     <TableCell>
                       {d.progress > 0 ? (
@@ -162,6 +233,22 @@ export function Deployments() {
                       {d.startedAt
                         ? new Date(d.startedAt).toLocaleString()
                         : "-"}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {canFinalize(d) ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={finalizing === d.id}
+                          onClick={() => handleFinalize(d)}
+                          title="Eject the virtual media and boot from disk"
+                        >
+                          <Disc className="h-3.5 w-3.5 mr-1" />
+                          {finalizing === d.id ? "Finalizing…" : "Finalize"}
+                        </Button>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">-</span>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}


### PR DESCRIPTION
This PR delivers two related Redfish features for the fleet server, developed and lab-tested together:

1. **BMC Registration** — runtime BMC management, status, image-source settings, eject/finalize.
2. **Declarative vendor quirk profiles (RFC 0001)** — community-scalable vendor support: YAML profiles, a read-only `probe` command, an operator quirks directory with support tiers, recorded-mockup CI, and a UI vendor selector driven by the loaded profiles.

---

# Part 1 — BMC Registration

## What

A dedicated **BMC Registration** experience for the fleet server — a sidebar page + the backend to manage BMCs, their image source, and the virtual-media lifecycle at **runtime** (not only at `auroraboot web` launch). Designed in `staff-architect` review and built in 5 phases, each a focused commit set.

This closes several gaps surfaced during local end-to-end testing:
- there was **no BMC-management page** (it was a deferred Phase-6 fast-follow),
- image serving was **launch-flag-only**,
- the fleet path couldn't select a ComputerSystem on **multi-system BMCs** (hard 500),
- and the virtual-media **install loop** (BMCs that don't honor one-time boot) had no remediation.

## Phases

| Commits | Phase |
|---|---|
| `8e0409c` | **P1** — BMC Registration page + sidebar entry; CRUD + on-demand inspect; "Manage BMCs" link from the deploy dialog |
| `53e50c7` | **P2** — per-BMC **SystemID** threaded into the fleet deploy + inspect path. **Closes the multi-system 500** (the CLI's `--system-id`, now in the UI/REST path) |
| `bcbfc63` `b4f8ca3` | **P3** — runtime **image-source settings** (`Setting` GORM table): global default image URL + per-BMC override + runtime serve enable/advertised-URL; deploy precedence (per-deploy > per-BMC > global > local-serve); SSRF-validated on write and at deploy |
| `7835105` `9c5c987` | **P4** — persisted inspect + **session-free reachability ping** (`GET /bmc-targets/:id/status`, unauthenticated ServiceRoot, no session churn) + **throttled sequential refresh-all**; status badges |
| `84234cd` `c6c973a` | **P5** — **signal-driven `Finalize`** (eject + best-effort boot-to-disk) **decoupled from mid-install**; eject-on-phone-home (server-derived trigger, atomic CAS) + admin manual finalize/eject endpoints; opt-in, default OFF. Remediates the **#7 install loop** |
| `0534d1d` | Security-review fixes — validate BMC `Endpoint` (server-side SSRF) + time-box the auto-eject fallback with audit logging |
| `4ccafeb` | Opt-in **power-cycle on Finalize** (off → eject → boot-disk → on) for BMCs/emulators that don't apply eject to a running machine (from a lab finding) |
| `fde9c81` | `-race` fix in a test fake (deployment store returns copies, mirroring gorm) |

## Security review

Reviewed by an internal `security-architect` pass (ship-with-fixes; both Mediums fixed in `0534d1d`). Key properties: the P5 auto-eject trigger input is **server-derived only** (a node's request body never selects a target), atomic DB-level `CASEjectState`, admin-only manual endpoints, scrubbed BMC errors, BMC creds decrypted only for the finalize session, status-cache fields server-owned. Operator URLs (per-BMC/global/advertised/deploy) all pass `ValidateMediaURL`.

---

# Part 2 — Redfish vendor quirk profiles (RFC 0001)

## What

Every BMC vendor implements DMTF Redfish a little differently — and frequently not compliantly. Rather than the maintainers owning a hardware lab for every vendor × model × firmware, this makes vendor support **community-scalable**: vendor "quirks" become **declarative YAML profiles** (inert data, not code) that operators can author, share, and contribute — validated in CI against **recorded hardware evidence** (DMTF mockups). Full rationale and the rejected alternatives (Lua/CEL/WASM/plugins) are in `docs/rfc/0001-redfish-vendor-quirk-profiles.md`.

## Highlights

| Commits | Piece |
|---|---|
| `fc1ecaf` | RFC 0001 — the ecosystem contract, support tiers, why not a scripting engine |
| `9d0c9f6` | **P1** — declarative profile schema + loader + **safe view boundary**: a profile can never set the (SSRF-validated) image URL, force an unsupported ResetType, or touch sessions/TLS/system selection |
| `5d4fe8d` | **P2** — read-only `auroraboot redfish probe`: reports what a BMC actually exposes and emits a tier-C **starter profile** |
| `4684cdf` | **P3** — operator `--quirks-dir` / `--redfish-quirks-dir`, name-first selection, project-derived **support tiers** (A core-tested / B community-validated / C unverified) |
| `5ee27d7` | contributor guide + PR template + example profiles |
| `cc7b5c6` `d5ec6de` | **P4** — recorded-mockup **CI replay harness** + per-vendor golden tests → tier B is real, **no hardware in CI** |
| `a038944` `ccf1d15` | merge into this PR + **UI integration**: `GET /api/v1/redfish/quirk-profiles`; the BMC form and Deploy dialog vendor selector is now populated from the **loaded** profiles with tier badges (was a hardcoded list) |

## Safety

A quirk profile is **inert data with a bounded blast radius** — that's what makes it safe to accept from contributors whose hardware we've never seen. Hooks receive read-only "Views" and return constrained answers (an ordering of indices, an enum pick, a sparse allowlisted patch); the image URL is structurally absent, ResetType is re-validated against the BMC's advertised allowable values, and the support tier is **derived by the project, never asserted by a profile**. Operator profiles are always tier C and loudly logged.

## The self-service loop it enables

`deploy fails → probe the BMC → tweak the starter profile until it works → (optionally) record a sanitized mockup and PR profile+mockup together → CI replays it forever`. The UI integration closes the last rung: a loaded profile is now **selectable in the BMC vendor dropdown with its tier**, instead of an API-only string.

## Testing

`pkg/redfish` (incl. the new probe, registry, mockup-replay golden tests, and the `Registry.Profiles()` listing) green; the recorded iLO mockup proves `generic` and `ilo` select **different** media on the same recorded tree (the regression value). UI `tsc --noEmit` + `vite build` clean. Lab-validated end to end: probe an unknown BMC → starter profile → load via `--redfish-quirks-dir` → selectable in the UI with its tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)