### PR TITLE
fix(ui): fall back to short artifact ID when name is empty

### DIFF
--- a/ui/src/components/CommandDialog.tsx
+++ b/ui/src/components/CommandDialog.tsx
@@ -389,9 +389,11 @@ export function CommandDialog({
                                   <span className="truncate">
                                     {a.name || a.id.slice(0, 8)}
                                   </span>
-                                  <span className="text-xs text-muted-foreground truncate">
-                                    {a.id.slice(0, 8)}
-                                  </span>
+                                  {a.name && (
+                                    <span className="text-xs text-muted-foreground truncate">
+                                      {a.id.slice(0, 8)}
+                                    </span>
+                                  )}
                                 </div>
                               </SelectItem>
                             ))}

--- a/ui/src/components/CommandDialog.tsx
+++ b/ui/src/components/CommandDialog.tsx
@@ -370,7 +370,7 @@ export function CommandDialog({
                                   <SelectItem key={a.id} value={a.id}>
                                     <div className="flex flex-col gap-0.5 min-w-0">
                                       <span className="truncate font-medium">
-                                        {a.name || a.baseImage?.split("/").pop() || "Unnamed"}
+                                        {a.name || a.id.slice(0, 8)}
                                       </span>
                                       <span className="text-xs text-muted-foreground truncate">
                                         {a.id.slice(0, 8)}
@@ -387,7 +387,7 @@ export function CommandDialog({
                               <SelectItem key={a.id} value={a.id}>
                                 <div className="flex flex-col gap-0.5 min-w-0">
                                   <span className="truncate">
-                                    {a.name || a.baseImage?.split("/").pop() || "Unnamed"}
+                                    {a.name || a.id.slice(0, 8)}
                                   </span>
                                   <span className="text-xs text-muted-foreground truncate">
                                     {a.id.slice(0, 8)}

--- a/ui/src/components/CommandDialog.tsx
+++ b/ui/src/components/CommandDialog.tsx
@@ -372,9 +372,11 @@ export function CommandDialog({
                                       <span className="truncate font-medium">
                                         {a.name || a.id.slice(0, 8)}
                                       </span>
-                                      <span className="text-xs text-muted-foreground truncate">
-                                        {a.id.slice(0, 8)}
-                                      </span>
+                                      {a.name && (
+                                        <span className="text-xs text-muted-foreground truncate">
+                                          {a.id.slice(0, 8)}
+                                        </span>
+                                      )}
                                     </div>
                                   </SelectItem>
                                 ))}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -135,7 +135,7 @@ export function Dashboard() {
     ...artifacts.slice(0, 20).map((a) => ({
       id: `artifact-${a.id}`,
       type: "artifact" as const,
-      label: a.name || a.baseImage || "Untitled artifact",
+      label: a.name || a.id.slice(0, 8),
       status: a.phase,
       time: a.createdAt,
       link: `/artifacts/${a.id}`,
@@ -200,7 +200,7 @@ export function Dashboard() {
                     className="bg-[#EE5007] hover:bg-[#FF7442] text-white"
                     onClick={() => navigate(`/artifacts/${readyArtifact.id}`)}
                   >
-                    Deploy "{readyArtifact.name || readyArtifact.baseImage}"
+                    Deploy "{readyArtifact.name || readyArtifact.id.slice(0, 8)}"
                     <ArrowRight className="h-4 w-4 ml-2" />
                   </Button>
                 ) : (
@@ -336,7 +336,7 @@ export function Dashboard() {
                     <Package className="h-4 w-4 shrink-0 text-[#EE5007]" />
                     <div className="flex-1 min-w-0">
                       <p className="font-medium truncate">
-                        {build.name || build.baseImage || "Untitled"}
+                        {build.name || build.id.slice(0, 8)}
                       </p>
                       <p className="text-xs text-muted-foreground">
                         Started {timeAgo(build.createdAt)}


### PR DESCRIPTION
Small display fix so artifacts without a `name` render consistently across the UI. The Dashboard activity feed, the Deploy hero button, the active builds list and the CommandDialog artifact picker were showing "Untitled", "Unnamed" or the raw `baseImage` string. They now fall back to `a.id.slice(0, 8)`, which is what `Artifacts.tsx` and `ArtifactDetail.tsx` already do, so the same artifact is labelled the same way everywhere.

Purely cosmetic — no backend or validation changes. This is the smaller alternative to #640, which tried to make `name` required across the stack and was closed in favour of just handling the empty case gracefully in the UI.

Signed-off-by: Itxaka <itxaka@kairos.io>