### PR TITLE
refactor: rename insecure flag to allow-insecure-registries

### DIFF
--- a/deployer/deployer.go
+++ b/deployer/deployer.go
@@ -66,6 +66,8 @@ func LoadByte(b []byte) (*schema.Config, *schema.ReleaseArtifact, error) {
 		return nil, nil, err
 	}
 
+	config.HandleDeprecations(internal.Log)
+
 	return config, release, nil
 }
 

--- a/deployer/deployer_suite_test.go
+++ b/deployer/deployer_suite_test.go
@@ -1,0 +1,13 @@
+package deployer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeployer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deployer Suite")
+}

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -1,0 +1,28 @@
+package deployer_test
+
+import (
+	"github.com/kairos-io/AuroraBoot/deployer"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LoadByte", func() {
+	It("reads the allow-insecure-registries key", func() {
+		cfg, _, err := deployer.LoadByte([]byte("allow-insecure-registries: true\n"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.AllowInsecureRegistries).To(BeTrue())
+	})
+
+	It("still honours the deprecated insecure key", func() {
+		cfg, _, err := deployer.LoadByte([]byte("insecure: true\n"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.AllowInsecureRegistries).To(BeTrue())
+	})
+
+	It("defaults both flags to false when neither key is present", func() {
+		cfg, _, err := deployer.LoadByte([]byte("arch: amd64\n"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.AllowInsecureRegistries).To(BeFalse())
+	})
+})

--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -98,7 +98,7 @@ func (d *Deployer) StepDumpSource() error {
 	internal.Log.Logger.Debug().Str("arch", d.Config.Arch).Str("image", d.Artifact.ContainerImage).Msg("StepDumpSource: config arch and image")
 	return d.Add(constants.OpDumpSource,
 		herd.EnableIf(d.fromImage),
-		herd.WithDeps(constants.OpPrepareDirs), herd.WithCallback(ops.DumpSource(d.Artifact.ContainerImage, d.tmpRootFs, d.Config.Arch, d.Config.Insecure)))
+		herd.WithDeps(constants.OpPrepareDirs), herd.WithCallback(ops.DumpSource(d.Artifact.ContainerImage, d.tmpRootFs, d.Config.Arch, d.Config.AllowInsecureRegistries)))
 }
 
 func (d *Deployer) StepGenISO() error {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -991,6 +991,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/settings/image-source": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Read the runtime image-source settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.imageSourceResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "description": "Sets the global default image URL and the local-serve enable flag / advertised URL. Enabling local serve requires a launch-configured listener.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Update the runtime image-source settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.imageSourceResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/settings/registration-token": {
             "get": {
                 "security": [
@@ -1147,6 +1197,10 @@ const docTemplate = `{
         "handlers.APICreateArtifactRequest": {
             "type": "object",
             "properties": {
+                "allow-insecure-registries": {
+                    "type": "boolean",
+                    "example": false
+                },
                 "arch": {
                     "type": "string",
                     "enum": [
@@ -1163,10 +1217,6 @@ const docTemplate = `{
                 },
                 "dockerfile": {
                     "type": "string"
-                },
-                "insecure": {
-                    "type": "boolean",
-                    "example": false
                 },
                 "kairosInitImage": {
                     "type": "string"
@@ -1395,9 +1445,44 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.imageSourceLocalServe": {
+            "type": "object",
+            "properties": {
+                "advertisedURL": {
+                    "description": "AdvertisedURL is the advertised base URL the BMC reaches the served ISO at.",
+                    "type": "string"
+                },
+                "configured": {
+                    "description": "Configured reports whether a local ISO-serve listener was configured at\nlaunch (--redfish-serve-addr). Without it, local serving cannot be enabled.",
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "description": "Enabled is the runtime gate (only meaningful when Configured).",
+                    "type": "boolean"
+                },
+                "usesTLS": {
+                    "description": "UsesTLS reports whether the listener serves over HTTPS.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "handlers.imageSourceResponse": {
+            "type": "object",
+            "properties": {
+                "defaultImageURL": {
+                    "type": "string"
+                },
+                "localServe": {
+                    "$ref": "#/definitions/handlers.imageSourceLocalServe"
+                }
+            }
+        },
         "store.ArtifactRecord": {
             "type": "object",
             "properties": {
+                "allow-insecure-registries": {
+                    "type": "boolean"
+                },
                 "arch": {
                     "type": "string"
                 },
@@ -1436,9 +1521,6 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "string"
-                },
-                "insecure": {
-                    "type": "boolean"
                 },
                 "iso": {
                     "type": "boolean"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -984,6 +984,56 @@
                 }
             }
         },
+        "/api/v1/settings/image-source": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Read the runtime image-source settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.imageSourceResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "description": "Sets the global default image URL and the local-serve enable flag / advertised URL. Enabling local serve requires a launch-configured listener.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Settings"
+                ],
+                "summary": "Update the runtime image-source settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.imageSourceResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/settings/registration-token": {
             "get": {
                 "security": [
@@ -1140,6 +1190,10 @@
         "handlers.APICreateArtifactRequest": {
             "type": "object",
             "properties": {
+                "allow-insecure-registries": {
+                    "type": "boolean",
+                    "example": false
+                },
                 "arch": {
                     "type": "string",
                     "enum": [
@@ -1156,10 +1210,6 @@
                 },
                 "dockerfile": {
                     "type": "string"
-                },
-                "insecure": {
-                    "type": "boolean",
-                    "example": false
                 },
                 "kairosInitImage": {
                     "type": "string"
@@ -1388,9 +1438,44 @@
                 }
             }
         },
+        "handlers.imageSourceLocalServe": {
+            "type": "object",
+            "properties": {
+                "advertisedURL": {
+                    "description": "AdvertisedURL is the advertised base URL the BMC reaches the served ISO at.",
+                    "type": "string"
+                },
+                "configured": {
+                    "description": "Configured reports whether a local ISO-serve listener was configured at\nlaunch (--redfish-serve-addr). Without it, local serving cannot be enabled.",
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "description": "Enabled is the runtime gate (only meaningful when Configured).",
+                    "type": "boolean"
+                },
+                "usesTLS": {
+                    "description": "UsesTLS reports whether the listener serves over HTTPS.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "handlers.imageSourceResponse": {
+            "type": "object",
+            "properties": {
+                "defaultImageURL": {
+                    "type": "string"
+                },
+                "localServe": {
+                    "$ref": "#/definitions/handlers.imageSourceLocalServe"
+                }
+            }
+        },
         "store.ArtifactRecord": {
             "type": "object",
             "properties": {
+                "allow-insecure-registries": {
+                    "type": "boolean"
+                },
                 "arch": {
                     "type": "string"
                 },
@@ -1429,9 +1514,6 @@
                 },
                 "id": {
                     "type": "string"
-                },
-                "insecure": {
-                    "type": "boolean"
                 },
                 "iso": {
                     "type": "boolean"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -74,6 +74,9 @@ definitions:
     type: object
   handlers.APICreateArtifactRequest:
     properties:
+      allow-insecure-registries:
+        example: false
+        type: boolean
       arch:
         enum:
         - amd64
@@ -86,9 +89,6 @@ definitions:
         type: string
       dockerfile:
         type: string
-      insecure:
-        example: false
-        type: boolean
       kairosInitImage:
         type: string
       kairosVersion:
@@ -244,8 +244,35 @@ definitions:
       nodeOnline:
         type: boolean
     type: object
+  handlers.imageSourceLocalServe:
+    properties:
+      advertisedURL:
+        description: AdvertisedURL is the advertised base URL the BMC reaches the
+          served ISO at.
+        type: string
+      configured:
+        description: |-
+          Configured reports whether a local ISO-serve listener was configured at
+          launch (--redfish-serve-addr). Without it, local serving cannot be enabled.
+        type: boolean
+      enabled:
+        description: Enabled is the runtime gate (only meaningful when Configured).
+        type: boolean
+      usesTLS:
+        description: UsesTLS reports whether the listener serves over HTTPS.
+        type: boolean
+    type: object
+  handlers.imageSourceResponse:
+    properties:
+      defaultImageURL:
+        type: string
+      localServe:
+        $ref: '#/definitions/handlers.imageSourceLocalServe'
+    type: object
   store.ArtifactRecord:
     properties:
+      allow-insecure-registries:
+        type: boolean
       arch:
         type: string
       artifacts:
@@ -272,8 +299,6 @@ definitions:
         type: boolean
       id:
         type: string
-      insecure:
-        type: boolean
       iso:
         type: boolean
       kairosInitImage:
@@ -1036,6 +1061,37 @@ paths:
       summary: Import a key set exported from another instance
       tags:
       - SecureBoot
+  /api/v1/settings/image-source:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.imageSourceResponse'
+      security:
+      - AdminBearer: []
+      summary: Read the runtime image-source settings
+      tags:
+      - Settings
+    put:
+      consumes:
+      - application/json
+      description: Sets the global default image URL and the local-serve enable flag
+        / advertised URL. Enabling local serve requires a launch-configured listener.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.imageSourceResponse'
+      security:
+      - AdminBearer: []
+      summary: Update the runtime image-source settings
+      tags:
+      - Settings
   /api/v1/settings/registration-token:
     get:
       produces:

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kairos-io/AuroraBoot/deployer"
+	"github.com/kairos-io/AuroraBoot/pkg/builder"
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
 	"github.com/kairos-io/AuroraBoot/pkg/schema"
-	"github.com/kairos-io/AuroraBoot/pkg/uki"
-	"github.com/kairos-io/AuroraBoot/pkg/builder"
 	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/kairos-io/AuroraBoot/pkg/uki"
 	sdklogger "github.com/kairos-io/kairos-sdk/types/logger"
 	"github.com/spectrocloud-labs/herd"
 )
@@ -50,9 +50,9 @@ func DefaultUKIBuildFunc(opts uki.Options) error { return uki.Build(opts) }
 
 // Builder implements builder.ArtifactBuilder using AuroraBoot.
 type Builder struct {
-	builds      map[string]*buildState
-	mu          sync.RWMutex
-	baseDir     string
+	builds         map[string]*buildState
+	mu             sync.RWMutex
+	baseDir        string
 	deployFunc     DeployerFunc
 	ukiBuildFn     UKIBuildFunc
 	store          store.ArtifactStore
@@ -182,32 +182,32 @@ func (b *Builder) Build(ctx context.Context, opts builder.BuildOptions) (*builde
 	// Persist artifact record in DB if store is available.
 	if b.store != nil {
 		rec := &store.ArtifactRecord{
-			ID:               id,
-			Name:             opts.Name,
-			Phase:            store.ArtifactPending,
-			BaseImage:        opts.BaseImage,
-			KairosVersion:    opts.KairosVersion,
-			Model:            opts.Model,
-			ISO:              opts.ISO,
-			CloudImage:       opts.CloudImage,
-			Netboot:          opts.Netboot,
-			FIPS:             opts.FIPS,
-			TrustedBoot:      opts.TrustedBoot,
-			Arch:             opts.Source.Arch,
-			Variant:          opts.Source.Variant,
-			Insecure:         opts.Source.Insecure,
-			RawDisk:          opts.Outputs.RawDisk,
-			Tar:              opts.Outputs.Tar,
-			GCE:              opts.Outputs.GCE,
-			VHD:              opts.Outputs.VHD,
-			UKI:              opts.Outputs.UKI,
-			KairosInitImage:  opts.KairosInitImage,
-			AutoInstall:      opts.Provisioning.AutoInstall,
-			RegisterAuroraBoot: opts.Provisioning.RegisterAuroraBoot,
-			Dockerfile:       opts.Dockerfile,
-			CloudConfig:      opts.CloudConfig,
-			CreatedAt:        time.Now(),
-			UpdatedAt:        time.Now(),
+			ID:                      id,
+			Name:                    opts.Name,
+			Phase:                   store.ArtifactPending,
+			BaseImage:               opts.BaseImage,
+			KairosVersion:           opts.KairosVersion,
+			Model:                   opts.Model,
+			ISO:                     opts.ISO,
+			CloudImage:              opts.CloudImage,
+			Netboot:                 opts.Netboot,
+			FIPS:                    opts.FIPS,
+			TrustedBoot:             opts.TrustedBoot,
+			Arch:                    opts.Source.Arch,
+			Variant:                 opts.Source.Variant,
+			AllowInsecureRegistries: opts.Source.AllowInsecureRegistries,
+			RawDisk:                 opts.Outputs.RawDisk,
+			Tar:                     opts.Outputs.Tar,
+			GCE:                     opts.Outputs.GCE,
+			VHD:                     opts.Outputs.VHD,
+			UKI:                     opts.Outputs.UKI,
+			KairosInitImage:         opts.KairosInitImage,
+			AutoInstall:             opts.Provisioning.AutoInstall,
+			RegisterAuroraBoot:      opts.Provisioning.RegisterAuroraBoot,
+			Dockerfile:              opts.Dockerfile,
+			CloudConfig:             opts.CloudConfig,
+			CreatedAt:               time.Now(),
+			UpdatedAt:               time.Now(),
 		}
 		if err := b.store.Create(ctx, rec); err != nil {
 			cancel()
@@ -292,9 +292,15 @@ func (b *Builder) run(ctx context.Context, bs *buildState, opts builder.BuildOpt
 	if logWriter != nil {
 		fmt.Fprintf(logWriter, "=== Starting AuroraBoot build ===\n")
 		fmt.Fprintf(logWriter, "Image: %s\n", containerImage)
-		if opts.ISO { fmt.Fprintf(logWriter, "Output: ISO\n") }
-		if opts.CloudImage { fmt.Fprintf(logWriter, "Output: Cloud Image (raw disk)\n") }
-		if opts.Netboot { fmt.Fprintf(logWriter, "Output: Netboot\n") }
+		if opts.ISO {
+			fmt.Fprintf(logWriter, "Output: ISO\n")
+		}
+		if opts.CloudImage {
+			fmt.Fprintf(logWriter, "Output: Cloud Image (raw disk)\n")
+		}
+		if opts.Netboot {
+			fmt.Fprintf(logWriter, "Output: Netboot\n")
+		}
 		fmt.Fprintf(logWriter, "Output dir: %s\n", outputDir)
 		if opts.CloudConfig != "" {
 			fmt.Fprintf(logWriter, "Cloud config:\n%s\n", opts.CloudConfig)
@@ -566,7 +572,7 @@ func (b *Builder) assembleConfig(opts builder.BuildOptions, containerImage, outp
 		config.Arch = opts.Source.Arch
 	}
 
-	config.Insecure = opts.Source.Insecure
+	config.AllowInsecureRegistries = opts.Source.AllowInsecureRegistries
 
 	if opts.CloudImage || opts.Outputs.RawDisk || opts.Outputs.GCE || opts.Outputs.VHD {
 		config.Disk.EFI = true
@@ -750,7 +756,7 @@ func collectArtifacts(dir string) []string {
 		".tar":    true,
 		".tar.gz": true,
 		".vhd":    true,
-		".sha256":  true,
+		".sha256": true,
 	}
 
 	var artifacts []string

--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -64,7 +64,7 @@ var BuildISOCmd = cli.Command{
 			Name:  "extend-live-cmdline",
 			Usage: "Append options to the kernel cmdline when booting from the live/installer ISO (e.g. rd.debug rd.shell). Does not affect the installed system.",
 		},
-		InsecureFlag,
+		AllowInsecureRegistriesFlag,
 	},
 	ArgsUsage: "<source>",
 	Action: func(ctx *cli.Context) error {
@@ -111,10 +111,10 @@ var BuildISOCmd = cli.Command{
 			ContainerImage: source,
 		}
 		isoOptions := schema.ISO{
-			OverrideName:  ctx.String("override-name"),
-			IncludeDate:   ctx.Bool("date"),
-			OverlayISO:    ctx.String("overlay-iso"),
-			OverlayRootfs: ctx.String("overlay-rootfs"),
+			OverrideName:      ctx.String("override-name"),
+			IncludeDate:       ctx.Bool("date"),
+			OverlayISO:        ctx.String("overlay-iso"),
+			OverlayRootfs:     ctx.String("overlay-rootfs"),
 			ExtendLiveCmdline: ctx.String("extend-live-cmdline"),
 		}
 
@@ -123,11 +123,11 @@ var BuildISOCmd = cli.Command{
 		}
 
 		c := schema.Config{
-			ISO:         isoOptions,
-			State:       ctx.String("output"),
-			CloudConfig: cloudConfig,
-			Arch:        ctx.String("arch"),
-			Insecure:    ctx.Bool("insecure"),
+			ISO:                     isoOptions,
+			State:                   ctx.String("output"),
+			CloudConfig:             cloudConfig,
+			Arch:                    ctx.String("arch"),
+			AllowInsecureRegistries: ctx.Bool("allow-insecure-registries"),
 		}
 
 		if c.State == "" {

--- a/internal/cmd/build-iso_test.go
+++ b/internal/cmd/build-iso_test.go
@@ -89,9 +89,16 @@ var _ = Describe("build-iso", Label("iso", "cmd"), func() {
 		Expect(err.Error()).ToNot(ContainSubstring("extend-live-cmdline"))
 	})
 
-	It("Accepts the insecure flag", Label("flags"), func() {
-		err = app.Run([]string{"", "build-iso", "--insecure", "system/cos"})
+	It("Accepts the allow-insecure-registries flag", Label("flags"), func() {
+		err = app.Run([]string{"", "build-iso", "--allow-insecure-registries", "system/cos"})
 		// Fails on image reference, but the flag should be accepted (no "unknown flag" error)
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).ToNot(ContainSubstring("flag provided but not defined"))
+	})
+
+	It("Accepts the deprecated insecure alias", Label("flags"), func() {
+		err = app.Run([]string{"", "build-iso", "--insecure", "system/cos"})
+		// The deprecated alias must keep working for v0.22.0 scripts.
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).ToNot(ContainSubstring("flag provided but not defined"))
 	})

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -2,13 +2,18 @@ package cmd
 
 import "github.com/urfave/cli/v2"
 
-// InsecureFlag is shared by every command that pulls container images, so the
-// flag is defined once and behaves consistently. urfave/cli v2 has no
-// persistent-flag mechanism; defining it as a global app flag would force it to
-// be passed before the subcommand (e.g. "auroraboot --insecure build-iso ..."),
-// breaking the natural "build-iso --insecure ..." form, so we share a single
-// flag value across the commands that need it instead.
-var InsecureFlag = &cli.BoolFlag{
-	Name:  "insecure",
-	Usage: "Allow pulling container images from registries over plain HTTP or with untrusted/self-signed TLS certificates",
+// AllowInsecureRegistriesFlag is shared by every command that pulls container
+// images, so the flag is defined once and behaves consistently. urfave/cli v2
+// has no persistent-flag mechanism; defining it as a global app flag would force
+// it to be passed before the subcommand (e.g.
+// "auroraboot --allow-insecure-registries build-iso ..."), breaking the natural
+// "build-iso --allow-insecure-registries ..." form, so we share a single flag
+// value across the commands that need it instead.
+//
+// The legacy "insecure" name is kept as a deprecated alias so scripts written
+// against v0.22.0 keep working.
+var AllowInsecureRegistriesFlag = &cli.BoolFlag{
+	Name:    "allow-insecure-registries",
+	Aliases: []string{"insecure"},
+	Usage:   "Allow pulling container images from registries over plain HTTP or with untrusted/self-signed TLS certificates. The --insecure alias is deprecated; use --allow-insecure-registries instead",
 }

--- a/internal/cmd/unpack.go
+++ b/internal/cmd/unpack.go
@@ -39,7 +39,7 @@ Examples:
 			Usage:   "Set the log level",
 			Value:   "info",
 		},
-		InsecureFlag,
+		AllowInsecureRegistriesFlag,
 	},
 	ArgsUsage: "<image> <destination>",
 	Action: func(ctx *cli.Context) error {
@@ -82,7 +82,7 @@ Examples:
 			Msg("Unpacking container image")
 
 		// Use the existing DumpSource function which already supports arch
-		dumpFn := ops.DumpSource(image, func() string { return destination }, arch, ctx.Bool("insecure"))
+		dumpFn := ops.DumpSource(image, func() string { return destination }, arch, ctx.Bool("allow-insecure-registries"))
 		if err := dumpFn(ctx.Context); err != nil {
 			return fmt.Errorf("failed to unpack image: %w", err)
 		}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -20,9 +20,10 @@ type ImageSource struct {
 	Variant           string // "core" or "standard"
 	KubernetesDistro  string
 	KubernetesVersion string
-	// Insecure allows pulling the base image from a registry served over plain
-	// HTTP or presenting an untrusted/self-signed TLS certificate.
-	Insecure bool
+	// AllowInsecureRegistries allows pulling the base image from a registry
+	// served over plain HTTP or presenting an untrusted/self-signed TLS
+	// certificate.
+	AllowInsecureRegistries bool
 }
 
 // OutputOptions selects which artifact formats to produce.

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -146,60 +146,60 @@ const (
 // image and used for upgrade tracking), not the Kairos framework
 // version of the base image.
 type Artifact struct {
-	ID               string        `json:"id"`
-	Name             string        `json:"name,omitempty"`
-	Saved            bool          `json:"saved,omitempty"`
-	Phase            ArtifactPhase `json:"phase"`
-	Message          string        `json:"message,omitempty"`
-	BaseImage        string        `json:"baseImage"`
-	KairosVersion    string        `json:"kairosVersion"`
-	Model            string        `json:"model"`
-	Arch             string        `json:"arch"`
-	Variant          string        `json:"variant"`
-	Insecure         bool          `json:"insecure"`
-	KubernetesDistro string        `json:"kubernetesDistro,omitempty"`
-	ISO              bool          `json:"iso"`
-	CloudImage       bool          `json:"cloudImage"`
-	Netboot          bool          `json:"netboot"`
-	RawDisk          bool          `json:"rawDisk"`
-	Tar              bool          `json:"tar"`
-	GCE              bool          `json:"gce"`
-	VHD              bool          `json:"vhd"`
-	UKI              bool          `json:"uki"`
-	FIPS             bool          `json:"fips"`
-	TrustedBoot      bool          `json:"trustedBoot"`
-	AutoInstall      bool          `json:"autoInstall"`
-	RegisterAuroraBoot bool          `json:"registerAuroraBoot"`
-	Dockerfile       string        `json:"dockerfile,omitempty"`
-	CloudConfig      string        `json:"cloudConfig,omitempty"`
-	TargetGroupID    string        `json:"targetGroupId,omitempty"`
-	ContainerImage   string        `json:"containerImage,omitempty"`
-	Artifacts        []string      `json:"artifacts,omitempty"`
-	CreatedAt        time.Time     `json:"createdAt"`
-	UpdatedAt        time.Time     `json:"updatedAt"`
+	ID                      string        `json:"id"`
+	Name                    string        `json:"name,omitempty"`
+	Saved                   bool          `json:"saved,omitempty"`
+	Phase                   ArtifactPhase `json:"phase"`
+	Message                 string        `json:"message,omitempty"`
+	BaseImage               string        `json:"baseImage"`
+	KairosVersion           string        `json:"kairosVersion"`
+	Model                   string        `json:"model"`
+	Arch                    string        `json:"arch"`
+	Variant                 string        `json:"variant"`
+	AllowInsecureRegistries bool          `json:"allow-insecure-registries"`
+	KubernetesDistro        string        `json:"kubernetesDistro,omitempty"`
+	ISO                     bool          `json:"iso"`
+	CloudImage              bool          `json:"cloudImage"`
+	Netboot                 bool          `json:"netboot"`
+	RawDisk                 bool          `json:"rawDisk"`
+	Tar                     bool          `json:"tar"`
+	GCE                     bool          `json:"gce"`
+	VHD                     bool          `json:"vhd"`
+	UKI                     bool          `json:"uki"`
+	FIPS                    bool          `json:"fips"`
+	TrustedBoot             bool          `json:"trustedBoot"`
+	AutoInstall             bool          `json:"autoInstall"`
+	RegisterAuroraBoot      bool          `json:"registerAuroraBoot"`
+	Dockerfile              string        `json:"dockerfile,omitempty"`
+	CloudConfig             string        `json:"cloudConfig,omitempty"`
+	TargetGroupID           string        `json:"targetGroupId,omitempty"`
+	ContainerImage          string        `json:"containerImage,omitempty"`
+	Artifacts               []string      `json:"artifacts,omitempty"`
+	CreatedAt               time.Time     `json:"createdAt"`
+	UpdatedAt               time.Time     `json:"updatedAt"`
 }
 
 // CreateArtifactRequest is the body of POST /api/v1/artifacts.
 // This is a large struct; most fields are optional and reasonable
 // defaults are applied server-side. Mirrors internal handler DTO.
 type CreateArtifactRequest struct {
-	Name              string                 `json:"name,omitempty"`
-	BaseImage         string                 `json:"baseImage,omitempty"`
-	KairosVersion     string                 `json:"kairosVersion,omitempty"`
-	Model             string                 `json:"model,omitempty"`
-	Arch              string                 `json:"arch,omitempty"`
-	Variant           string                 `json:"variant,omitempty"`
-	KubernetesDistro  string                 `json:"kubernetesDistro,omitempty"`
-	KubernetesVersion string                 `json:"kubernetesVersion,omitempty"`
-	Insecure          bool                   `json:"insecure,omitempty"`
-	Dockerfile        string                 `json:"dockerfile,omitempty"`
-	OverlayRootfs     string                 `json:"overlayRootfs,omitempty"`
-	KairosInitImage   string                 `json:"kairosInitImage,omitempty"`
-	Outputs           ArtifactOutputs        `json:"outputs"`
-	Signing           ArtifactSigning        `json:"signing"`
-	Provisioning      ArtifactProvisioning   `json:"provisioning"`
-	CloudConfig       string                 `json:"cloudConfig,omitempty"`
-	Extra             map[string]interface{} `json:"-"` // reserved for future fields
+	Name                    string                 `json:"name,omitempty"`
+	BaseImage               string                 `json:"baseImage,omitempty"`
+	KairosVersion           string                 `json:"kairosVersion,omitempty"`
+	Model                   string                 `json:"model,omitempty"`
+	Arch                    string                 `json:"arch,omitempty"`
+	Variant                 string                 `json:"variant,omitempty"`
+	KubernetesDistro        string                 `json:"kubernetesDistro,omitempty"`
+	KubernetesVersion       string                 `json:"kubernetesVersion,omitempty"`
+	AllowInsecureRegistries bool                   `json:"allow-insecure-registries,omitempty"`
+	Dockerfile              string                 `json:"dockerfile,omitempty"`
+	OverlayRootfs           string                 `json:"overlayRootfs,omitempty"`
+	KairosInitImage         string                 `json:"kairosInitImage,omitempty"`
+	Outputs                 ArtifactOutputs        `json:"outputs"`
+	Signing                 ArtifactSigning        `json:"signing"`
+	Provisioning            ArtifactProvisioning   `json:"provisioning"`
+	CloudConfig             string                 `json:"cloudConfig,omitempty"`
+	Extra                   map[string]interface{} `json:"-"` // reserved for future fields
 }
 
 // ArtifactOutputs toggles build output formats.
@@ -228,13 +228,13 @@ type ArtifactSigning struct {
 
 // ArtifactProvisioning describes cloud-config injection options.
 type ArtifactProvisioning struct {
-	AutoInstall      bool   `json:"autoInstall"`
+	AutoInstall        bool   `json:"autoInstall"`
 	RegisterAuroraBoot bool   `json:"registerAuroraBoot"`
-	TargetGroupID    string `json:"targetGroupId,omitempty"`
-	UserMode         string `json:"userMode,omitempty"`
-	Username         string `json:"username,omitempty"`
-	Password         string `json:"password,omitempty"`
-	SSHKeys          string `json:"sshKeys,omitempty"`
+	TargetGroupID      string `json:"targetGroupId,omitempty"`
+	UserMode           string `json:"userMode,omitempty"`
+	Username           string `json:"username,omitempty"`
+	Password           string `json:"password,omitempty"`
+	SSHKeys            string `json:"sshKeys,omitempty"`
 }
 
 // UpdateArtifactRequest is the body of PATCH /api/v1/artifacts/:id.

--- a/pkg/handlers/api_dto.go
+++ b/pkg/handlers/api_dto.go
@@ -101,22 +101,22 @@ type APIUpdateCommandStatusRequest struct {
 // Mirrors the shape the frontend sends; see internal/handlers/artifacts.go
 // for the authoritative parser.
 type APICreateArtifactRequest struct {
-	Name              string                  `json:"name"`
-	BaseImage         string                  `json:"baseImage"`
-	KairosVersion     string                  `json:"kairosVersion" example:"v1.0"`
-	Model             string                  `json:"model" example:"generic"`
-	Arch              string                  `json:"arch" example:"amd64" enums:"amd64,arm64"`
-	Variant           string                  `json:"variant" example:"core" enums:"core,standard"`
-	KubernetesDistro  string                  `json:"kubernetesDistro" enums:"k3s,k0s"`
-	KubernetesVersion string                  `json:"kubernetesVersion"`
-	Insecure          bool                    `json:"insecure" example:"false"`
-	Dockerfile        string                  `json:"dockerfile"`
-	OverlayRootfs     string                  `json:"overlayRootfs"`
-	KairosInitImage   string                  `json:"kairosInitImage"`
-	Outputs           APIArtifactOutputs      `json:"outputs"`
-	Signing           APIArtifactSigning      `json:"signing"`
-	Provisioning      APIArtifactProvisioning `json:"provisioning"`
-	CloudConfig       string                  `json:"cloudConfig"`
+	Name                    string                  `json:"name"`
+	BaseImage               string                  `json:"baseImage"`
+	KairosVersion           string                  `json:"kairosVersion" example:"v1.0"`
+	Model                   string                  `json:"model" example:"generic"`
+	Arch                    string                  `json:"arch" example:"amd64" enums:"amd64,arm64"`
+	Variant                 string                  `json:"variant" example:"core" enums:"core,standard"`
+	KubernetesDistro        string                  `json:"kubernetesDistro" enums:"k3s,k0s"`
+	KubernetesVersion       string                  `json:"kubernetesVersion"`
+	AllowInsecureRegistries bool                    `json:"allow-insecure-registries" example:"false"`
+	Dockerfile              string                  `json:"dockerfile"`
+	OverlayRootfs           string                  `json:"overlayRootfs"`
+	KairosInitImage         string                  `json:"kairosInitImage"`
+	Outputs                 APIArtifactOutputs      `json:"outputs"`
+	Signing                 APIArtifactSigning      `json:"signing"`
+	Provisioning            APIArtifactProvisioning `json:"provisioning"`
+	CloudConfig             string                  `json:"cloudConfig"`
 }
 
 // APIArtifactOutputs toggles the build's output formats.
@@ -145,13 +145,13 @@ type APIArtifactSigning struct {
 
 // APIArtifactProvisioning holds cloud-config injection options.
 type APIArtifactProvisioning struct {
-	AutoInstall        bool     `json:"autoInstall"`
-	RegisterAuroraBoot bool     `json:"registerAuroraBoot"`
-	TargetGroupID      string   `json:"targetGroupId"`
-	UserMode           string   `json:"userMode" enums:"default,custom,none"`
-	Username           string   `json:"username"`
-	Password           string   `json:"password"`
-	SSHKeys            string   `json:"sshKeys"`
+	AutoInstall        bool   `json:"autoInstall"`
+	RegisterAuroraBoot bool   `json:"registerAuroraBoot"`
+	TargetGroupID      string `json:"targetGroupId"`
+	UserMode           string `json:"userMode" enums:"default,custom,none"`
+	Username           string `json:"username"`
+	Password           string `json:"password"`
+	SSHKeys            string `json:"sshKeys"`
 	// AllowedCommands is the explicit list emitted under phonehome.allowed_commands.
 	// Nil means "use AuroraBoot's safe default set". An empty slice means deny-all
 	// (observe-only node) — the UI warns when the operator picks this.

--- a/pkg/handlers/artifacts.go
+++ b/pkg/handlers/artifacts.go
@@ -26,7 +26,7 @@ type ArtifactHandler struct {
 	groups         store.GroupStore
 	secureBootKeys store.SecureBootKeySetStore
 	regToken       string
-	aurorabootURL    string
+	aurorabootURL  string
 	artifactsDir   string
 }
 
@@ -38,26 +38,26 @@ func NewArtifactHandler(b builder.ArtifactBuilder, artifactStore store.ArtifactS
 		groups:         groups,
 		secureBootKeys: secureBootKeys,
 		regToken:       regToken,
-		aurorabootURL:    aurorabootURL,
+		aurorabootURL:  aurorabootURL,
 		artifactsDir:   artifactsDir,
 	}
 }
 
 // createArtifactRequest is the expected body for creating an artifact build.
 type createArtifactRequest struct {
-	Name              string `json:"name"`
-	BaseImage         string `json:"baseImage"`
-	KairosVersion     string `json:"kairosVersion"`
-	Model             string `json:"model"`
-	Arch              string `json:"arch"`
-	Variant           string `json:"variant"`
-	KubernetesDistro  string `json:"kubernetesDistro"`
-	KubernetesVersion string `json:"kubernetesVersion"`
-	Insecure          bool   `json:"insecure"`
-	Dockerfile        string `json:"dockerfile"`
-	BuildContextDir   string `json:"buildContextDir"`
-	OverlayRootfs     string `json:"overlayRootfs"`
-	KairosInitImage   string `json:"kairosInitImage"`
+	Name                    string `json:"name"`
+	BaseImage               string `json:"baseImage"`
+	KairosVersion           string `json:"kairosVersion"`
+	Model                   string `json:"model"`
+	Arch                    string `json:"arch"`
+	Variant                 string `json:"variant"`
+	KubernetesDistro        string `json:"kubernetesDistro"`
+	KubernetesVersion       string `json:"kubernetesVersion"`
+	AllowInsecureRegistries bool   `json:"allow-insecure-registries"`
+	Dockerfile              string `json:"dockerfile"`
+	BuildContextDir         string `json:"buildContextDir"`
+	OverlayRootfs           string `json:"overlayRootfs"`
+	KairosInitImage         string `json:"kairosInitImage"`
 
 	Outputs      artifactOutputs    `json:"outputs"`
 	Signing      *signingConfig     `json:"signing,omitempty"`
@@ -81,11 +81,11 @@ type artifactOutputs struct {
 }
 
 type signingConfig struct {
-	UKIKeySetID        string `json:"ukiKeySetId"`
-	UKISecureBootKey   string `json:"ukiSecureBootKey"`
-	UKISecureBootCert  string `json:"ukiSecureBootCert"`
-	UKITPMPCRKey       string `json:"ukiTpmPcrKey"`
-	UKIPublicKeysDir   string `json:"ukiPublicKeysDir"`
+	UKIKeySetID         string `json:"ukiKeySetId"`
+	UKISecureBootKey    string `json:"ukiSecureBootKey"`
+	UKISecureBootCert   string `json:"ukiSecureBootCert"`
+	UKITPMPCRKey        string `json:"ukiTpmPcrKey"`
+	UKIPublicKeysDir    string `json:"ukiPublicKeysDir"`
 	UKISecureBootEnroll string `json:"ukiSecureBootEnroll"`
 }
 
@@ -185,14 +185,14 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 	}
 	// Set grouped fields.
 	opts.Source = builder.ImageSource{
-		BaseImage:         req.BaseImage,
-		KairosVersion:     req.KairosVersion,
-		Model:             req.Model,
-		Arch:              req.Arch,
-		Variant:           req.Variant,
-		KubernetesDistro:  req.KubernetesDistro,
-		KubernetesVersion: req.KubernetesVersion,
-		Insecure:          req.Insecure,
+		BaseImage:               req.BaseImage,
+		KairosVersion:           req.KairosVersion,
+		Model:                   req.Model,
+		Arch:                    req.Arch,
+		Variant:                 req.Variant,
+		KubernetesDistro:        req.KubernetesDistro,
+		KubernetesVersion:       req.KubernetesVersion,
+		AllowInsecureRegistries: req.AllowInsecureRegistries,
 	}
 	opts.Outputs = builder.OutputOptions{
 		ISO:         req.Outputs.ISO,
@@ -274,38 +274,38 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 	// primary key. But builders that don't persist (e.g. the mock builder used
 	// in tests, or any builder constructed without a store) rely on this Create
 	// being the one that writes the row — so keep it. Both sites set the same
-	// fields, including Insecure, so the stored record is identical either way.
+	// fields, including AllowInsecureRegistries, so the stored record is identical either way.
 	if h.store != nil {
 		rec := &store.ArtifactRecord{
-			ID:                status.ID,
-			Name:              req.Name,
-			Phase:             status.Phase,
-			Message:           status.Message,
-			BaseImage:         req.BaseImage,
-			KairosVersion:     req.KairosVersion,
-			Model:             req.Model,
-			ISO:               req.Outputs.ISO,
-			CloudImage:        req.Outputs.CloudImage,
-			Netboot:           req.Outputs.Netboot,
-			FIPS:              req.Outputs.FIPS,
-			TrustedBoot:       req.Outputs.TrustedBoot,
-			Arch:              req.Arch,
-			Variant:           req.Variant,
-			Insecure:          req.Insecure,
-			RawDisk:           req.Outputs.RawDisk,
-			Tar:               req.Outputs.Tar,
-			GCE:               req.Outputs.GCE,
-			VHD:               req.Outputs.VHD,
-			UKI:               req.Outputs.UKI,
-			KairosInitImage:   req.KairosInitImage,
-			AutoInstall:       autoInstall,
-			RegisterAuroraBoot:  registerAuroraBoot,
-			Dockerfile:        req.Dockerfile,
-			CloudConfig:       opts.CloudConfig,
-			KubernetesDistro:  req.KubernetesDistro,
-			KubernetesVersion: req.KubernetesVersion,
-			TargetGroupID:     req.Provisioning.TargetGroupId,
-			OverlayRootfs:     req.OverlayRootfs,
+			ID:                      status.ID,
+			Name:                    req.Name,
+			Phase:                   status.Phase,
+			Message:                 status.Message,
+			BaseImage:               req.BaseImage,
+			KairosVersion:           req.KairosVersion,
+			Model:                   req.Model,
+			ISO:                     req.Outputs.ISO,
+			CloudImage:              req.Outputs.CloudImage,
+			Netboot:                 req.Outputs.Netboot,
+			FIPS:                    req.Outputs.FIPS,
+			TrustedBoot:             req.Outputs.TrustedBoot,
+			Arch:                    req.Arch,
+			Variant:                 req.Variant,
+			AllowInsecureRegistries: req.AllowInsecureRegistries,
+			RawDisk:                 req.Outputs.RawDisk,
+			Tar:                     req.Outputs.Tar,
+			GCE:                     req.Outputs.GCE,
+			VHD:                     req.Outputs.VHD,
+			UKI:                     req.Outputs.UKI,
+			KairosInitImage:         req.KairosInitImage,
+			AutoInstall:             autoInstall,
+			RegisterAuroraBoot:      registerAuroraBoot,
+			Dockerfile:              req.Dockerfile,
+			CloudConfig:             opts.CloudConfig,
+			KubernetesDistro:        req.KubernetesDistro,
+			KubernetesVersion:       req.KubernetesVersion,
+			TargetGroupID:           req.Provisioning.TargetGroupId,
+			OverlayRootfs:           req.OverlayRootfs,
 		}
 		_ = h.store.Create(ctx, rec)
 	}

--- a/pkg/ops/container.go
+++ b/pkg/ops/container.go
@@ -12,16 +12,16 @@ import (
 	imageutils "github.com/kairos-io/kairos-sdk/utils/image"
 )
 
-// insecureImageExtractor pulls OCI images allowing plain-HTTP registries and
-// registries serving untrusted/self-signed TLS certificates. It implements
-// kairos-sdk's imagetypes.ImageExtractor so it can be plugged into elemental
-// via WithImageExtractor, mirroring kairos-agent's OCIImageExtractor but
-// passing the insecure option down to the SDK.
-type insecureImageExtractor struct{}
+// allowInsecureRegistriesImageExtractor pulls OCI images allowing plain-HTTP
+// registries and registries serving untrusted/self-signed TLS certificates. It
+// implements kairos-sdk's imagetypes.ImageExtractor so it can be plugged into
+// elemental via WithImageExtractor, mirroring kairos-agent's OCIImageExtractor
+// but passing the insecure-registry option down to the SDK.
+type allowInsecureRegistriesImageExtractor struct{}
 
-var _ sdkImage.ImageExtractor = insecureImageExtractor{}
+var _ sdkImage.ImageExtractor = allowInsecureRegistriesImageExtractor{}
 
-func (e insecureImageExtractor) ExtractImage(imageRef, destination, platformRef string, excludes ...string) error {
+func (e allowInsecureRegistriesImageExtractor) ExtractImage(imageRef, destination, platformRef string, excludes ...string) error {
 	if platformRef == "" {
 		platformRef = utils.GetCurrentPlatform()
 	}
@@ -32,7 +32,7 @@ func (e insecureImageExtractor) ExtractImage(imageRef, destination, platformRef 
 	return imageutils.ExtractOCIImage(img, destination, excludes...)
 }
 
-func (e insecureImageExtractor) GetOCIImageSize(imageRef, platformRef string) (int64, error) {
+func (e allowInsecureRegistriesImageExtractor) GetOCIImageSize(imageRef, platformRef string) (int64, error) {
 	if platformRef == "" {
 		platformRef = utils.GetCurrentPlatform()
 	}
@@ -41,21 +41,22 @@ func (e insecureImageExtractor) GetOCIImageSize(imageRef, platformRef string) (i
 
 // DumpSource pulls a container image either remotely or locally from a docker daemon
 // or simply copies the directory to the destination.
-// When insecure is true, pulls are allowed from plain-HTTP registries and from
-// registries presenting untrusted/self-signed TLS certificates.
+// When allowInsecureRegistries is true, pulls are allowed from plain-HTTP
+// registries and from registries presenting untrusted/self-signed TLS
+// certificates.
 // Supports these prefixes:
 // https://github.com/kairos-io/kairos-agent/blob/1e81cdef38677c8a36cae50d3334559976f66481/pkg/types/v1/common.go#L30-L33
-func DumpSource(image string, dstFunc valueGetOnCall, arch string, insecure bool) func(ctx context.Context) error {
+func DumpSource(image string, dstFunc valueGetOnCall, arch string, allowInsecureRegistries bool) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		dst := dstFunc()
 		if image == "" {
 			return fmt.Errorf("image source is empty, cannot dump to %s", dst)
 		}
-		internal.Log.Logger.Debug().Str("arch", arch).Bool("insecure", insecure).Msg("DumpSource: arch parameter")
+		internal.Log.Logger.Debug().Str("arch", arch).Bool("allow-insecure-registries", allowInsecureRegistries).Msg("DumpSource: arch parameter")
 
 		var extractor sdkImage.ImageExtractor = imageextractor.OCIImageExtractor{}
-		if insecure {
-			extractor = insecureImageExtractor{}
+		if allowInsecureRegistries {
+			extractor = allowInsecureRegistriesImageExtractor{}
 		}
 		opts := []GenericOptions{
 			WithImageExtractor(extractor),

--- a/pkg/ops/container_test.go
+++ b/pkg/ops/container_test.go
@@ -95,7 +95,7 @@ var _ = Describe("DumpSource against an insecure registry", Label("ops"), func()
 		Expect(os.RemoveAll(destDir)).To(Succeed())
 	})
 
-	It("fails without the insecure flag", func() {
+	It("fails without allow-insecure-registries", func() {
 		err := DumpSource("docker://"+imageRef, func() string { return destDir }, "", false)(context.Background())
 		Expect(err).To(HaveOccurred())
 		// It must fail because of TLS verification, not because the ref is
@@ -107,7 +107,7 @@ var _ = Describe("DumpSource against an insecure registry", Label("ops"), func()
 		))
 	})
 
-	It("succeeds with the insecure flag and extracts the image", func() {
+	It("succeeds with allow-insecure-registries and extracts the image", func() {
 		err := DumpSource("docker://"+imageRef, func() string { return destDir }, "", true)(context.Background())
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/schema/config.go
+++ b/pkg/schema/config.go
@@ -37,9 +37,14 @@ type Config struct {
 	// Architecture to use for container image pulling (e.g., "amd64", "arm64")
 	Arch string `yaml:"arch"`
 
-	// Insecure allows pulling container images from registries over plain HTTP
-	// or presenting untrusted/self-signed TLS certificates
-	Insecure bool `yaml:"insecure"`
+	// AllowInsecureRegistries allows pulling container images from registries
+	// over plain HTTP or presenting untrusted/self-signed TLS certificates
+	AllowInsecureRegistries bool `yaml:"allow-insecure-registries"`
+
+	// DeprecatedInsecure preserves the old "insecure" config key so configs
+	// written against v0.22.0 keep working. Prefer "allow-insecure-registries".
+	// Reconciled into AllowInsecureRegistries by NormalizeDeprecated.
+	DeprecatedInsecure bool `yaml:"insecure"`
 
 	// ISO block configuration
 	ISO ISO `yaml:"iso"`
@@ -99,6 +104,19 @@ func (i *ISO) HandleDeprecations(log logger.KairosLogger) {
 		log.Logger.Warn().Msg("'iso.data' is deprecated and will be removed in a future release. Both 'iso.data' and 'iso.overlay_iso' are set; 'iso.data' will be ignored.")
 	}
 	i.DataPath = ""
+}
+
+// HandleDeprecations reconciles deprecated top-level config keys into their
+// current equivalents. The old "insecure" key is migrated to
+// "allow-insecure-registries".
+func (c *Config) HandleDeprecations(log logger.KairosLogger) {
+	if c.DeprecatedInsecure {
+		log.Logger.Warn().Msg("'insecure' is deprecated and will be removed in a future release. Use 'allow-insecure-registries' instead.")
+		if !c.AllowInsecureRegistries {
+			c.AllowInsecureRegistries = c.DeprecatedInsecure
+		}
+		c.DeprecatedInsecure = false
+	}
 }
 
 func (c Config) StateDir(s ...string) string {

--- a/pkg/schema/config_test.go
+++ b/pkg/schema/config_test.go
@@ -56,3 +56,43 @@ var _ = Describe("ISO HandleDeprecations", func() {
 		Expect(iso.Name).To(Equal("test-iso"))
 	})
 })
+
+var _ = Describe("Config HandleDeprecations", func() {
+	var (
+		cfg schema.Config
+		log logger.KairosLogger
+	)
+
+	BeforeEach(func() {
+		cfg = schema.Config{}
+		log = logger.NewKairosLogger("test", "error", false)
+	})
+
+	It("does nothing when neither key is set", func() {
+		cfg.HandleDeprecations(log)
+		Expect(cfg.AllowInsecureRegistries).To(BeFalse())
+		Expect(cfg.DeprecatedInsecure).To(BeFalse())
+	})
+
+	It("migrates the deprecated insecure key to allow-insecure-registries", func() {
+		cfg.DeprecatedInsecure = true
+		cfg.HandleDeprecations(log)
+		Expect(cfg.AllowInsecureRegistries).To(BeTrue())
+		Expect(cfg.DeprecatedInsecure).To(BeFalse())
+	})
+
+	It("keeps allow-insecure-registries when only that key is set", func() {
+		cfg.AllowInsecureRegistries = true
+		cfg.HandleDeprecations(log)
+		Expect(cfg.AllowInsecureRegistries).To(BeTrue())
+		Expect(cfg.DeprecatedInsecure).To(BeFalse())
+	})
+
+	It("does not clobber allow-insecure-registries when both keys are set", func() {
+		cfg.AllowInsecureRegistries = true
+		cfg.DeprecatedInsecure = true
+		cfg.HandleDeprecations(log)
+		Expect(cfg.AllowInsecureRegistries).To(BeTrue())
+		Expect(cfg.DeprecatedInsecure).To(BeFalse())
+	})
+})

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -139,41 +139,41 @@ type CommandStore interface {
 
 // ArtifactRecord stores a build artifact and its metadata.
 type ArtifactRecord struct {
-	ID                 string    `json:"id" gorm:"primaryKey"`
-	Name               string    `json:"name,omitempty"`
-	Saved              bool      `json:"saved,omitempty"`
-	Phase              string    `json:"phase"`
-	Message            string    `json:"message"`
-	BaseImage          string    `json:"baseImage"`
-	KairosVersion      string    `json:"kairosVersion"`
-	Model              string    `json:"model"`
-	ISO                bool      `json:"iso"`
-	CloudImage         bool      `json:"cloudImage"`
-	Netboot            bool      `json:"netboot"`
-	FIPS               bool      `json:"fips"`
-	TrustedBoot        bool      `json:"trustedBoot"`
-	Arch               string    `json:"arch,omitempty"`
-	Variant            string    `json:"variant,omitempty"`
-	Insecure           bool      `json:"insecure"`
-	RawDisk            bool      `json:"rawDisk"`
-	Tar                bool      `json:"tar"`
-	GCE                bool      `json:"gce"`
-	VHD                bool      `json:"vhd"`
-	UKI                bool      `json:"uki"`
-	KairosInitImage    string    `json:"kairosInitImage,omitempty"`
-	AutoInstall        bool      `json:"autoInstall"`
-	RegisterAuroraBoot bool      `json:"registerAuroraBoot"`
-	Dockerfile         string    `json:"dockerfile,omitempty"`
-	CloudConfig        string    `json:"cloudConfig,omitempty" gorm:"type:text"`
-	KubernetesDistro   string    `json:"kubernetesDistro,omitempty"`
-	KubernetesVersion  string    `json:"kubernetesVersion,omitempty"`
-	TargetGroupID      string    `json:"targetGroupId,omitempty"`
-	ContainerImage     string    `json:"containerImage,omitempty"`
-	OverlayRootfs      string    `json:"overlayRootfs,omitempty"`
-	ArtifactFiles      []string  `json:"artifacts" gorm:"serializer:json"`
-	Logs               string    `json:"-" gorm:"type:text"`
-	CreatedAt          time.Time `json:"createdAt"`
-	UpdatedAt          time.Time `json:"updatedAt"`
+	ID                      string    `json:"id" gorm:"primaryKey"`
+	Name                    string    `json:"name,omitempty"`
+	Saved                   bool      `json:"saved,omitempty"`
+	Phase                   string    `json:"phase"`
+	Message                 string    `json:"message"`
+	BaseImage               string    `json:"baseImage"`
+	KairosVersion           string    `json:"kairosVersion"`
+	Model                   string    `json:"model"`
+	ISO                     bool      `json:"iso"`
+	CloudImage              bool      `json:"cloudImage"`
+	Netboot                 bool      `json:"netboot"`
+	FIPS                    bool      `json:"fips"`
+	TrustedBoot             bool      `json:"trustedBoot"`
+	Arch                    string    `json:"arch,omitempty"`
+	Variant                 string    `json:"variant,omitempty"`
+	AllowInsecureRegistries bool      `json:"allow-insecure-registries"`
+	RawDisk                 bool      `json:"rawDisk"`
+	Tar                     bool      `json:"tar"`
+	GCE                     bool      `json:"gce"`
+	VHD                     bool      `json:"vhd"`
+	UKI                     bool      `json:"uki"`
+	KairosInitImage         string    `json:"kairosInitImage,omitempty"`
+	AutoInstall             bool      `json:"autoInstall"`
+	RegisterAuroraBoot      bool      `json:"registerAuroraBoot"`
+	Dockerfile              string    `json:"dockerfile,omitempty"`
+	CloudConfig             string    `json:"cloudConfig,omitempty" gorm:"type:text"`
+	KubernetesDistro        string    `json:"kubernetesDistro,omitempty"`
+	KubernetesVersion       string    `json:"kubernetesVersion,omitempty"`
+	TargetGroupID           string    `json:"targetGroupId,omitempty"`
+	ContainerImage          string    `json:"containerImage,omitempty"`
+	OverlayRootfs           string    `json:"overlayRootfs,omitempty"`
+	ArtifactFiles           []string  `json:"artifacts" gorm:"serializer:json"`
+	Logs                    string    `json:"-" gorm:"type:text"`
+	CreatedAt               time.Time `json:"createdAt"`
+	UpdatedAt               time.Time `json:"updatedAt"`
 }
 
 // Artifact phases.

--- a/ui/src/api/artifacts.ts
+++ b/ui/src/api/artifacts.ts
@@ -11,7 +11,7 @@ export interface Artifact {
   model: string;
   arch?: string;
   variant?: string;
-  insecure?: boolean;
+  "allow-insecure-registries"?: boolean;
   iso: boolean;
   cloudImage: boolean;
   netboot: boolean;
@@ -87,7 +87,7 @@ export interface CreateArtifactInput {
    * Allow pulling the base image from a registry served over plain HTTP or
    * presenting an untrusted/self-signed TLS certificate.
    */
-  insecure?: boolean;
+  "allow-insecure-registries"?: boolean;
   dockerfile?: string;
   overlayRootfs?: string;
   kairosInitImage?: string;

--- a/ui/src/lib/buildConfig.ts
+++ b/ui/src/lib/buildConfig.ts
@@ -50,7 +50,7 @@ export interface BuildConfigPayload {
     kubernetesDistro?: string;
     kubernetesVersion?: string;
     kairosInitImage?: string;
-    insecure?: boolean;
+    "allow-insecure-registries"?: boolean;
   };
   dockerfile?: string;
   overlayRootfs?: string;
@@ -105,7 +105,8 @@ export function payloadFromBuilder(args: {
       kubernetesDistro: form.variant === "standard" ? form.kubernetesDistro || undefined : undefined,
       kubernetesVersion: form.variant === "standard" ? form.kubernetesVersion || undefined : undefined,
       kairosInitImage: form.kairosInitImage || undefined,
-      insecure: buildMode === "image" ? form.insecure || undefined : undefined,
+      "allow-insecure-registries":
+        buildMode === "image" ? form["allow-insecure-registries"] || undefined : undefined,
     },
     dockerfile: buildMode === "dockerfile" ? form.dockerfile : undefined,
     overlayRootfs: form.overlayRootfs || undefined,
@@ -152,7 +153,8 @@ export function payloadFromArtifact(artifact: Artifact, groups: Group[]): BuildC
       kubernetesDistro: artifact.kubernetesDistro || undefined,
       kubernetesVersion: artifact.kubernetesVersion || undefined,
       kairosInitImage: artifact.kairosInitImage || undefined,
-      insecure: buildMode === "image" ? artifact.insecure || undefined : undefined,
+      "allow-insecure-registries":
+        buildMode === "image" ? artifact["allow-insecure-registries"] || undefined : undefined,
     },
     dockerfile: buildMode === "dockerfile" ? artifact.dockerfile : undefined,
     outputs: {

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -361,7 +361,7 @@ const EMPTY_FORM: CreateArtifactInput = {
   variant: "core",
   kubernetesDistro: "",
   kubernetesVersion: "",
-  insecure: false,
+  "allow-insecure-registries": false,
   dockerfile: "",
   overlayRootfs: "",
   kairosInitImage: "",
@@ -612,7 +612,7 @@ export function ArtifactBuilder() {
       variant: src.variant || "core",
       kubernetesDistro: src.kubernetesDistro || "",
       kubernetesVersion: src.kubernetesVersion || "",
-      insecure: src.insecure ?? false,
+      "allow-insecure-registries": src["allow-insecure-registries"] ?? false,
       dockerfile: parsed.dockerfile || "",
       overlayRootfs: parsed.overlayRootfs || "",
       kairosInitImage: src.kairosInitImage || "",
@@ -679,7 +679,7 @@ export function ArtifactBuilder() {
           variant: a.variant || "core",
           kubernetesDistro: a.kubernetesDistro || "",
           kubernetesVersion: a.kubernetesVersion || "",
-          insecure: a.insecure ?? false,
+          "allow-insecure-registries": a["allow-insecure-registries"] ?? false,
           dockerfile: a.dockerfile || "",
           kairosInitImage: a.kairosInitImage || "",
           outputs: {
@@ -923,7 +923,8 @@ export function ArtifactBuilder() {
       kubernetesDistro: form.variant === "standard" ? form.kubernetesDistro : undefined,
       kubernetesVersion: form.variant === "standard" ? form.kubernetesVersion : undefined,
       // Only meaningful when pulling a base image from a registry.
-      insecure: buildMode === "image" ? form.insecure : undefined,
+      "allow-insecure-registries":
+        buildMode === "image" ? form["allow-insecure-registries"] : undefined,
       dockerfile: buildMode === "dockerfile" ? form.dockerfile : undefined,
       overlayRootfs: form.overlayRootfs || undefined,
       kairosInitImage: form.kairosInitImage || undefined,
@@ -1140,11 +1141,11 @@ export function ArtifactBuilder() {
                     <label className="flex items-center gap-2 text-sm font-medium">
                       <input
                         type="checkbox"
-                        checked={form.insecure ?? false}
-                        onChange={(e) => update("insecure", e.target.checked)}
+                        checked={form["allow-insecure-registries"] ?? false}
+                        onChange={(e) => update("allow-insecure-registries", e.target.checked)}
                         className="rounded border-input"
                       />
-                      Insecure registry
+                      Allow insecure registries
                     </label>
                     <p className="text-xs text-muted-foreground mt-1 ml-6">
                       Allow pulling the base image from a registry served over plain HTTP or with an untrusted/self-signed TLS certificate.
@@ -2041,10 +2042,10 @@ export function ArtifactBuilder() {
                         {buildMode === "dockerfile" ? "(Dockerfile)" : form.baseImage || "\u2014"}
                       </span>
                     </div>
-                    {buildMode === "image" && form.insecure && (
+                    {buildMode === "image" && form["allow-insecure-registries"] && (
                       <div className="flex gap-2">
                         <span className="text-muted-foreground w-28 shrink-0">Registry:</span>
-                        <span>Insecure (plain HTTP / untrusted TLS allowed)</span>
+                        <span>Insecure registries allowed (plain HTTP / untrusted TLS)</span>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
Rename the user-facing "insecure" term for insecure-registry support to the self-explanatory "allow-insecure-registries", matching the change made in kairos-agent. This is a rename only; no behavior changes.

- CLI: --insecure becomes --allow-insecure-registries on build-iso and unpack. The old --insecure name is kept as a deprecated urfave/cli alias so scripts written against v0.22.0 keep working; the usage text marks it deprecated.
- Go identifiers: Insecure fields/params/vars become AllowInsecureRegistries (schema.Config, BuildOptions.Source, ArtifactRecord, DumpSource param, the createArtifactRequest DTO and client types). The shared InsecureFlag var becomes AllowInsecureRegistriesFlag and insecureImageExtractor becomes allowInsecureRegistriesImageExtractor (behavior unchanged).
- Config / JSON / yaml keys: insecure becomes allow-insecure-registries to match kairos-agent's kebab key. The old top-level "insecure" config key is still read via Config.HandleDeprecations, which migrates it into AllowInsecureRegistries and logs a deprecation warning, so existing configs keep working.
- Web UI: the checkbox field, state and label are renamed; the label now reads "Allow insecure registries". The TS API DTOs use the allow-insecure-registries JSON key so the wire format matches the backend.
- Regenerated the OpenAPI spec with swag. The regeneration also picks up pre-existing drift (a settings/image-source endpoint missing from the committed spec) unrelated to this rename.