### PR TITLE
fix(iso): use SDK riscv64 GRUB EFI search paths for ISO builds

### DIFF
--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -631,16 +631,14 @@ func (b BuildISOAction) copyShim(tempdir, rootdir string) error {
 	return err
 }
 
-// getEfiGrubFilesForArch returns the possible grub EFI file paths for the given architecture
-// This extends the SDK's GetEfiGrubFiles with riscv64 support
+// getEfiGrubFilesForArch returns the possible grub EFI file paths for the given architecture.
+// For riscv64, prepend the openSUSE layout then delegate to the SDK (Debian/Ubuntu monolithic paths, ESP fallbacks, etc.).
 func getEfiGrubFilesForArch(arch string) []string {
 	if utils.IsRiscv64(arch) {
-		return []string{
-			"/usr/share/efi/riscv64/grub.efi",
-			"/usr/lib/grub/riscv64-efi/grubriscv64.efi",
-			"/boot/efi/EFI/BOOT/BOOTRISCV64.EFI",
-			"/boot/efi/EFI/fedora/grubriscv64.efi",
-		}
+		return append(
+			[]string{"/usr/share/efi/riscv64/grub.efi"},
+			sdkutils.GetEfiGrubFiles(arch)...,
+		)
 	}
 	return sdkutils.GetEfiGrubFiles(arch)
 }

--- a/pkg/ops/iso_test.go
+++ b/pkg/ops/iso_test.go
@@ -28,3 +28,17 @@ var _ = Describe("applyGrubTemplate", Label("iso"), func() {
 		Expect(string(result)).To(ContainSubstring(" rd.debug"))
 	})
 })
+
+var _ = Describe("getEfiGrubFilesForArch", Label("iso"), func() {
+	It("includes openSUSE and SDK riscv64 grub EFI paths", func() {
+		paths := getEfiGrubFilesForArch("riscv64")
+		Expect(paths).To(ContainElement("/usr/share/efi/riscv64/grub.efi"))
+		Expect(paths).To(ContainElement("/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi"))
+		Expect(paths).To(ContainElement("/boot/efi/EFI/ubuntu/grubriscv64.efi"))
+		Expect(paths).To(ContainElement("/boot/efi/EFI/debian/grubriscv64.efi"))
+	})
+
+	It("delegates non-riscv64 arches to the SDK", func() {
+		Expect(getEfiGrubFilesForArch("arm64")).To(ContainElement("/usr/lib/grub/arm64-efi/grubaa64.efi"))
+	})
+})

--- a/pkg/ops/iso_test.go
+++ b/pkg/ops/iso_test.go
@@ -1,6 +1,7 @@
 package ops
 
 import (
+	sdkutils "github.com/kairos-io/kairos-sdk/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -30,15 +31,15 @@ var _ = Describe("applyGrubTemplate", Label("iso"), func() {
 })
 
 var _ = Describe("getEfiGrubFilesForArch", Label("iso"), func() {
-	It("includes openSUSE and SDK riscv64 grub EFI paths", func() {
+	It("prepends the openSUSE riscv64 path before SDK paths", func() {
 		paths := getEfiGrubFilesForArch("riscv64")
-		Expect(paths).To(ContainElement("/usr/share/efi/riscv64/grub.efi"))
-		Expect(paths).To(ContainElement("/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi"))
-		Expect(paths).To(ContainElement("/boot/efi/EFI/ubuntu/grubriscv64.efi"))
-		Expect(paths).To(ContainElement("/boot/efi/EFI/debian/grubriscv64.efi"))
+		sdkPaths := sdkutils.GetEfiGrubFiles("riscv64")
+
+		Expect(paths[0]).To(Equal("/usr/share/efi/riscv64/grub.efi"))
+		Expect(paths).To(Equal(append([]string{"/usr/share/efi/riscv64/grub.efi"}, sdkPaths...)))
 	})
 
-	It("delegates non-riscv64 arches to the SDK", func() {
-		Expect(getEfiGrubFilesForArch("arm64")).To(ContainElement("/usr/lib/grub/arm64-efi/grubaa64.efi"))
+	It("returns the SDK path list for non-riscv64 arches", func() {
+		Expect(getEfiGrubFilesForArch("arm64")).To(Equal(sdkutils.GetEfiGrubFiles("arm64")))
 	})
 })


### PR DESCRIPTION
## Summary

- Fixes `build-iso` failing on Ubuntu/Debian riscv64 rootfs with `could not find any grub efi file to copy`
- Replaces AuroraBoot's short custom riscv64 GRUB path list with **openSUSE path + kairos-sdk `GetEfiGrubFiles()`**, which already includes the Debian/Ubuntu monolithic layout (`/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi`)

## Context

Manual riscv64 core ISO testing surfaced two gaps (tracked in kairos-io/kairos#4235, parent kairos-io/kairos#4083):

1. **kairos-init** — `GrubPackages` has no `ArchRiscV64` entry for Debian-family distros (separate fix needed in kairos-init)
2. **AuroraBoot** — this PR; even when `grub-efi-riscv64-bin` is present, the old path list never checked the monolithic install location used by Ubuntu/Debian

## Test plan

- [x] `go test ./pkg/ops/`
- [ ] Build ISO from an Ubuntu 24.04 riscv64 Kairos container with `grub-efi-riscv64-bin` installed
- [ ] Confirm openSUSE (`/usr/share/efi/riscv64/grub.efi`) still works

Fixes kairos-io/kairos#4235
Part of kairos-io/kairos#4083

Made with [Cursor](https://cursor.com)