### PR TITLE
fix: unpack temp-rootfs on local fs instead of state_dir (#3922)

### DIFF
--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -220,8 +221,16 @@ func (d *Deployer) fromImage() bool {
 // rootfs on a native filesystem sidesteps the limitation entirely; only the
 // finished artifacts (ISO/raw disk) are written to state_dir. See
 // https://github.com/kairos-io/kairos/issues/3922.
+//
+// The directory name is derived from state_dir so that concurrent in-process
+// builds (the internal builder gives each build a distinct state_dir and runs
+// them in parallel) get distinct unpack directories, exactly as they did when
+// temp-rootfs lived under state_dir. Only the location changes here, not the
+// per-build uniqueness, so PrepDirs' RemoveAll for one build can never clobber
+// another build's rootfs.
 func (d *Deployer) tmpRootFs() string {
-	return filepath.Join(os.TempDir(), "auroraboot-temp-rootfs")
+	sum := sha256.Sum256([]byte(d.Config.State))
+	return filepath.Join(os.TempDir(), fmt.Sprintf("auroraboot-temp-rootfs-%x", sum[:8]))
 }
 
 func (d *Deployer) destination() string {

--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -206,8 +206,22 @@ func (d *Deployer) fromImage() bool {
 	return d.Artifact.ContainerImage != ""
 }
 
+// tmpRootFs is the directory where the container image is unpacked before it is
+// turned into an ISO or raw disk. It deliberately lives on the local filesystem
+// (os.TempDir(), i.e. /tmp inside the container) rather than under state_dir.
+//
+// state_dir is frequently a host bind mount, and on Docker Desktop for macOS
+// that mount is backed by VirtioFS, which cannot faithfully represent all the
+// Linux metadata (ownership + restrictive modes) that containerd's tar-apply
+// sets while unpacking a rootfs. Since containerd started chmod'ing files
+// through the open descriptor (containerd 61c2733f, first shipped in v1.7.31),
+// unpacking a read-only root-owned file such as /etc/sudoers.d/* onto that mount
+// fails with "failed to Lchown ... permission denied". Keeping the intermediate
+// rootfs on a native filesystem sidesteps the limitation entirely; only the
+// finished artifacts (ISO/raw disk) are written to state_dir. See
+// https://github.com/kairos-io/kairos/issues/3922.
 func (d *Deployer) tmpRootFs() string {
-	return d.Config.StateDir("temp-rootfs")
+	return filepath.Join(os.TempDir(), "auroraboot-temp-rootfs")
 }
 
 func (d *Deployer) destination() string {

--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -229,8 +229,11 @@ func (d *Deployer) fromImage() bool {
 // per-build uniqueness, so PrepDirs' RemoveAll for one build can never clobber
 // another build's rootfs.
 func (d *Deployer) tmpRootFs() string {
-	sum := sha256.Sum256([]byte(d.Config.State))
-	return filepath.Join(os.TempDir(), fmt.Sprintf("auroraboot-temp-rootfs-%x", sum[:8]))
+	// Hash the normalized state_dir (StateDir cleans the path, so "/output" and
+	// "/output/" collapse to the same key) and use the full digest so distinct
+	// state_dirs can never collide onto the same unpack directory.
+	sum := sha256.Sum256([]byte(d.Config.StateDir()))
+	return filepath.Join(os.TempDir(), fmt.Sprintf("auroraboot-temp-rootfs-%x", sum[:]))
 }
 
 func (d *Deployer) destination() string {

--- a/deployer/steps_test.go
+++ b/deployer/steps_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/kairos-io/AuroraBoot/pkg/schema"
 )
 
+// isUnder reports whether path is the dir itself or lives inside it, comparing
+// on path-segment boundaries so that "/tmp-rootfs" is not considered under
+// "/tmp".
+func isUnder(path, dir string) bool {
+	rel, err := filepath.Rel(filepath.Clean(dir), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
 // TestTmpRootFsNotUnderStateDir is a regression test for
 // https://github.com/kairos-io/kairos/issues/3922.
 //
@@ -24,12 +35,11 @@ func TestTmpRootFsNotUnderStateDir(t *testing.T) {
 
 	tmp := d.tmpRootFs()
 
-	if strings.HasPrefix(filepath.Clean(tmp), filepath.Clean(stateDir)+string(os.PathSeparator)) {
+	if isUnder(tmp, stateDir) {
 		t.Fatalf("tmpRootFs() must not live under state_dir %q, got %q", stateDir, tmp)
 	}
-
-	if want := os.TempDir(); !strings.HasPrefix(filepath.Clean(tmp), filepath.Clean(want)) {
-		t.Fatalf("tmpRootFs() must live under the local temp dir %q, got %q", want, tmp)
+	if !isUnder(tmp, os.TempDir()) {
+		t.Fatalf("tmpRootFs() must live under the local temp dir %q, got %q", os.TempDir(), tmp)
 	}
 }
 
@@ -40,5 +50,18 @@ func TestTmpRootFsStable(t *testing.T) {
 
 	if a, b := d.tmpRootFs(), d.tmpRootFs(); a != b {
 		t.Fatalf("tmpRootFs() must be stable across calls, got %q then %q", a, b)
+	}
+}
+
+// TestTmpRootFsUniquePerStateDir guards the concurrency invariant: the internal
+// builder runs multiple builds in parallel in the same process, each with a
+// distinct state_dir. Their unpack directories must not collide, otherwise one
+// build's PrepDirs RemoveAll would wipe another build's rootfs mid-unpack.
+func TestTmpRootFsUniquePerStateDir(t *testing.T) {
+	a := &Deployer{Config: schema.Config{State: "/builds/aaaa"}}
+	b := &Deployer{Config: schema.Config{State: "/builds/bbbb"}}
+
+	if a.tmpRootFs() == b.tmpRootFs() {
+		t.Fatalf("distinct state_dirs must map to distinct temp rootfs dirs, both got %q", a.tmpRootFs())
 	}
 }

--- a/deployer/steps_test.go
+++ b/deployer/steps_test.go
@@ -1,0 +1,44 @@
+package deployer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kairos-io/AuroraBoot/pkg/schema"
+)
+
+// TestTmpRootFsNotUnderStateDir is a regression test for
+// https://github.com/kairos-io/kairos/issues/3922.
+//
+// state_dir is commonly a host bind mount. On Docker Desktop for macOS that
+// mount is backed by VirtioFS, which cannot represent all the Linux metadata
+// containerd's tar-apply sets while unpacking a rootfs, so unpacking there
+// fails with "failed to Lchown ... permission denied". The intermediate rootfs
+// must therefore stay on the local filesystem (os.TempDir()), never under
+// state_dir.
+func TestTmpRootFsNotUnderStateDir(t *testing.T) {
+	stateDir := "/output" // a bind-mounted state_dir, as in the bug report
+	d := &Deployer{Config: schema.Config{State: stateDir}}
+
+	tmp := d.tmpRootFs()
+
+	if strings.HasPrefix(filepath.Clean(tmp), filepath.Clean(stateDir)+string(os.PathSeparator)) {
+		t.Fatalf("tmpRootFs() must not live under state_dir %q, got %q", stateDir, tmp)
+	}
+
+	if want := os.TempDir(); !strings.HasPrefix(filepath.Clean(tmp), filepath.Clean(want)) {
+		t.Fatalf("tmpRootFs() must live under the local temp dir %q, got %q", want, tmp)
+	}
+}
+
+// TestTmpRootFsStable ensures the path is deterministic across calls, since it
+// is evaluated both eagerly at step registration and lazily inside callbacks.
+func TestTmpRootFsStable(t *testing.T) {
+	d := &Deployer{Config: schema.Config{State: "/output"}}
+
+	if a, b := d.tmpRootFs(), d.tmpRootFs(); a != b {
+		t.Fatalf("tmpRootFs() must be stable across calls, got %q then %q", a, b)
+	}
+}

--- a/deployer/steps_test.go
+++ b/deployer/steps_test.go
@@ -53,6 +53,20 @@ func TestTmpRootFsStable(t *testing.T) {
 	}
 }
 
+// TestTmpRootFsNormalizesStateDir ensures superficial differences in state_dir
+// (a trailing slash, an unclean path) map to the same unpack directory, so the
+// same logical build always resolves to one temp rootfs.
+func TestTmpRootFsNormalizesStateDir(t *testing.T) {
+	a := &Deployer{Config: schema.Config{State: "/output"}}
+	b := &Deployer{Config: schema.Config{State: "/output/"}}
+	c := &Deployer{Config: schema.Config{State: "/output/../output"}}
+
+	if a.tmpRootFs() != b.tmpRootFs() || a.tmpRootFs() != c.tmpRootFs() {
+		t.Fatalf("equivalent state_dirs must map to the same temp rootfs: %q, %q, %q",
+			a.tmpRootFs(), b.tmpRootFs(), c.tmpRootFs())
+	}
+}
+
 // TestTmpRootFsUniquePerStateDir guards the concurrency invariant: the internal
 // builder runs multiple builds in parallel in the same process, each with a
 // distinct state_dir. Their unpack directories must not collide, otherwise one


### PR DESCRIPTION
## Problem

Fixes kairos-io/kairos#3922.

AuroraBoot unpacks the source container image into `state_dir/temp-rootfs`. `state_dir` is commonly a **host bind mount** (users mount it to collect the output artifacts). On Docker Desktop for macOS that mount is backed by **VirtioFS**, which cannot faithfully represent the Linux ownership + restrictive-mode metadata that containerd's tar-apply sets while unpacking a rootfs.

Since containerd started `chmod`'ing files through the open descriptor ([containerd `61c2733f`](https://github.com/containerd/containerd/commit/61c2733fde2971d2d5fb3b9d5363d626700350fd), first shipped in v1.7.31 and pulled into AuroraBoot via the kairos-sdk bump in **v0.22.0**), unpacking a read-only root-owned file such as `/etc/sudoers.d/*` onto that mount fails:

```
<dump-source> (error: ... failed to Lchown "/output/temp-rootfs/etc/sudoers.d/99-k2-rescue"
for UID 0, GID 0: ... permission denied)
```

`fchmod(fd, 0440)` makes the APFS backing file genuinely read-only to the macOS Docker user, so the following `lchown` gets `EACCES` — a documented Docker Desktop VirtioFS behavior ([docker/for-mac#6812](https://github.com/docker/for-mac/issues/6812)). This matches the exact good→bad release boundary bisected in the issue (v0.21.2 ✅ → v0.22.0 ❌).

Huge thanks to @wyvernzora for the thorough bisection and root-cause analysis in the issue.

## Fix

Unpack the intermediate rootfs on the **local filesystem** (`os.TempDir()`, i.e. `/tmp` inside the container) instead of under `state_dir`. Only the finished ISO/raw-disk artifacts are written to `state_dir`. This sidesteps the VirtioFS metadata limitation entirely rather than fighting Docker/containerd.

Why it's safe:
- `temp-rootfs` is purely internal — `CleanTmpDirs` deletes it and the artifact collector (`builder.go`) already skips it. Nothing consumes it from `state_dir`.
- Consistent with existing conventions: the UKI, sysext, and raw-disk `gendisk` paths already stage large intermediates under `os.TempDir()`.
- The path stays deterministic, which matters because `tmpRootFs()` is evaluated both eagerly at step registration and lazily inside callbacks.

**Tradeoff:** intermediate rootfs disk usage moves from the `state_dir` bind mount to the container's `/tmp` (the VM's virtual disk on Docker Desktop). The raw-disk path already stages there, so this introduces no new class of risk.

## Test

Adds `deployer/steps_test.go` asserting `tmpRootFs()` never lives under `state_dir` and stays under the local temp dir (plus a stability check). Verified passing on a Linux target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)