### PR TITLE
fix(agent): emit phonehome allowed_commands one entry per line

### DIFF
--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -498,12 +498,22 @@ GROUP="${AURORABOOT_GROUP:-}"
 # defaults too — deny-all must be configured from the AuroraBoot UI instead.
 ALLOWED_RAW="${AURORABOOT_ALLOWED_COMMANDS:-upgrade,upgrade-recovery,reboot,unregister}"
 ALLOWED_YAML=""
+# _NL is a literal newline, used to put each list entry on its own line.
+# Do NOT build the list with $(printf '\n'): command substitution strips
+# trailing newlines, so the separator would expand to nothing and every entry
+# would end up concatenated on a single line ("    - a    - b"), which does not
+# parse as a YAML sequence.
+_NL='
+'
 _old_ifs="$IFS"
 IFS=','
 for c in $ALLOWED_RAW; do
     c=$(echo "$c" | xargs)  # trim whitespace
     if [ -n "$c" ]; then
-        ALLOWED_YAML="${ALLOWED_YAML}    - ${c}$(printf '\n')"
+        if [ -n "$ALLOWED_YAML" ]; then
+            ALLOWED_YAML="${ALLOWED_YAML}${_NL}"
+        fi
+        ALLOWED_YAML="${ALLOWED_YAML}    - ${c}"
     fi
 done
 IFS="$_old_ifs"

--- a/pkg/handlers/nodes_test.go
+++ b/pkg/handlers/nodes_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	"github.com/kairos-io/AuroraBoot/pkg/auth"
 	"github.com/kairos-io/AuroraBoot/pkg/handlers"
@@ -442,6 +443,92 @@ var _ = Describe("NodeHandler", func() {
 				out, err := cmd.CombinedOutput()
 				Expect(err).NotTo(HaveOccurred(), "%s: %s", shell, out)
 			}
+		})
+
+		// renderPhonehomeYAML runs the script's real allowed_commands builder and
+		// config heredoc under /bin/sh and returns the YAML it would write to
+		// /oem/phonehome.yaml. It executes the served script verbatim (only
+		// redirecting the heredoc to stdout) so the assertions cover the actual
+		// shipped rendering, not a re-implementation of it.
+		renderPhonehomeYAML := func(allowedCommands string) []byte {
+			if _, err := exec.LookPath("sh"); err != nil {
+				Skip("sh not installed")
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/install-agent", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			Expect(handler.InstallScript(c)).To(Succeed())
+			script := rec.Body.String()
+
+			// Take the ALLOWED_RAW builder and the config heredoc as two exact
+			// slices, dropping what sits between them: the script echoes progress
+			// to stdout and mkdir's /oem there, which would pollute the captured
+			// YAML and need root. Everything after the heredoc starts
+			// kairos-agent, which we neither can nor want to run here.
+			const builderEnd = `IFS="$_old_ifs"`
+			const heredocStart = "cat > /oem/phonehome.yaml << EOF"
+
+			builderAt := strings.Index(script, "ALLOWED_RAW=")
+			Expect(builderAt).To(BeNumerically(">=", 0), "install script no longer defines ALLOWED_RAW")
+			builderEndAt := strings.Index(script[builderAt:], builderEnd)
+			Expect(builderEndAt).To(BeNumerically(">=", 0), "install script no longer restores IFS after the loop")
+			builder := script[builderAt : builderAt+builderEndAt+len(builderEnd)]
+
+			heredocAt := strings.Index(script, heredocStart)
+			Expect(heredocAt).To(BeNumerically(">", builderAt), "install script no longer writes the config heredoc")
+			rest := script[heredocAt:]
+			end := strings.Index(rest, "\nEOF\n")
+			Expect(end).To(BeNumerically(">=", 0), "config heredoc is not terminated")
+			heredoc := strings.Replace(rest[:end+len("\nEOF\n")], heredocStart, "cat << EOF", 1)
+
+			fragment := builder + "\n" + heredoc
+
+			cmd := exec.Command("sh", "-c", fragment)
+			cmd.Env = append(os.Environ(), "AURORABOOT_ALLOWED_COMMANDS="+allowedCommands)
+			out, err := cmd.Output()
+			Expect(err).NotTo(HaveOccurred(), "rendering phonehome.yaml: %s", out)
+			return out
+		}
+
+		// parseAllowed unmarshals the rendered config and returns the list. This
+		// is the point of the test: a raw substring check passes even when every
+		// entry is concatenated onto one line, which is how the original bug hid.
+		parseAllowed := func(out []byte) []string {
+			var cfg struct {
+				Phonehome struct {
+					AllowedCommands []string `yaml:"allowed_commands"`
+				} `yaml:"phonehome"`
+			}
+			Expect(yaml.Unmarshal(out, &cfg)).To(Succeed(), "rendered config is not valid YAML:\n%s", out)
+			return cfg.Phonehome.AllowedCommands
+		}
+
+		It("should render allowed_commands as a parseable YAML list, one entry per line", func() {
+			out := renderPhonehomeYAML("upgrade,reboot,apply-cloud-config,unregister")
+
+			// Regression guard for the $(printf '\n') bug: command substitution
+			// strips trailing newlines, so the separator vanished and the list
+			// collapsed to a single scalar ("- upgrade    - reboot    - ...").
+			Expect(parseAllowed(out)).To(Equal([]string{
+				"upgrade", "reboot", "apply-cloud-config", "unregister",
+			}), "allowed_commands did not parse into distinct entries:\n%s", out)
+		})
+
+		It("should render the safe defaults when AURORABOOT_ALLOWED_COMMANDS is unset", func() {
+			out := renderPhonehomeYAML("")
+
+			Expect(parseAllowed(out)).To(Equal([]string{
+				"upgrade", "upgrade-recovery", "reboot", "unregister",
+			}), "default allowed_commands are wrong:\n%s", out)
+		})
+
+		It("should trim whitespace and drop empty entries", func() {
+			out := renderPhonehomeYAML("upgrade, reboot ,,unregister")
+
+			Expect(parseAllowed(out)).To(Equal([]string{
+				"upgrade", "reboot", "unregister",
+			}), "entries were not trimmed/compacted:\n%s", out)
 		})
 	})
 })


