### PR TITLE
ci: disable the riscv64 release image build

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -12,30 +12,12 @@ permissions:
 concurrency:
   group: ci-image-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: false # we never want to cancel a running job on release
+# NOTE: the riscv64 release build (and the build-ui job that existed solely to feed
+# it a prebuilt UI artifact) is disabled: the runner is slow/flaky and repeatedly
+# broke releases — a failed riscv64 job skips the final manifest job, leaving the
+# release tag unpublished on quay (v0.22.0). Re-enable by restoring the
+# build-ui/build-linux-riscv64 jobs from git history once the runner is reliable.
 jobs:
-  build-ui:
-    # Build UI on amd64 for riscv64 - QEMU emulation of amd64 on riscv64 is unstable
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: ui/package-lock.json
-      - name: Build UI
-        working-directory: ui
-        run: |
-          npm ci
-          npm run build
-      - name: Upload UI artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-dist
-          path: internal/ui/dist
-          retention-days: 1
   build-linux-amd64:
     runs-on: 'ubuntu-24.04'
     steps:
@@ -82,42 +64,10 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
-  build-linux-riscv64:
-    runs-on: 'ubuntu-24.04-riscv'
-    needs: build-ui
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Download UI artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ui-dist
-          path: internal/ui/dist
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: network=host
-      - uses: docker/login-action@v4
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-      - name: Build
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile.riscv64
-          build-args: |
-            VERSION=${{ github.ref_name }}
-          provenance: false
-          platforms: linux/riscv64
-          push: true
-          tags: quay.io/kairos/auroraboot:${{ github.ref_name }}-riscv64
   build:
     needs:
       - build-linux-amd64
       - build-linux-arm64
-      - build-linux-riscv64
     runs-on: ubuntu-24.04
     steps:
       - uses: docker/login-action@v4
@@ -137,4 +87,3 @@ jobs:
           sources: |
             quay.io/kairos/auroraboot:${{ github.ref_name }}-amd64
             quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
-            quay.io/kairos/auroraboot:${{ github.ref_name }}-riscv64


### PR DESCRIPTION
## What

Drops the `build-linux-riscv64` job (and `build-ui`, which existed solely to feed it a prebuilt UI artifact) from the **release** image workflow. The final multi-arch manifest is now stitched from amd64+arm64 only.

## Why

The riscv64 runner repeatedly breaks releases: a failed riscv64 job skips the final manifest job, leaving the release tag itself **unpublished on quay**. Concretely, `quay.io/kairos/auroraboot:v0.22.0` does not exist (404) — only the `-amd64`/`-arm64` arch tags made it. A day-later re-run of just the failed job can't recover either, because the 1-day `ui-dist` artifact has expired by then ("Artifact not found: ui-dist").

A release should publish deterministically; riscv64 can be re-enabled from git history once the runner is reliable. PR CI riscv64 coverage (`test-riscv64.yml`) is untouched.

## Context

v0.23.0 is being re-cut on top of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)