### PR TITLE
fix(ui): bake k3s/k0s enablement into standard artifact cloud-config

### DIFF
--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -158,6 +158,7 @@ type Artifact struct {
 	Variant                 string        `json:"variant"`
 	AllowInsecureRegistries bool          `json:"allow-insecure-registries"`
 	KubernetesDistro        string        `json:"kubernetesDistro,omitempty"`
+	KubernetesEnabled       *bool         `json:"kubernetesEnabled,omitempty"`
 	ISO                     bool          `json:"iso"`
 	CloudImage              bool          `json:"cloudImage"`
 	Netboot                 bool          `json:"netboot"`
@@ -191,6 +192,7 @@ type CreateArtifactRequest struct {
 	Variant                 string                 `json:"variant,omitempty"`
 	KubernetesDistro        string                 `json:"kubernetesDistro,omitempty"`
 	KubernetesVersion       string                 `json:"kubernetesVersion,omitempty"`
+	KubernetesEnabled       *bool                  `json:"kubernetesEnabled,omitempty"`
 	AllowInsecureRegistries bool                   `json:"allow-insecure-registries,omitempty"`
 	Dockerfile              string                 `json:"dockerfile,omitempty"`
 	OverlayRootfs           string                 `json:"overlayRootfs,omitempty"`

--- a/pkg/handlers/api_dto.go
+++ b/pkg/handlers/api_dto.go
@@ -109,6 +109,7 @@ type APICreateArtifactRequest struct {
 	Variant                 string                  `json:"variant" example:"core" enums:"core,standard"`
 	KubernetesDistro        string                  `json:"kubernetesDistro" enums:"k3s,k0s"`
 	KubernetesVersion       string                  `json:"kubernetesVersion"`
+	KubernetesEnabled       *bool                   `json:"kubernetesEnabled"`
 	AllowInsecureRegistries bool                    `json:"allow-insecure-registries" example:"false"`
 	Dockerfile              string                  `json:"dockerfile"`
 	OverlayRootfs           string                  `json:"overlayRootfs"`

--- a/pkg/handlers/artifacts.go
+++ b/pkg/handlers/artifacts.go
@@ -249,6 +249,8 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 		regToken:           h.regToken,
 		groupName:          groupName,
 		allowedCommands:    allowedCommands,
+		variant:            req.Variant,
+		kubernetesDistro:   req.KubernetesDistro,
 		userMode:           req.Provisioning.UserMode,
 		username:           req.Provisioning.Username,
 		password:           req.Provisioning.Password,
@@ -791,6 +793,8 @@ type cloudConfigParams struct {
 	// allowedCommands is always emitted verbatim when registerAuroraBoot is true.
 	// Callers substitute phonehomeSafeDefaults for nil input before calling.
 	allowedCommands []string
+	variant          string // "core" or "standard"
+	kubernetesDistro string // "k3s" or "k0s" when variant=standard
 	userMode        string // "default", "custom", "none"
 	username        string
 	password        string
@@ -815,6 +819,15 @@ func buildCloudConfig(p cloudConfigParams) string {
 			"auto":   true,
 			"device": "auto",
 			"reboot": true,
+		}
+	}
+
+	if p.variant == "standard" {
+		switch p.kubernetesDistro {
+		case "k3s":
+			doc["k3s"] = map[string]interface{}{"enabled": true}
+		case "k0s":
+			doc["k0s"] = map[string]interface{}{"enabled": true}
 		}
 	}
 

--- a/pkg/handlers/artifacts.go
+++ b/pkg/handlers/artifacts.go
@@ -53,6 +53,7 @@ type createArtifactRequest struct {
 	Variant                 string `json:"variant"`
 	KubernetesDistro        string `json:"kubernetesDistro"`
 	KubernetesVersion       string `json:"kubernetesVersion"`
+	KubernetesEnabled       *bool  `json:"kubernetesEnabled"`
 	AllowInsecureRegistries bool   `json:"allow-insecure-registries"`
 	Dockerfile              string `json:"dockerfile"`
 	BuildContextDir         string `json:"buildContextDir"`
@@ -223,6 +224,11 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 		allowedCommands = append([]string(nil), phonehomeSafeDefaults...)
 	}
 
+	kubernetesEnabled := true
+	if req.KubernetesEnabled != nil {
+		kubernetesEnabled = *req.KubernetesEnabled
+	}
+
 	opts.Provisioning = builder.ProvisioningOptions{
 		AutoInstall:        autoInstall,
 		RegisterAuroraBoot: registerAuroraBoot,
@@ -251,6 +257,7 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 		allowedCommands:    allowedCommands,
 		variant:            req.Variant,
 		kubernetesDistro:   req.KubernetesDistro,
+		kubernetesEnabled:  kubernetesEnabled,
 		userMode:           req.Provisioning.UserMode,
 		username:           req.Provisioning.Username,
 		password:           req.Provisioning.Password,
@@ -306,6 +313,7 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 			CloudConfig:             opts.CloudConfig,
 			KubernetesDistro:        req.KubernetesDistro,
 			KubernetesVersion:       req.KubernetesVersion,
+			KubernetesEnabled:       boolPtr(kubernetesEnabled),
 			TargetGroupID:           req.Provisioning.TargetGroupId,
 			OverlayRootfs:           req.OverlayRootfs,
 		}
@@ -793,9 +801,10 @@ type cloudConfigParams struct {
 	// allowedCommands is always emitted verbatim when registerAuroraBoot is true.
 	// Callers substitute phonehomeSafeDefaults for nil input before calling.
 	allowedCommands []string
-	variant          string // "core" or "standard"
-	kubernetesDistro string // "k3s" or "k0s" when variant=standard
-	userMode        string // "default", "custom", "none"
+	variant           string // "core" or "standard"
+	kubernetesDistro  string // "k3s" or "k0s" when variant=standard
+	kubernetesEnabled bool   // cloud-config k3s/k0s.enabled (standard variant only)
+	userMode          string // "default", "custom", "none"
 	username        string
 	password        string
 	sshKeys         string // newline-separated public keys
@@ -822,12 +831,12 @@ func buildCloudConfig(p cloudConfigParams) string {
 		}
 	}
 
-	if p.variant == "standard" {
+	if p.variant == "standard" && p.kubernetesDistro != "" {
 		switch p.kubernetesDistro {
 		case "k3s":
-			doc["k3s"] = map[string]interface{}{"enabled": true}
+			doc["k3s"] = map[string]interface{}{"enabled": p.kubernetesEnabled}
 		case "k0s":
-			doc["k0s"] = map[string]interface{}{"enabled": true}
+			doc["k0s"] = map[string]interface{}{"enabled": p.kubernetesEnabled}
 		}
 	}
 
@@ -952,3 +961,5 @@ func mergeYAML(dst, src map[string]interface{}) {
 		dst[k] = sv
 	}
 }
+
+func boolPtr(v bool) *bool { return &v }

--- a/pkg/handlers/artifacts_test.go
+++ b/pkg/handlers/artifacts_test.go
@@ -169,6 +169,12 @@ var _ = Describe("ArtifactHandler", func() {
 			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("k3s:"))
 			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("k0s:"))
 		})
+
+		It("merges extra k3s YAML without duplicating the top-level key", func() {
+			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true},"cloudConfig":"k3s:\n  enabled: true\n  cluster-cidr: 10.42.0.0/16"}`)
+			Expect(strings.Count(fb.lastOpts.CloudConfig, "k3s:")).To(Equal(1))
+			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("cluster-cidr"))
+		})
 	})
 
 	Describe("List", func() {

--- a/pkg/handlers/artifacts_test.go
+++ b/pkg/handlers/artifacts_test.go
@@ -131,6 +131,35 @@ var _ = Describe("ArtifactHandler", func() {
 		})
 	})
 
+	Describe("Create — kubernetes provider cloud-config", func() {
+		post := func(body string) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			Expect(handler.Create(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusCreated))
+		}
+
+		It("enables k3s in cloud-config for the standard variant", func() {
+			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
+			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("k3s:"))
+			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: true"))
+		})
+
+		It("enables k0s in cloud-config for the standard variant", func() {
+			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k0s","outputs":{"iso":true}}`)
+			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("k0s:"))
+			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: true"))
+		})
+
+		It("omits kubernetes provider stanzas for the core variant", func() {
+			post(`{"baseImage":"ubuntu:24.04","variant":"core","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
+			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("k3s:"))
+			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("k0s:"))
+		})
+	})
+
 	Describe("List", func() {
 		It("should list all builds", func() {
 			fb.builds = []*builder.BuildStatus{

--- a/pkg/handlers/artifacts_test.go
+++ b/pkg/handlers/artifacts_test.go
@@ -153,6 +153,17 @@ var _ = Describe("ArtifactHandler", func() {
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: true"))
 		})
 
+		It("disables k3s in cloud-config when kubernetesEnabled is false", func() {
+			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","kubernetesEnabled":false,"outputs":{"iso":true}}`)
+			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("k3s:"))
+			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: false"))
+		})
+
+		It("defaults kubernetesEnabled to true when omitted", func() {
+			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
+			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: true"))
+		})
+
 		It("omits kubernetes provider stanzas for the core variant", func() {
 			post(`{"baseImage":"ubuntu:24.04","variant":"core","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
 			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("k3s:"))

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -167,6 +167,7 @@ type ArtifactRecord struct {
 	CloudConfig             string    `json:"cloudConfig,omitempty" gorm:"type:text"`
 	KubernetesDistro        string    `json:"kubernetesDistro,omitempty"`
 	KubernetesVersion       string    `json:"kubernetesVersion,omitempty"`
+	KubernetesEnabled       *bool     `json:"kubernetesEnabled,omitempty"`
 	TargetGroupID           string    `json:"targetGroupId,omitempty"`
 	ContainerImage          string    `json:"containerImage,omitempty"`
 	OverlayRootfs           string    `json:"overlayRootfs,omitempty"`

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,7 +22,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.15.0",
-        "tailwind-merge": "^2.6.0"
+        "tailwind-merge": "^2.6.0",
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -1462,9 +1463,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1482,9 +1480,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1502,9 +1497,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1522,9 +1514,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1542,9 +1531,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1562,9 +1548,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1791,9 +1774,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1811,9 +1791,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1831,9 +1808,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1851,9 +1825,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4969,6 +4940,21 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,7 +25,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.15.0",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/ui/src/api/artifacts.ts
+++ b/ui/src/api/artifacts.ts
@@ -29,6 +29,7 @@ export interface Artifact {
   cloudConfig?: string;
   kubernetesDistro?: string;
   kubernetesVersion?: string;
+  kubernetesEnabled?: boolean;
   targetGroupId?: string;
   containerImage?: string;
   artifacts: string[];
@@ -83,6 +84,7 @@ export interface CreateArtifactInput {
   variant: string;
   kubernetesDistro?: string;
   kubernetesVersion?: string;
+  kubernetesEnabled?: boolean;
   /**
    * Allow pulling the base image from a registry served over plain HTTP or
    * presenting an untrusted/self-signed TLS certificate.

--- a/ui/src/lib/buildConfig.test.ts
+++ b/ui/src/lib/buildConfig.test.ts
@@ -138,6 +138,7 @@ describe("payloadFromBuilder", () => {
 
     expect(p.source.kubernetesDistro).toBeUndefined();
     expect(p.source.kubernetesVersion).toBeUndefined();
+    expect(p.source.kubernetesEnabled).toBeUndefined();
   });
 
   it("preserves Kubernetes fields on the standard variant", () => {
@@ -158,6 +159,26 @@ describe("payloadFromBuilder", () => {
 
     expect(p.source.kubernetesDistro).toBe("k3s");
     expect(p.source.kubernetesVersion).toBe("v1.28.0");
+    expect(p.source.kubernetesEnabled).toBe(true);
+  });
+
+  it("preserves kubernetesEnabled=false on the standard variant", () => {
+    const p = payloadFromBuilder({
+      form: makeForm({
+        variant: "standard",
+        kubernetesDistro: "k3s",
+        kubernetesEnabled: false,
+      }),
+      buildMode: "image",
+      groups,
+      keySets,
+      userMode: "default",
+      username: "",
+      sshKeys: "",
+      advancedConfig: "",
+    });
+
+    expect(p.source.kubernetesEnabled).toBe(false);
   });
 
   it("resolves group + key set to names for portability", () => {

--- a/ui/src/lib/buildConfig.ts
+++ b/ui/src/lib/buildConfig.ts
@@ -49,6 +49,7 @@ export interface BuildConfigPayload {
     variant: string;
     kubernetesDistro?: string;
     kubernetesVersion?: string;
+    kubernetesEnabled?: boolean;
     kairosInitImage?: string;
     "allow-insecure-registries"?: boolean;
   };
@@ -104,6 +105,7 @@ export function payloadFromBuilder(args: {
       variant: form.variant,
       kubernetesDistro: form.variant === "standard" ? form.kubernetesDistro || undefined : undefined,
       kubernetesVersion: form.variant === "standard" ? form.kubernetesVersion || undefined : undefined,
+      kubernetesEnabled: form.variant === "standard" ? form.kubernetesEnabled ?? true : undefined,
       kairosInitImage: form.kairosInitImage || undefined,
       "allow-insecure-registries":
         buildMode === "image" ? form["allow-insecure-registries"] || undefined : undefined,
@@ -152,6 +154,8 @@ export function payloadFromArtifact(artifact: Artifact, groups: Group[]): BuildC
       variant: artifact.variant || "core",
       kubernetesDistro: artifact.kubernetesDistro || undefined,
       kubernetesVersion: artifact.kubernetesVersion || undefined,
+      kubernetesEnabled:
+        artifact.variant === "standard" ? artifact.kubernetesEnabled ?? true : undefined,
       kairosInitImage: artifact.kairosInitImage || undefined,
       "allow-insecure-registries":
         buildMode === "image" ? artifact["allow-insecure-registries"] || undefined : undefined,

--- a/ui/src/lib/cloudConfigPreview.test.ts
+++ b/ui/src/lib/cloudConfigPreview.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "yaml";
+
+import { buildCloudConfigPreview } from "./cloudConfigPreview";
+import { PHONEHOME_SAFE_DEFAULTS } from "./buildConfig";
+
+const base: Parameters<typeof buildCloudConfigPreview>[0] = {
+  autoInstall: true,
+  registerAuroraBoot: true,
+  groupName: "production",
+  allowedCommands: [...PHONEHOME_SAFE_DEFAULTS],
+  variant: "standard",
+  kubernetesDistro: "k3s",
+  kubernetesEnabled: true,
+  userMode: "default",
+  username: "",
+  password: "",
+  sshKeys: "",
+  extraYAML: "",
+};
+
+function docBody(yaml: string): Record<string, unknown> {
+  const body = yaml.replace(/^#cloud-config\n?/, "");
+  const parsed = parse(body);
+  expect(parsed).toBeTypeOf("object");
+  return parsed as Record<string, unknown>;
+}
+
+describe("buildCloudConfigPreview", () => {
+  it("emits k3s.enabled for standard variant", () => {
+    const doc = docBody(buildCloudConfigPreview(base));
+    expect(doc.k3s).toEqual({ enabled: true });
+  });
+
+  it("merges extra k3s config instead of duplicating the top-level key", () => {
+    const yaml = buildCloudConfigPreview({
+      ...base,
+      extraYAML: "k3s:\n  enabled: true\n  cluster-cidr: 10.42.0.0/16",
+    });
+    expect(yaml.match(/^k3s:/gm)?.length ?? 0).toBeLessThanOrEqual(1);
+
+    const doc = docBody(yaml);
+    expect(doc.k3s).toEqual({
+      enabled: true,
+      "cluster-cidr": "10.42.0.0/16",
+    });
+  });
+
+  it("lets extra YAML override kubernetes enabled when present", () => {
+    const doc = docBody(
+      buildCloudConfigPreview({
+        ...base,
+        kubernetesEnabled: true,
+        extraYAML: "k3s:\n  enabled: false",
+      }),
+    );
+    expect(doc.k3s).toEqual({ enabled: false });
+  });
+
+  it("omits k3s for core variant", () => {
+    const doc = docBody(
+      buildCloudConfigPreview({
+        ...base,
+        variant: "core",
+        kubernetesDistro: "k3s",
+      }),
+    );
+    expect(doc.k3s).toBeUndefined();
+  });
+
+  it("merges extra stages under the canonical stages key", () => {
+    const doc = docBody(
+      buildCloudConfigPreview({
+        ...base,
+        extraYAML: "stages:\n  boot:\n    - commands:\n        - echo hi",
+      }),
+    );
+    const stages = doc.stages as Record<string, unknown>;
+    expect(stages.initramfs).toBeDefined();
+    expect(stages.boot).toBeDefined();
+  });
+});

--- a/ui/src/lib/cloudConfigPreview.test.ts
+++ b/ui/src/lib/cloudConfigPreview.test.ts
@@ -79,4 +79,13 @@ describe("buildCloudConfigPreview", () => {
     expect(stages.initramfs).toBeDefined();
     expect(stages.boot).toBeDefined();
   });
+
+  it("ignores prototype-pollution keys in extra YAML", () => {
+    const protoKey = "__proto__";
+    buildCloudConfigPreview({
+      ...base,
+      extraYAML: `${protoKey}:\n  polluted: true\nk3s:\n  enabled: false`,
+    });
+    expect(Object.prototype).not.toHaveProperty("polluted");
+  });
 });

--- a/ui/src/lib/cloudConfigPreview.ts
+++ b/ui/src/lib/cloudConfigPreview.ts
@@ -1,0 +1,118 @@
+import { parse, stringify } from "yaml";
+
+type YamlMap = Record<string, unknown>;
+type YamlValue = unknown;
+
+export interface CloudConfigPreviewInput {
+  autoInstall: boolean;
+  registerAuroraBoot: boolean;
+  groupName: string;
+  allowedCommands: readonly string[];
+  variant: string;
+  kubernetesDistro: string;
+  kubernetesEnabled: boolean;
+  userMode: "default" | "custom" | "none";
+  username: string;
+  password: string;
+  sshKeys: string;
+  extraYAML: string;
+}
+
+// Mirrors pkg/handlers/artifacts.go mergeYAML: maps merge recursively, slices
+// concatenate, scalars from extra YAML override canonical defaults.
+function mergeYAML(dst: YamlMap, src: YamlMap): void {
+  for (const [k, sv] of Object.entries(src)) {
+    const dv = dst[k];
+    if (dv === undefined) {
+      dst[k] = sv;
+      continue;
+    }
+    if (isMap(dv) && isMap(sv)) {
+      mergeYAML(dv, sv);
+      continue;
+    }
+    if (Array.isArray(dv) && Array.isArray(sv)) {
+      dst[k] = [...dv, ...sv];
+      continue;
+    }
+    dst[k] = sv;
+  }
+}
+
+function isMap(v: YamlValue): v is YamlMap {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// Builds the Review-step cloud-config preview. Logic must stay aligned with
+// buildCloudConfig in pkg/handlers/artifacts.go (canonical doc + merged extra).
+export function buildCloudConfigPreview(input: CloudConfigPreviewInput): string {
+  const doc: YamlMap = {};
+
+  if (input.autoInstall) {
+    doc.install = { auto: true, device: "auto", reboot: true };
+  }
+
+  if (input.variant === "standard" && input.kubernetesDistro) {
+    if (input.kubernetesDistro === "k3s") {
+      doc.k3s = { enabled: input.kubernetesEnabled };
+    } else if (input.kubernetesDistro === "k0s") {
+      doc.k0s = { enabled: input.kubernetesEnabled };
+    }
+  }
+
+  if (input.registerAuroraBoot) {
+    doc.phonehome = {
+      url: "<server-url>",
+      registration_token: "<token>",
+      group: input.groupName,
+      allowed_commands: [...input.allowedCommands],
+    };
+  }
+
+  if (input.userMode !== "none") {
+    const username =
+      input.userMode === "default" || !input.username.trim()
+        ? "kairos"
+        : input.username;
+    const password =
+      input.userMode === "default" || !input.password.trim()
+        ? "kairos"
+        : input.password;
+    const sshLines = input.sshKeys
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const stage = sshLines.length > 0 ? "network" : "initramfs";
+
+    const userEntry: YamlMap = {
+      passwd: password,
+      groups: ["admin"],
+    };
+    if (sshLines.length > 0) {
+      userEntry.ssh_authorized_keys = sshLines;
+    }
+
+    doc.stages = {
+      [stage]: [{ users: { [username]: userEntry } }],
+    };
+  }
+
+  const extra = input.extraYAML.trim();
+  if (extra) {
+    let body = extra;
+    if (body.startsWith("#cloud-config")) {
+      body = body.replace(/^#cloud-config\s*\n?/, "");
+    }
+    try {
+      const extraDoc = parse(body);
+      if (isMap(extraDoc)) {
+        mergeYAML(doc, extraDoc);
+      }
+    } catch {
+      // Invalid extra YAML: show canonical doc only, same as backend fallback
+      // behaviour when unmarshal fails (extra is skipped).
+    }
+  }
+
+  return `#cloud-config\n${stringify(doc)}`;
+}

--- a/ui/src/lib/cloudConfigPreview.ts
+++ b/ui/src/lib/cloudConfigPreview.ts
@@ -31,7 +31,7 @@ function mergeYAML(dst: YamlMap, src: YamlMap): void {
     if (!isSafeMergeKey(k)) {
       continue;
     }
-    if (!Object.hasOwn(dst, k)) {
+    if (!Object.prototype.hasOwnProperty.call(dst, k)) {
       dst[k] = sv;
       continue;
     }

--- a/ui/src/lib/cloudConfigPreview.ts
+++ b/ui/src/lib/cloudConfigPreview.ts
@@ -18,15 +18,24 @@ export interface CloudConfigPreviewInput {
   extraYAML: string;
 }
 
+const UNSAFE_MERGE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isSafeMergeKey(key: string): boolean {
+  return !UNSAFE_MERGE_KEYS.has(key);
+}
+
 // Mirrors pkg/handlers/artifacts.go mergeYAML: maps merge recursively, slices
 // concatenate, scalars from extra YAML override canonical defaults.
 function mergeYAML(dst: YamlMap, src: YamlMap): void {
   for (const [k, sv] of Object.entries(src)) {
-    const dv = dst[k];
-    if (dv === undefined) {
+    if (!isSafeMergeKey(k)) {
+      continue;
+    }
+    if (!Object.hasOwn(dst, k)) {
       dst[k] = sv;
       continue;
     }
+    const dv = dst[k];
     if (isMap(dv) && isMap(sv)) {
       mergeYAML(dv, sv);
       continue;
@@ -46,7 +55,7 @@ function isMap(v: YamlValue): v is YamlMap {
 // Builds the Review-step cloud-config preview. Logic must stay aligned with
 // buildCloudConfig in pkg/handlers/artifacts.go (canonical doc + merged extra).
 export function buildCloudConfigPreview(input: CloudConfigPreviewInput): string {
-  const doc: YamlMap = {};
+  const doc = Object.create(null) as YamlMap;
 
   if (input.autoInstall) {
     doc.install = { auto: true, device: "auto", reboot: true };

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -230,7 +230,7 @@ const TEMPLATES: BuildTemplate[] = [
       kairosVersion: KAIROS_VERSION,
       model: "generic",
       arch: "amd64",
-      variant: "core",
+      variant: "standard",
       kubernetesDistro: "k3s",
       outputs: { iso: true, cloudImage: false, netboot: false, rawDisk: false, tar: false, gce: false, vhd: false, uki: false, fips: false, trustedBoot: false },
     },
@@ -755,6 +755,16 @@ export function ArtifactBuilder() {
       lines.push("  auto: true");
       lines.push("  device: auto");
       lines.push("  reboot: true");
+    }
+
+    if (form.variant === "standard") {
+      if (form.kubernetesDistro === "k3s") {
+        lines.push("k3s:");
+        lines.push("  enabled: true");
+      } else if (form.kubernetesDistro === "k0s") {
+        lines.push("k0s:");
+        lines.push("  enabled: true");
+      }
     }
 
     if (form.provisioning.registerAuroraBoot) {
@@ -1315,7 +1325,22 @@ export function ArtifactBuilder() {
                     <button
                       key={v.value}
                       type="button"
-                      onClick={() => update("variant", v.value)}
+                      onClick={() => {
+                        if (v.value === "standard") {
+                          setForm((prev) => ({
+                            ...prev,
+                            variant: "standard",
+                            kubernetesDistro: prev.kubernetesDistro || "k3s",
+                          }));
+                        } else {
+                          setForm((prev) => ({
+                            ...prev,
+                            variant: "core",
+                            kubernetesDistro: "",
+                            kubernetesVersion: "",
+                          }));
+                        }
+                      }}
                       className={`text-left rounded-lg border p-4 transition-colors ${
                         selected
                           ? "border-[#EE5007] bg-[#EE5007]/5 ring-1 ring-[#EE5007]"

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -232,6 +232,7 @@ const TEMPLATES: BuildTemplate[] = [
       arch: "amd64",
       variant: "standard",
       kubernetesDistro: "k3s",
+      kubernetesEnabled: true,
       outputs: { iso: true, cloudImage: false, netboot: false, rawDisk: false, tar: false, gce: false, vhd: false, uki: false, fips: false, trustedBoot: false },
     },
   },
@@ -361,6 +362,7 @@ const EMPTY_FORM: CreateArtifactInput = {
   variant: "core",
   kubernetesDistro: "",
   kubernetesVersion: "",
+  kubernetesEnabled: true,
   "allow-insecure-registries": false,
   dockerfile: "",
   overlayRootfs: "",
@@ -612,6 +614,7 @@ export function ArtifactBuilder() {
       variant: src.variant || "core",
       kubernetesDistro: src.kubernetesDistro || "",
       kubernetesVersion: src.kubernetesVersion || "",
+      kubernetesEnabled: src.kubernetesEnabled ?? true,
       "allow-insecure-registries": src["allow-insecure-registries"] ?? false,
       dockerfile: parsed.dockerfile || "",
       overlayRootfs: parsed.overlayRootfs || "",
@@ -679,6 +682,7 @@ export function ArtifactBuilder() {
           variant: a.variant || "core",
           kubernetesDistro: a.kubernetesDistro || "",
           kubernetesVersion: a.kubernetesVersion || "",
+          kubernetesEnabled: a.variant === "standard" ? a.kubernetesEnabled ?? true : true,
           "allow-insecure-registries": a["allow-insecure-registries"] ?? false,
           dockerfile: a.dockerfile || "",
           kairosInitImage: a.kairosInitImage || "",
@@ -757,13 +761,14 @@ export function ArtifactBuilder() {
       lines.push("  reboot: true");
     }
 
-    if (form.variant === "standard") {
+    if (form.variant === "standard" && form.kubernetesDistro) {
+      const enabled = form.kubernetesEnabled ?? true;
       if (form.kubernetesDistro === "k3s") {
         lines.push("k3s:");
-        lines.push("  enabled: true");
+        lines.push(`  enabled: ${enabled}`);
       } else if (form.kubernetesDistro === "k0s") {
         lines.push("k0s:");
-        lines.push("  enabled: true");
+        lines.push(`  enabled: ${enabled}`);
       }
     }
 
@@ -932,6 +937,7 @@ export function ArtifactBuilder() {
       variant: form.variant,
       kubernetesDistro: form.variant === "standard" ? form.kubernetesDistro : undefined,
       kubernetesVersion: form.variant === "standard" ? form.kubernetesVersion : undefined,
+      kubernetesEnabled: form.variant === "standard" ? form.kubernetesEnabled ?? true : undefined,
       // Only meaningful when pulling a base image from a registry.
       "allow-insecure-registries":
         buildMode === "image" ? form["allow-insecure-registries"] : undefined,
@@ -1331,6 +1337,7 @@ export function ArtifactBuilder() {
                             ...prev,
                             variant: "standard",
                             kubernetesDistro: prev.kubernetesDistro || "k3s",
+                            kubernetesEnabled: prev.kubernetesEnabled ?? true,
                           }));
                         } else {
                           setForm((prev) => ({
@@ -1338,6 +1345,7 @@ export function ArtifactBuilder() {
                             variant: "core",
                             kubernetesDistro: "",
                             kubernetesVersion: "",
+                            kubernetesEnabled: true,
                           }));
                         }
                       }}
@@ -1370,6 +1378,20 @@ export function ArtifactBuilder() {
                   <CardTitle className="text-sm">Kubernetes</CardTitle>
                 </CardHeader>
                 <CardContent className="grid gap-4">
+                  <label className="flex items-center gap-2 text-sm font-medium">
+                    <input
+                      type="checkbox"
+                      checked={form.kubernetesEnabled ?? true}
+                      onChange={(e) => update("kubernetesEnabled", e.target.checked)}
+                      className="rounded border-input"
+                    />
+                    Enable Kubernetes on first boot
+                    <InfoTooltip>
+                      Baked into cloud-config as <code className="font-mono">k3s.enabled</code> or{" "}
+                      <code className="font-mono">k0s.enabled</code>. The distribution is still bundled
+                      into the image for offline installs; disable this to defer starting the cluster.
+                    </InfoTooltip>
+                  </label>
                   <div className="grid gap-2">
                     <Label>
                       Distribution
@@ -2094,6 +2116,10 @@ export function ArtifactBuilder() {
                     </div>
                     {form.variant === "standard" && (
                       <>
+                        <div className="flex gap-2">
+                          <span className="text-muted-foreground w-28 shrink-0">K8s Enabled:</span>
+                          <span>{form.kubernetesEnabled ?? true ? "Yes" : "No"}</span>
+                        </div>
                         <div className="flex gap-2">
                           <span className="text-muted-foreground w-28 shrink-0">K8s Distro:</span>
                           <span>{form.kubernetesDistro || "\u2014"}</span>

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -13,6 +13,7 @@ import {
   PHONEHOME_SAFE_DEFAULTS,
   PHONEHOME_DESTRUCTIVE_COMMANDS,
 } from "@/lib/buildConfig";
+import { buildCloudConfigPreview } from "@/lib/cloudConfigPreview";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -748,80 +749,26 @@ export function ArtifactBuilder() {
     }
   }
 
-  // Frontend cloud-config preview — must match the backend's buildCloudConfig
-  // in internal/handlers/artifacts.go. The backend is the source of truth at
-  // build time; this function only powers the Review-step preview.
+  // Frontend cloud-config preview — must match buildCloudConfig in
+  // pkg/handlers/artifacts.go. The backend is the source of truth at build
+  // time; this function only powers the Review-step preview.
   function buildCloudConfig(): string {
-    const lines: string[] = ["#cloud-config"];
-
-    if (form.provisioning.autoInstall) {
-      lines.push("install:");
-      lines.push("  auto: true");
-      lines.push("  device: auto");
-      lines.push("  reboot: true");
-    }
-
-    if (form.variant === "standard" && form.kubernetesDistro) {
-      const enabled = form.kubernetesEnabled ?? true;
-      if (form.kubernetesDistro === "k3s") {
-        lines.push("k3s:");
-        lines.push(`  enabled: ${enabled}`);
-      } else if (form.kubernetesDistro === "k0s") {
-        lines.push("k0s:");
-        lines.push(`  enabled: ${enabled}`);
-      }
-    }
-
-    if (form.provisioning.registerAuroraBoot) {
-      const groupName = groups.find((g) => g.id === form.provisioning.targetGroupId)?.name || "";
-      lines.push("phonehome:");
-      lines.push(`  url: "<server-url>"`);
-      lines.push(`  registration_token: "<token>"`);
-      lines.push(`  group: "${groupName}"`);
-      const allowed = form.provisioning.allowedCommands ?? [];
-      if (allowed.length === 0) {
-        lines.push("  allowed_commands: []");
-      } else {
-        lines.push("  allowed_commands:");
-        for (const cmd of allowed) {
-          lines.push(`    - ${cmd}`);
-        }
-      }
-    }
-
-    if (userMode !== "none") {
-      const u = userMode === "default" || !username ? "kairos" : username;
-      const p = userMode === "default" || !password ? "kairos" : password;
-      const sshList = sshKeys.split("\n").map((s) => s.trim()).filter(Boolean);
-      const stage = sshList.length > 0 ? "network" : "initramfs";
-
-      lines.push("stages:");
-      lines.push(`  ${stage}:`);
-      lines.push("    - users:");
-      lines.push(`        ${u}:`);
-      lines.push(`          passwd: ${p}`);
-      lines.push("          groups:");
-      lines.push("            - admin");
-
-      if (sshList.length > 0) {
-        lines.push("          ssh_authorized_keys:");
-        sshList.forEach((key) => {
-          lines.push(`            - "${key}"`);
-        });
-      }
-    }
-
-    let cc = lines.join("\n") + "\n";
-
-    if (advancedConfig.trim()) {
-      let extra = advancedConfig.trim();
-      if (extra.startsWith("#cloud-config")) {
-        extra = extra.replace(/^#cloud-config\s*\n?/, "");
-      }
-      cc += "\n" + extra + "\n";
-    }
-
-    return cc;
+    const groupName =
+      groups.find((g) => g.id === form.provisioning.targetGroupId)?.name || "";
+    return buildCloudConfigPreview({
+      autoInstall: form.provisioning.autoInstall,
+      registerAuroraBoot: form.provisioning.registerAuroraBoot,
+      groupName,
+      allowedCommands: form.provisioning.allowedCommands ?? [],
+      variant: form.variant,
+      kubernetesDistro: form.kubernetesDistro || "",
+      kubernetesEnabled: form.kubernetesEnabled ?? true,
+      userMode,
+      username,
+      password,
+      sshKeys,
+      extraYAML: advancedConfig,
+    });
   }
 
   // computeErrors produces a structured list: each error knows which wizard


### PR DESCRIPTION
## Summary

- Emit `k3s.enabled: true` or `k0s.enabled: true` in the baked cloud-config when building a **Standard** variant artifact with the matching distro selected
- Align the Review-step cloud-config preview with the backend (`buildCloudConfig`)
- Default to **K3s** when switching variant to Standard in the UI
- Fix **Hadron + K3s** template to use `variant: standard` (was `core` with a dangling `kubernetesDistro`)

## Problem

Selecting Standard + K3s in Artifact Builder passed `kubernetesDistro` to kairos-init for image build, but the generated cloud-config never enabled the provider at runtime. Kairos expects e.g.:

```yaml
k3s:
  enabled: true
```

See kairos-io/kairos#4192.

## Test plan

- [x] `go test ./pkg/handlers/... -ginkgo.focus="kubernetes provider"`
- [x] `npm test -- --run buildConfig`
- [ ] Manual: Artifact Builder → Standard + K3s → Review cloud-config shows `k3s.enabled: true`


Made with [Cursor](https://cursor.com)