### PR TITLE
fix(builder): stop hardcoding docker: prefix on UKI build source

### DIFF
--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -610,7 +610,10 @@ func (b *Builder) buildUKI(ctx context.Context, opts builder.BuildOptions, conta
 	}
 
 	ukiOpts := uki.Options{
-		Source:           "docker:" + containerImage,
+		// containerImage is a full source URI; its scheme (oci:, docker:, a
+		// local daemon ref, etc.) is resolved downstream by NewSrcFromURI, so
+		// pass it through unchanged rather than forcing a scheme here.
+		Source:           containerImage,
 		OutputDir:        outputDir,
 		OutputType:       string(constants.IsoOutput),
 		Name:             "kairos",

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -610,9 +610,10 @@ func (b *Builder) buildUKI(ctx context.Context, opts builder.BuildOptions, conta
 	}
 
 	ukiOpts := uki.Options{
-		// containerImage is a full source URI; its scheme (oci:, docker:, a
-		// local daemon ref, etc.) is resolved downstream by NewSrcFromURI, so
-		// pass it through unchanged rather than forcing a scheme here.
+		// containerImage may be a plain Docker reference (quay.io/...), a
+		// locally-tagged image (auroraboot-*), or a fully schemed source URI
+		// (oci:, docker:, etc.). NewSrcFromURI resolves all of these downstream,
+		// so pass it through unchanged rather than forcing a scheme here.
 		Source:           containerImage,
 		OutputDir:        outputDir,
 		OutputType:       string(constants.IsoOutput),

--- a/internal/builder/auroraboot/builder_test.go
+++ b/internal/builder/auroraboot/builder_test.go
@@ -292,7 +292,7 @@ var _ = Describe("AuroraBoot Builder", func() {
 
 			ukiMu.Lock()
 			defer ukiMu.Unlock()
-			Expect(capturedUKI.Source).To(Equal("docker:quay.io/kairos/ubuntu:latest"))
+			Expect(capturedUKI.Source).To(Equal("quay.io/kairos/ubuntu:latest"))
 			Expect(capturedUKI.OutputDir).To(ContainSubstring("uki-ok"))
 			Expect(capturedUKI.OutputType).To(Equal("iso"))
 			Expect(capturedUKI.Name).To(Equal("kairos"))

--- a/internal/builder/auroraboot/builder_test.go
+++ b/internal/builder/auroraboot/builder_test.go
@@ -304,6 +304,33 @@ var _ = Describe("AuroraBoot Builder", func() {
 			Expect(capturedUKI.OverlayRootfs).To(Equal("/tmp/my-overlay"))
 		})
 
+		It("passes a schemed source reference through to UKI unchanged", func() {
+			_, err := b.Build(context.Background(), builder.BuildOptions{
+				ID:        "uki-schemed",
+				BaseImage: "oci:quay.io/kairos/ubuntu:latest",
+				Outputs: builder.OutputOptions{
+					ISO: true, // so the deployer step runs and we hit buildUKI after
+					UKI: true,
+				},
+				Signing: builder.SigningOptions{
+					UKISecureBootKey:    "/keys/db.key",
+					UKISecureBootCert:   "/keys/db.pem",
+					UKITPMPCRKey:        "/keys/tpm.pem",
+					UKIPublicKeysDir:    "/keys",
+					UKISecureBootEnroll: "force",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(deployCalled, 5*time.Second).Should(Receive())
+			Eventually(ukiCalled, 5*time.Second).Should(Receive())
+
+			ukiMu.Lock()
+			defer ukiMu.Unlock()
+			// The scheme must survive untouched: no extra "docker:" prefixing.
+			Expect(capturedUKI.Source).To(Equal("oci:quay.io/kairos/ubuntu:latest"))
+		})
+
 		It("fails the build with a helpful message when UKI keys are missing", func() {
 			_, err := b.Build(context.Background(), builder.BuildOptions{
 				ID:        "uki-nokeys",


### PR DESCRIPTION
The build-as-a-service UKI path forced the image source to "docker:" + containerImage. For a bare local image that is harmless (docker: and a bare ref both resolve via parseImageReference), but it breaks any source that already carries a scheme (e.g. oci:img became docker:oci:img) and is inconsistent with both the non-UKI path and the build-uki CLI, which pass the source through unchanged.

Pass containerImage through as-is so its scheme (oci:, docker:, local daemon, etc.) is honored, the same way the other build paths do.

Completes https://github.com/kairos-io/kairos/issues/3500