### PR TITLE
fix(artifacts): require non-empty name on create/update

### DIFF
--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -71,6 +71,15 @@ func New(dsn string) (*Store, error) {
 		return nil, fmt.Errorf("auto-migrating: %w", err)
 	}
 
+	// Backfill: artifact_records created before name became required may have
+	// an empty name. Give them a deterministic fallback so the UI never has
+	// to render a nameless entry. Idempotent — reruns match nothing.
+	if err := db.Exec(
+		`UPDATE artifact_records SET name = 'artifact-' || substr(id, 1, 8) WHERE name IS NULL OR name = ''`,
+	).Error; err != nil {
+		return nil, fmt.Errorf("backfilling artifact names: %w", err)
+	}
+
 	return &Store{db: db}, nil
 }
 

--- a/pkg/handlers/artifacts.go
+++ b/pkg/handlers/artifacts.go
@@ -137,6 +137,10 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 	}
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "name is required"})
+	}
 
 	ctx := c.Request().Context()
 
@@ -591,7 +595,11 @@ func (h *ArtifactHandler) Update(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 	}
 	if patch.Name != nil {
-		rec.Name = *patch.Name
+		name := strings.TrimSpace(*patch.Name)
+		if name == "" {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": "name cannot be empty"})
+		}
+		rec.Name = name
 	}
 	if patch.Saved != nil {
 		rec.Saved = *patch.Saved

--- a/pkg/handlers/artifacts_test.go
+++ b/pkg/handlers/artifacts_test.go
@@ -31,7 +31,7 @@ var _ = Describe("ArtifactHandler", func() {
 
 	Describe("Create", func() {
 		It("should create a build", func() {
-			body := `{"baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true}}`
+			body := `{"name":"test-artifact","baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true}}`
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
@@ -53,7 +53,7 @@ var _ = Describe("ArtifactHandler", func() {
 			// error; the handler must surface that as a client error.
 			fb.buildErr = fmt.Errorf("%w: invalid kairos version %q", builder.ErrInvalidBuildOptions, "latest && id")
 
-			body := `{"baseImage":"quay.io/kairos/ubuntu:24.04","kairosVersion":"latest && id","outputs":{"iso":true}}`
+			body := `{"name":"test-artifact","baseImage":"quay.io/kairos/ubuntu:24.04","kairosVersion":"latest && id","outputs":{"iso":true}}`
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
@@ -74,7 +74,7 @@ var _ = Describe("ArtifactHandler", func() {
 		It("returns 500 for a genuine server failure", func() {
 			fb.buildErr = fmt.Errorf("disk full")
 
-			body := `{"baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true}}`
+			body := `{"name":"test-artifact","baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true}}`
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts", strings.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
@@ -83,6 +83,22 @@ var _ = Describe("ArtifactHandler", func() {
 			err := handler.Create(c)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rec.Code).To(Equal(http.StatusInternalServerError))
+		})
+
+		It("rejects a build with an empty name", func() {
+			body := `{"name":"","baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true}}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			Expect(handler.Create(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+
+			var resp map[string]string
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["error"]).To(ContainSubstring("name is required"))
+			Expect(fb.builds).To(BeEmpty())
 		})
 	})
 
@@ -100,7 +116,7 @@ var _ = Describe("ArtifactHandler", func() {
 		}
 
 		It("substitutes safe defaults when allowedCommands is omitted", func() {
-			post(`{"baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true}}`)
+			post(`{"name":"test-artifact","baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true}}`)
 			Expect(fb.lastOpts.Provisioning.AllowedCommands).To(ConsistOf("upgrade", "upgrade-recovery", "reboot", "unregister"))
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("phonehome:"))
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("allowed_commands:"))
@@ -109,7 +125,7 @@ var _ = Describe("ArtifactHandler", func() {
 		})
 
 		It("passes through a custom allowedCommands list verbatim", func() {
-			post(`{"baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true},"provisioning":{"registerAuroraBoot":true,"allowedCommands":["exec","reboot"]}}`)
+			post(`{"name":"test-artifact","baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true},"provisioning":{"registerAuroraBoot":true,"allowedCommands":["exec","reboot"]}}`)
 			Expect(fb.lastOpts.Provisioning.AllowedCommands).To(Equal([]string{"exec", "reboot"}))
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("- exec"))
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("- reboot"))
@@ -118,14 +134,14 @@ var _ = Describe("ArtifactHandler", func() {
 		})
 
 		It("emits an empty list when the operator opts into observe-only", func() {
-			post(`{"baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true},"provisioning":{"registerAuroraBoot":true,"allowedCommands":[]}}`)
+			post(`{"name":"test-artifact","baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true},"provisioning":{"registerAuroraBoot":true,"allowedCommands":[]}}`)
 			Expect(fb.lastOpts.Provisioning.AllowedCommands).To(HaveLen(0))
 			Expect(fb.lastOpts.Provisioning.AllowedCommands).NotTo(BeNil())
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("allowed_commands: []"))
 		})
 
 		It("omits the phonehome stanza entirely when registerAuroraBoot is false", func() {
-			post(`{"baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true},"provisioning":{"registerAuroraBoot":false}}`)
+			post(`{"name":"test-artifact","baseImage":"quay.io/kairos/ubuntu:24.04","outputs":{"iso":true},"provisioning":{"registerAuroraBoot":false}}`)
 			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("phonehome:"))
 			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("allowed_commands"))
 		})
@@ -142,36 +158,36 @@ var _ = Describe("ArtifactHandler", func() {
 		}
 
 		It("enables k3s in cloud-config for the standard variant", func() {
-			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
+			post(`{"name":"test-artifact","baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("k3s:"))
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: true"))
 		})
 
 		It("enables k0s in cloud-config for the standard variant", func() {
-			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k0s","outputs":{"iso":true}}`)
+			post(`{"name":"test-artifact","baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k0s","outputs":{"iso":true}}`)
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("k0s:"))
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: true"))
 		})
 
 		It("disables k3s in cloud-config when kubernetesEnabled is false", func() {
-			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","kubernetesEnabled":false,"outputs":{"iso":true}}`)
+			post(`{"name":"test-artifact","baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","kubernetesEnabled":false,"outputs":{"iso":true}}`)
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("k3s:"))
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: false"))
 		})
 
 		It("defaults kubernetesEnabled to true when omitted", func() {
-			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
+			post(`{"name":"test-artifact","baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("enabled: true"))
 		})
 
 		It("omits kubernetes provider stanzas for the core variant", func() {
-			post(`{"baseImage":"ubuntu:24.04","variant":"core","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
+			post(`{"name":"test-artifact","baseImage":"ubuntu:24.04","variant":"core","kubernetesDistro":"k3s","outputs":{"iso":true}}`)
 			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("k3s:"))
 			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("k0s:"))
 		})
 
 		It("merges extra k3s YAML without duplicating the top-level key", func() {
-			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true},"cloudConfig":"k3s:\n  enabled: true\n  cluster-cidr: 10.42.0.0/16"}`)
+			post(`{"name":"test-artifact","baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true},"cloudConfig":"k3s:\n  enabled: true\n  cluster-cidr: 10.42.0.0/16"}`)
 			Expect(strings.Count(fb.lastOpts.CloudConfig, "k3s:")).To(Equal(1))
 			Expect(fb.lastOpts.CloudConfig).To(ContainSubstring("cluster-cidr"))
 		})

--- a/ui/src/api/artifacts.ts
+++ b/ui/src/api/artifacts.ts
@@ -84,7 +84,7 @@ export interface CreateArtifactProvisioning {
 }
 
 export interface CreateArtifactInput {
-  name?: string;
+  name: string;
   baseImage: string;
   kairosVersion: string;
   model: string;

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -1034,6 +1034,9 @@ export function ArtifactBuilder() {
 
     // Step 0 — Source
     if (scope === undefined || scope === 0) {
+      if (!form.name?.trim()) {
+        errs.push({ field: "name", step: 0, message: "Name is required." });
+      }
       if (buildMode === "image" && !form.baseImage.trim()) {
         errs.push({ field: "baseImage", step: 0, message: "Base image is required." });
       }
@@ -1124,7 +1127,7 @@ export function ArtifactBuilder() {
     setErrors([]);
 
     const input: CreateArtifactInput = {
-      name: form.name || undefined,
+      name: form.name.trim(),
       baseImage: form.baseImage,
       // Belt and braces: if the user cleared the Version field after we
       // prefilled it, still send the default so the backend never gets a
@@ -1276,6 +1279,8 @@ export function ArtifactBuilder() {
                 </InfoTooltip>
               </Label>
               <Input
+                ref={bindRef("name")}
+                required
                 placeholder="e.g. Production v4.0.3 + custom agent"
                 value={form.name || ""}
                 onChange={(e) => update("name", e.target.value)}

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -1273,7 +1273,7 @@ export function ArtifactBuilder() {
           <div>
             <div className="mb-6 max-w-md">
               <Label className="mb-2 block text-sm font-medium">
-                Name
+                Name <span className="text-[#EE5007]" aria-hidden="true">*</span>
                 <InfoTooltip>
                   Friendly identifier shown throughout AuroraBoot. Not used in the generated artifact filenames.
                 </InfoTooltip>
@@ -1281,51 +1281,74 @@ export function ArtifactBuilder() {
               <Input
                 ref={bindRef("name")}
                 required
+                aria-required="true"
                 placeholder="e.g. Production v4.0.3 + custom agent"
                 value={form.name || ""}
                 onChange={(e) => update("name", e.target.value)}
               />
               <p className="text-xs text-muted-foreground mt-1">
-                A friendly name to identify this artifact.
+                Required. A friendly name to identify this artifact.
               </p>
             </div>
 
             {!cloneSource && (
               <div className="mb-6">
                 <Label className="mb-2 block text-sm font-medium">Start from a template</Label>
+                {!form.name?.trim() && (
+                  <p className="text-xs text-[#EE5007] mb-2">
+                    Enter a name above to unlock templates.
+                  </p>
+                )}
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                  {TEMPLATES.map((t) => (
-                    <Card
-                      key={t.name}
-                      className={`cursor-pointer transition-colors ${
-                        selectedTemplate === t.name
-                          ? "border-[#EE5007] bg-[#EE5007]/5 ring-1 ring-[#EE5007]/20"
-                          : "hover:border-[#FF7442]/40"
-                      }`}
-                      onClick={() => {
-                        setSelectedTemplate(t.name);
-                        setForm((prev) => ({
-                          ...EMPTY_FORM,
-                          ...t.values,
-                          name: prev.name, // preserve user-typed name
-                          outputs: { ...EMPTY_OUTPUTS, ...t.values.outputs },
-                          signing: { ...EMPTY_SIGNING, ...t.values.signing },
-                          provisioning: { ...EMPTY_PROVISIONING, ...t.values.provisioning },
-                        }));
-                        setCustomModel(false);
-                        // Custom + Hadron custom stay on Source step so the
-                        // user can reveal an inline sub-form (Image Source
-                        // card for Custom, compose panel for Hadron custom);
-                        // real templates advance straight to Configure.
-                        if (t.name !== "Custom" && t.name !== HADRON_TEMPLATE_NAME) setStep(1);
-                      }}
-                    >
-                      <CardContent className="p-3">
-                        <p className="font-medium text-sm">{t.name}</p>
-                        <p className="text-xs text-muted-foreground mt-1">{t.description}</p>
-                      </CardContent>
-                    </Card>
-                  ))}
+                  {TEMPLATES.map((t) => {
+                    const disabled = !form.name?.trim();
+                    return (
+                      <Card
+                        key={t.name}
+                        aria-disabled={disabled}
+                        className={`transition-colors ${
+                          disabled
+                            ? "cursor-not-allowed opacity-50"
+                            : "cursor-pointer"
+                        } ${
+                          selectedTemplate === t.name
+                            ? "border-[#EE5007] bg-[#EE5007]/5 ring-1 ring-[#EE5007]/20"
+                            : !disabled
+                            ? "hover:border-[#FF7442]/40"
+                            : ""
+                        }`}
+                        onClick={() => {
+                          if (disabled) {
+                            focusFirstError([
+                              { field: "name", step: 0, message: "Name is required." },
+                            ]);
+                            setErrors(["Name is required."]);
+                            return;
+                          }
+                          setSelectedTemplate(t.name);
+                          setForm((prev) => ({
+                            ...EMPTY_FORM,
+                            ...t.values,
+                            name: prev.name, // preserve user-typed name
+                            outputs: { ...EMPTY_OUTPUTS, ...t.values.outputs },
+                            signing: { ...EMPTY_SIGNING, ...t.values.signing },
+                            provisioning: { ...EMPTY_PROVISIONING, ...t.values.provisioning },
+                          }));
+                          setCustomModel(false);
+                          // Custom + Hadron custom stay on Source step so the
+                          // user can reveal an inline sub-form (Image Source
+                          // card for Custom, compose panel for Hadron custom);
+                          // real templates advance straight to Configure.
+                          if (t.name !== "Custom" && t.name !== HADRON_TEMPLATE_NAME) setStep(1);
+                        }}
+                      >
+                        <CardContent className="p-3">
+                          <p className="font-medium text-sm">{t.name}</p>
+                          <p className="text-xs text-muted-foreground mt-1">{t.description}</p>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
                 </div>
               </div>
             )}
@@ -2845,6 +2868,7 @@ export function ArtifactBuilder() {
               <Button
                 type="button"
                 onClick={() => { if (validateStep(step)) setStep(step + 1); }}
+                disabled={computeErrors(step).length > 0}
                 className="bg-[#EE5007] hover:bg-[#FF7442] text-white"
               >
                 Next


### PR DESCRIPTION
The dashboard was rendering blank buttons and list entries — `Deploy ""`, stray "noname" placeholders — whenever an artifact row had an empty `name`. Different pages fell back differently (`name || baseImage`, `name || id.slice(0,8)`, plain `name`), so the symptom moved around depending on where you looked. The real problem was that the create endpoint accepted an empty `Name` with no validation, so nameless rows could exist at all.

Backend now enforces it: `Create` trims and rejects an empty name with 400 `"name is required"`, and the `Update` PATCH rejects clearing it with `"name cannot be empty"`. For any legacy rows already in the DB, `store.go` runs a single idempotent `UPDATE ... WHERE name IS NULL OR name = ''` right after `AutoMigrate` that renames them to `artifact-<first 8 of id>`, so nothing renders blank once you upgrade.

On the UI side `ArtifactBuilder` marks name as required in the step-0 validator, wires it into `bindRef` so the focus-first-error handler lands on it, trims the value on submit, and `CreateArtifactInput.name` is no longer optional in the API types.

Before:
<img width="908" height="934" alt="image" src="https://github.com/user-attachments/assets/c2477fd2-81cb-4445-a8b7-884b4c747f62" />

After the migration:
<img width="908" height="934" alt="image" src="https://github.com/user-attachments/assets/32663b7a-3e80-4a8f-b189-331554769007" />


Templates now disabled until the name is filled: 
<img width="908" height="934" alt="image" src="https://github.com/user-attachments/assets/e2564ca8-bfde-476d-865e-cf5c070612da" />


Signed-off-by: Itxaka <itxaka@kairos.io>