### PR DESCRIPTION
Fixes the agent install script emitting a malformed `phonehome.allowed_commands` list, which silently broke the allow-list opt-in.

Tracking issue: kairos-io/kairos#4254 (AuroraBoot has GitHub issues disabled, so Kairos issues are filed in `kairos-io/kairos`).

## Root cause

`GET /api/v1/install-agent` serves a shell script that writes `/oem/phonehome.yaml` on the node. It built the list with:

```sh
ALLOWED_YAML="${ALLOWED_YAML}    - ${c}$(printf '\n')"
```

**Command substitution strips trailing newlines**, so `$(printf '\n')` expands to an empty string and the separator disappears. Every entry lands on one line:

```console
$ A=""; for c in one two; do A="${A}    - ${c}$(printf '\n')"; done
$ printf '%s' "$A" | cat -A
    - one    - two
```

Which produced this on the node:

```yaml
allowed_commands:
    - upgrade    - upgrade-recovery    - reboot    - unregister
```

That is not a YAML sequence — it parses as a single mangled scalar. So `AURORABOOT_ALLOWED_COMMANDS` silently did nothing and the agent refused any non-default command:

```
command "apply-cloud-config" is not permitted by the phonehome policy;
add it to phonehome.allowed_commands in cloud-config to opt in
```

Confirmed empirically on AuroraBoot v0.25.2 + kairos-agent v2.29.4: hand-rewriting `/oem/phonehome.yaml` with one item per line and restarting `kairos-agent-phonehome` makes the identical command succeed. **The rendering was the only fault** — the allow-list design (destructive commands are opt-in) is intentional and unchanged.

## The fix

`pkg/handlers/nodes.go` — build the list with a literal newline separator so each entry gets its own line.

Note the script lives inside a `fmt.Sprintf` **backtick** literal, so the tempting `printf '    - %s\n'` would need its `%s` doubled to survive Go's formatter; a literal-newline separator avoids that footgun entirely. Emitting the separator *between* entries (rather than after each) also avoids a trailing blank line.

Unchanged: whitespace trimming, empty-entry skipping, and always emitting the key with the safe defaults when the env var is unset.

Resulting output:

```yaml
  allowed_commands:
    - upgrade
    - reboot
    - apply-cloud-config
    - unregister
```

## Regression test

`pkg/handlers/nodes_test.go` adds three specs that take the **served script's real builder and config heredoc**, execute them under `/bin/sh`, and `yaml.Unmarshal` the output — asserting the list parses into the expected distinct entries.

This matters: a raw substring assertion passes even when every entry is concatenated onto one line, which is exactly how the bug hid. The specs cover a multi-value env var, the unset-defaults case, and whitespace/empty-entry handling.

Verified the guard actually bites — reverting `nodes.go` alone makes all three fail with *"allowed_commands did not parse into distinct entries"*.

## Blast-radius audit

`allowed_commands` is rendered in three places. All three were checked rather than assumed:

| Renderer | Mechanism | Verdict |
|---|---|---|
| `pkg/handlers/nodes.go` | shell string concatenation | ❌ **broken — fixed here** |
| `pkg/handlers/artifacts.go:875` | native `[]interface{}` → `yaml.Marshal(doc)` | ✅ correct |
| `ui/src/lib/cloudConfigPreview.ts:77` | native array → `stringify()` from the `yaml` package | ✅ correct |

Two clarifications on the file list: `pkg/builder/builder.go` only *declares* the `AllowedCommands` field — the actual Go rendering lives in `artifacts.go`. And `ui/src/lib/buildConfig.ts` never renders YAML; it carries the list as JSON to the API.

Only the shell script did string concatenation, which is precisely why it was the only one that broke.

## Verification

- `go build ./...` — clean
- `go vet ./pkg/handlers/...` — clean
- `go test ./pkg/handlers/...` — passing
- End-to-end: ran `auroraboot web`, fetched `/api/v1/install-agent?token=<tok>`, rendered the emitted heredoc with `AURORABOOT_ALLOWED_COMMANDS` set to five values, and piped it through a YAML parser — **5 distinct entries, including `apply-cloud-config`**.
