### PR TITLE
fix(install-agent): POSIX-safe import script and phone-home registration (#4152)

### DIFF
--- a/e2e/web/cypress/e2e/smoke.cy.js
+++ b/e2e/web/cypress/e2e/smoke.cy.js
@@ -43,7 +43,7 @@ describe("AuroraBoot web smoke", () => {
   it("serves the install-agent script", () => {
     cy.request({ url: "/api/v1/install-agent", failOnStatusCode: true }).then((res) => {
       expect(res.status).to.eq(200);
-      expect(res.body).to.include("#!/bin/bash");
+      expect(res.body).to.include("#!/bin/sh");
       expect(res.body).to.include("AURORABOOT_URL");
       expect(res.body).to.include("kairos-agent-phonehome");
     });

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -503,8 +503,7 @@ IFS=','
 for c in $ALLOWED_RAW; do
     c=$(echo "$c" | xargs)  # trim whitespace
     if [ -n "$c" ]; then
-        ALLOWED_YAML="${ALLOWED_YAML}    - ${c}
-"
+        ALLOWED_YAML="${ALLOWED_YAML}    - ${c}$(printf '\n')"
     fi
 done
 IFS="$_old_ifs"

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -472,9 +472,9 @@ func (h *NodeHandler) GetCommands(c echo.Context) error {
 
 // InstallScript handles GET /api/v1/install-agent.
 func (h *NodeHandler) InstallScript(c echo.Context) error {
-	script := fmt.Sprintf(`#!/bin/bash
+	script := fmt.Sprintf(`#!/bin/sh
 # AuroraBoot agent install script
-# Usage: curl -sSL %s/api/v1/install-agent | AURORABOOT_GROUP=mygroup bash
+# Usage: curl -sSL %s/api/v1/install-agent | AURORABOOT_GROUP=mygroup sh
 
 set -e
 
@@ -498,11 +498,16 @@ GROUP="${AURORABOOT_GROUP:-}"
 # defaults too — deny-all must be configured from the AuroraBoot UI instead.
 ALLOWED_RAW="${AURORABOOT_ALLOWED_COMMANDS:-upgrade,upgrade-recovery,reboot,unregister}"
 ALLOWED_YAML=""
-IFS=',' read -ra _cmds <<< "$ALLOWED_RAW"
-for c in "${_cmds[@]}"; do
+_old_ifs="$IFS"
+IFS=','
+for c in $ALLOWED_RAW; do
     c=$(echo "$c" | xargs)  # trim whitespace
-    [ -n "$c" ] && ALLOWED_YAML="${ALLOWED_YAML}    - ${c}"$'\n'
+    if [ -n "$c" ]; then
+        ALLOWED_YAML="${ALLOWED_YAML}    - ${c}
+"
+    fi
 done
+IFS="$_old_ifs"
 
 echo "Installing AuroraBoot agent..."
 echo "Server: ${AURORABOOT_URL}"
@@ -516,7 +521,8 @@ phonehome:
   registration_token: "${REG_TOKEN}"
   group: "${GROUP}"
   allowed_commands:
-${ALLOWED_YAML}EOF
+${ALLOWED_YAML}
+EOF
 
 echo "Config written to /oem/phonehome.yaml"
 
@@ -528,7 +534,23 @@ if ! command -v kairos-agent >/dev/null 2>&1; then
 fi
 echo "Starting kairos-agent..."
 kairos-agent start
-echo "kairos-agent-phonehome service installed and started."
+
+# kairos-agent writes the phone-home unit with a hardcoded /usr/sbin/kairos-agent
+# path, but some images install the binary elsewhere (e.g. /usr/bin). systemd
+# then fails with status=203/EXEC and the node never registers.
+AGENT_BIN="$(command -v kairos-agent)"
+UNIT=/etc/systemd/system/kairos-agent-phonehome.service
+if [ -n "$AGENT_BIN" ] && [ -f "$UNIT" ]; then
+    sed -i "s|^ExecStart=.*|ExecStart=${AGENT_BIN} phone-home|" "$UNIT"
+    systemctl daemon-reload
+    systemctl restart kairos-agent-phonehome
+fi
+
+if systemctl is-active --quiet kairos-agent-phonehome; then
+    echo "kairos-agent-phonehome service is active."
+else
+    echo "Warning: kairos-agent-phonehome is not active — check: systemctl status kairos-agent-phonehome" >&2
+fi
 
 echo "AuroraBoot agent installation complete."
 `, h.aurorabootURL, h.aurorabootURL)

--- a/pkg/handlers/nodes_test.go
+++ b/pkg/handlers/nodes_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"sync"
 
@@ -404,7 +406,7 @@ var _ = Describe("NodeHandler", func() {
 	})
 
 	Describe("InstallScript", func() {
-		It("should return a bash script", func() {
+		It("should return an install shell script", func() {
 			req := httptest.NewRequest(http.MethodGet, "/api/v1/install-agent", nil)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
@@ -412,8 +414,31 @@ var _ = Describe("NodeHandler", func() {
 			err := handler.InstallScript(c)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rec.Code).To(Equal(http.StatusOK))
-			Expect(rec.Body.String()).To(ContainSubstring("#!/bin/bash"))
+			Expect(rec.Body.String()).To(ContainSubstring("#!/bin/sh"))
 			Expect(rec.Body.String()).To(ContainSubstring("http://localhost:8080"))
+		})
+
+		It("should emit a shell script that passes sh -n and bash -n", func() {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/install-agent", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := handler.InstallScript(c)
+			Expect(err).NotTo(HaveOccurred())
+
+			tmp, err := os.CreateTemp("", "install-agent-*.sh")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(tmp.Name())
+
+			_, err = tmp.Write(rec.Body.Bytes())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tmp.Close()).To(Succeed())
+
+			for _, shell := range []string{"sh", "bash"} {
+				cmd := exec.Command(shell, "-n", tmp.Name())
+				out, err := cmd.CombinedOutput()
+				Expect(err).NotTo(HaveOccurred(), "%s: %s", shell, out)
+			}
 		})
 	})
 })

--- a/pkg/handlers/nodes_test.go
+++ b/pkg/handlers/nodes_test.go
@@ -435,6 +435,9 @@ var _ = Describe("NodeHandler", func() {
 			Expect(tmp.Close()).To(Succeed())
 
 			for _, shell := range []string{"sh", "bash"} {
+				if _, err := exec.LookPath(shell); err != nil {
+					Skip(shell + " not installed")
+				}
 				cmd := exec.Command(shell, "-n", tmp.Name())
 				out, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred(), "%s: %s", shell, out)

--- a/test/integration/install_script_test.go
+++ b/test/integration/install_script_test.go
@@ -14,10 +14,11 @@ var _ = Describe("Install Script", func() {
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 		body := readBody(resp)
-		Expect(body).To(ContainSubstring("#!/bin/bash"))
+		Expect(body).To(ContainSubstring("#!/bin/sh"))
 		Expect(body).To(ContainSubstring("AURORABOOT_URL"))
 		Expect(body).To(ContainSubstring("/oem/phonehome.yaml"))
-		Expect(body).To(ContainSubstring("kairos-agent-phonehome"))
+		Expect(body).To(ContainSubstring("sed -i"))
+		Expect(body).To(ContainSubstring("systemctl restart kairos-agent-phonehome"))
 	})
 
 	// The install script bakes allowed_commands into the node's cloud-config


### PR DESCRIPTION
## Summary

- Fix the `/api/v1/install-agent` script so it works when piped to `sh` (POSIX-safe allowed_commands loop, heredoc `EOF` on its own line).
- After `kairos-agent start`, patch the phone-home systemd unit to use the actual `kairos-agent` binary path and verify the service is active — workaround for kairos-agent hardcoding `/usr/sbin/kairos-agent` (kairos-io/kairos#4178).
- Add `sh -n` / `bash -n` syntax checks in unit tests; update integration and Cypress smoke expectations.
- Bump default kairos-init to **v0.14.7** for kairosification builds (includes the upstream agent path fix).

Fixes kairos-io/kairos#4152

## Test plan

- [x] `go test ./pkg/handlers/... ./internal/builder/auroraboot/...`
- [x] Manual: `curl …/install-agent | sh` on Kairos node — phonehome.yaml written, `kairos-agent-phonehome` active, node registers in UI
- [x] `docker compose up --build -d` and rebuild artifact with new kairos-init default


Made with [Cursor](https://cursor.com)