### PR TITLE
fix: reject missing declarative build source

### DIFF
--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -57,6 +57,9 @@ func GetApp(version string) *cli.App {
 			if err != nil {
 				return err
 			}
+			if r.ContainerImage == "" && (r.Repository == "" || r.ReleaseVersion == "" || r.ArtifactVersion == "" || r.Flavor == "") {
+				return errors.New("no source defined: provide container_image or a complete release artifact configuration")
+			}
 
 			c.ISO.HandleDeprecations(internal.Log)
 

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -1,0 +1,29 @@
+package cmd_test
+
+import (
+	"bytes"
+
+	cmdpkg "github.com/kairos-io/AuroraBoot/internal/cmd"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("root command", Label("cmd"), func() {
+	It("rejects an invocation without an image or release source", func() {
+		app := cmdpkg.GetApp("v0.0.0")
+		app.Writer = new(bytes.Buffer)
+
+		err := app.Run([]string{"auroraboot"})
+
+		Expect(err).To(MatchError("no source defined: provide container_image or a complete release artifact configuration"))
+	})
+
+	It("rejects an incomplete release source", func() {
+		app := cmdpkg.GetApp("v0.0.0")
+		app.Writer = new(bytes.Buffer)
+
+		err := app.Run([]string{"auroraboot", "--set", "repository=kairos-io/kairos"})
+
+		Expect(err).To(MatchError("no source defined: provide container_image or a complete release artifact configuration"))
+	})
+})


### PR DESCRIPTION
Fixes kairos-io/kairos#3024.

What: stop the declarative root command when it has no usable build source. A valid run must provide either `container_image` or the complete release tuple: `repository`, `release_version`, `artifact_version`, and `flavor`.

Why: `auroraboot` with no arguments currently builds release URLs from empty strings, starts concurrent downloads such as `https://github.com//releases/download//core--.iso`, and can panic in the downloader. A partial release configuration has the same failure mode.

How: validate the loaded configuration before registering the deployment graph. Empty and incomplete sources now return `no source defined: provide container_image or a complete release artifact configuration`. Regression tests cover both cases.

Tested with:
- `go test ./internal/cmd`
- `git diff HEAD^ --check`