### PR TITLE
feat(nodes): report node network addresses and boot state

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1218,6 +1218,24 @@ const docTemplate = `{
                 "dockerfile": {
                     "type": "string"
                 },
+                "hadronBase": {
+                    "type": "string"
+                },
+                "hadronExtra": {
+                    "type": "string"
+                },
+                "hadronFirmware": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hadronLayers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "kairosInitImage": {
                     "type": "string"
                 },
@@ -1231,6 +1249,9 @@ const docTemplate = `{
                         "k3s",
                         "k0s"
                     ]
+                },
+                "kubernetesEnabled": {
+                    "type": "boolean"
                 },
                 "kubernetesVersion": {
                     "type": "string"
@@ -1332,9 +1353,21 @@ const docTemplate = `{
         "handlers.APIHeartbeatRequest": {
             "type": "object",
             "properties": {
+                "addresses": {
+                    "description": "Addresses are the node's current network addresses (optional, multi-NIC).\nWhen present they replace the stored list (e.g. after a DHCP change); when\nomitted the stored list is preserved.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/store.NodeAddress"
+                    }
+                },
                 "agentVersion": {
                     "type": "string",
                     "example": "v2.27.0"
+                },
+                "bootState": {
+                    "description": "BootState is the node's current boot state (optional): one of\nactive | passive | recovery | autoreset (unknown values pass through).",
+                    "type": "string",
+                    "example": "active"
                 },
                 "labels": {
                     "type": "object",
@@ -1353,9 +1386,21 @@ const docTemplate = `{
         "handlers.APIRegisterRequest": {
             "type": "object",
             "properties": {
+                "addresses": {
+                    "description": "Addresses are the node's reported network addresses (optional, multi-NIC).\nStored exactly as received; interface filtering is the agent's job.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/store.NodeAddress"
+                    }
+                },
                 "agentVersion": {
                     "type": "string",
                     "example": "v2.27.0"
+                },
+                "bootState": {
+                    "description": "BootState is the node's reported boot state (optional): one of\nactive | passive | recovery | autoreset (unknown values pass through).",
+                    "type": "string",
+                    "example": "active"
                 },
                 "hostname": {
                     "type": "string",
@@ -1519,6 +1564,24 @@ const docTemplate = `{
                 "gce": {
                     "type": "boolean"
                 },
+                "hadronBase": {
+                    "type": "string"
+                },
+                "hadronExtra": {
+                    "type": "string"
+                },
+                "hadronFirmware": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hadronLayers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -1533,6 +1596,9 @@ const docTemplate = `{
                 },
                 "kubernetesDistro": {
                     "type": "string"
+                },
+                "kubernetesEnabled": {
+                    "type": "boolean"
                 },
                 "kubernetesVersion": {
                     "type": "string"
@@ -1590,7 +1656,18 @@ const docTemplate = `{
         "store.ManagedNode": {
             "type": "object",
             "properties": {
+                "addresses": {
+                    "description": "Addresses are the node's reported network addresses (multi-NIC). Optional\nand backward-compatible: an agent that does not send them leaves the list\nempty. Stored as JSON, mirroring OSRelease/Labels.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/store.NodeAddress"
+                    }
+                },
                 "agentVersion": {
+                    "type": "string"
+                },
+                "bootState": {
+                    "description": "BootState is the node's reported boot state for day-2 lifecycle (e.g. a node\nthat booted the passive image signals a broken active image). Known values:\nactive | passive | recovery | autoreset — but unknown values are accepted\nand stored as-is so future boot states pass through without a server change.",
                     "type": "string"
                 },
                 "createdAt": {
@@ -1630,6 +1707,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "store.NodeAddress": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1211,6 +1211,24 @@
                 "dockerfile": {
                     "type": "string"
                 },
+                "hadronBase": {
+                    "type": "string"
+                },
+                "hadronExtra": {
+                    "type": "string"
+                },
+                "hadronFirmware": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hadronLayers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "kairosInitImage": {
                     "type": "string"
                 },
@@ -1224,6 +1242,9 @@
                         "k3s",
                         "k0s"
                     ]
+                },
+                "kubernetesEnabled": {
+                    "type": "boolean"
                 },
                 "kubernetesVersion": {
                     "type": "string"
@@ -1325,9 +1346,21 @@
         "handlers.APIHeartbeatRequest": {
             "type": "object",
             "properties": {
+                "addresses": {
+                    "description": "Addresses are the node's current network addresses (optional, multi-NIC).\nWhen present they replace the stored list (e.g. after a DHCP change); when\nomitted the stored list is preserved.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/store.NodeAddress"
+                    }
+                },
                 "agentVersion": {
                     "type": "string",
                     "example": "v2.27.0"
+                },
+                "bootState": {
+                    "description": "BootState is the node's current boot state (optional): one of\nactive | passive | recovery | autoreset (unknown values pass through).",
+                    "type": "string",
+                    "example": "active"
                 },
                 "labels": {
                     "type": "object",
@@ -1346,9 +1379,21 @@
         "handlers.APIRegisterRequest": {
             "type": "object",
             "properties": {
+                "addresses": {
+                    "description": "Addresses are the node's reported network addresses (optional, multi-NIC).\nStored exactly as received; interface filtering is the agent's job.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/store.NodeAddress"
+                    }
+                },
                 "agentVersion": {
                     "type": "string",
                     "example": "v2.27.0"
+                },
+                "bootState": {
+                    "description": "BootState is the node's reported boot state (optional): one of\nactive | passive | recovery | autoreset (unknown values pass through).",
+                    "type": "string",
+                    "example": "active"
                 },
                 "hostname": {
                     "type": "string",
@@ -1512,6 +1557,24 @@
                 "gce": {
                     "type": "boolean"
                 },
+                "hadronBase": {
+                    "type": "string"
+                },
+                "hadronExtra": {
+                    "type": "string"
+                },
+                "hadronFirmware": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hadronLayers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -1526,6 +1589,9 @@
                 },
                 "kubernetesDistro": {
                     "type": "string"
+                },
+                "kubernetesEnabled": {
+                    "type": "boolean"
                 },
                 "kubernetesVersion": {
                     "type": "string"
@@ -1583,7 +1649,18 @@
         "store.ManagedNode": {
             "type": "object",
             "properties": {
+                "addresses": {
+                    "description": "Addresses are the node's reported network addresses (multi-NIC). Optional\nand backward-compatible: an agent that does not send them leaves the list\nempty. Stored as JSON, mirroring OSRelease/Labels.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/store.NodeAddress"
+                    }
+                },
                 "agentVersion": {
+                    "type": "string"
+                },
+                "bootState": {
+                    "description": "BootState is the node's reported boot state for day-2 lifecycle (e.g. a node\nthat booted the passive image signals a broken active image). Known values:\nactive | passive | recovery | autoreset — but unknown values are accepted\nand stored as-is so future boot states pass through without a server change.",
                     "type": "string"
                 },
                 "createdAt": {
@@ -1623,6 +1700,17 @@
                     "type": "string"
                 },
                 "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "store.NodeAddress": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -89,6 +89,18 @@ definitions:
         type: string
       dockerfile:
         type: string
+      hadronBase:
+        type: string
+      hadronExtra:
+        type: string
+      hadronFirmware:
+        items:
+          type: string
+        type: array
+      hadronLayers:
+        items:
+          type: string
+        type: array
       kairosInitImage:
         type: string
       kairosVersion:
@@ -99,6 +111,8 @@ definitions:
         - k3s
         - k0s
         type: string
+      kubernetesEnabled:
+        type: boolean
       kubernetesVersion:
         type: string
       model:
@@ -169,8 +183,22 @@ definitions:
     type: object
   handlers.APIHeartbeatRequest:
     properties:
+      addresses:
+        description: |-
+          Addresses are the node's current network addresses (optional, multi-NIC).
+          When present they replace the stored list (e.g. after a DHCP change); when
+          omitted the stored list is preserved.
+        items:
+          $ref: '#/definitions/store.NodeAddress'
+        type: array
       agentVersion:
         example: v2.27.0
+        type: string
+      bootState:
+        description: |-
+          BootState is the node's current boot state (optional): one of
+          active | passive | recovery | autoreset (unknown values pass through).
+        example: active
         type: string
       labels:
         additionalProperties:
@@ -183,8 +211,21 @@ definitions:
     type: object
   handlers.APIRegisterRequest:
     properties:
+      addresses:
+        description: |-
+          Addresses are the node's reported network addresses (optional, multi-NIC).
+          Stored exactly as received; interface filtering is the agent's job.
+        items:
+          $ref: '#/definitions/store.NodeAddress'
+        type: array
       agentVersion:
         example: v2.27.0
+        type: string
+      bootState:
+        description: |-
+          BootState is the node's reported boot state (optional): one of
+          active | passive | recovery | autoreset (unknown values pass through).
+        example: active
         type: string
       hostname:
         example: kairos-node-01
@@ -297,6 +338,18 @@ definitions:
         type: boolean
       gce:
         type: boolean
+      hadronBase:
+        type: string
+      hadronExtra:
+        type: string
+      hadronFirmware:
+        items:
+          type: string
+        type: array
+      hadronLayers:
+        items:
+          type: string
+        type: array
       id:
         type: string
       iso:
@@ -307,6 +360,8 @@ definitions:
         type: string
       kubernetesDistro:
         type: string
+      kubernetesEnabled:
+        type: boolean
       kubernetesVersion:
         type: string
       message:
@@ -344,7 +399,22 @@ definitions:
     type: object
   store.ManagedNode:
     properties:
+      addresses:
+        description: |-
+          Addresses are the node's reported network addresses (multi-NIC). Optional
+          and backward-compatible: an agent that does not send them leaves the list
+          empty. Stored as JSON, mirroring OSRelease/Labels.
+        items:
+          $ref: '#/definitions/store.NodeAddress'
+        type: array
       agentVersion:
+        type: string
+      bootState:
+        description: |-
+          BootState is the node's reported boot state for day-2 lifecycle (e.g. a node
+          that booted the passive image signals a broken active image). Known values:
+          active | passive | recovery | autoreset — but unknown values are accepted
+          and stored as-is so future boot states pass through without a server change.
         type: string
       createdAt:
         type: string
@@ -371,6 +441,13 @@ definitions:
       phase:
         type: string
       updatedAt:
+        type: string
+    type: object
+  store.NodeAddress:
+    properties:
+      address:
+        type: string
+      type:
         type: string
     type: object
   store.NodeCommand:

--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -33,8 +33,8 @@ func (a *NodeStoreAdapter) ListByLabels(ctx context.Context, labels map[string]s
 func (a *NodeStoreAdapter) ListBySelector(ctx context.Context, sel store.CommandSelector) ([]*store.ManagedNode, error) {
 	return a.S.ListBySelector(ctx, sel)
 }
-func (a *NodeStoreAdapter) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string) error {
-	return a.S.UpdateHeartbeat(ctx, id, agentVersion, osRelease)
+func (a *NodeStoreAdapter) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string) error {
+	return a.S.UpdateHeartbeat(ctx, id, agentVersion, osRelease, addresses, bootState)
 }
 func (a *NodeStoreAdapter) UpdatePhase(ctx context.Context, id string, phase string) error {
 	return a.S.UpdatePhase(ctx, id, phase)

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -253,7 +253,7 @@ func (s *Store) ListBySelector(ctx context.Context, sel store.CommandSelector) (
 	return nodes, nil
 }
 
-func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string) error {
+func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string) error {
 	var n store.ManagedNode
 	if err := s.db.WithContext(ctx).First(&n, "id = ?", id).Error; err != nil {
 		return err
@@ -263,6 +263,17 @@ func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion str
 	n.AgentVersion = agentVersion
 	n.OSRelease = osRelease
 	n.Phase = store.PhaseOnline
+	// Addresses and boot state are only updated when the heartbeat actually
+	// carries them: an older agent (or the WebSocket heartbeat path, which does
+	// not collect them) omits the fields, and must not clobber values a node
+	// supplied via register or a richer heartbeat. A real update — e.g. a DHCP
+	// change — sends the full current list, which replaces the stored one.
+	if addresses != nil {
+		n.Addresses = addresses
+	}
+	if bootState != "" {
+		n.BootState = bootState
+	}
 	return s.db.WithContext(ctx).Save(&n).Error
 }
 

--- a/internal/store/gorm/store_test.go
+++ b/internal/store/gorm/store_test.go
@@ -238,7 +238,11 @@ var _ = Describe("Gorm Store", func() {
 			Expect(s.Register(ctx, n)).To(Succeed())
 
 			osRel := map[string]string{"name": "Kairos", "version": "1.0"}
-			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.5.0", osRel)).To(Succeed())
+			addrs := []store.NodeAddress{
+				{Type: "InternalIP", Address: "10.0.10.21"},
+				{Type: "Hostname", Address: "hb1"},
+			}
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.5.0", osRel, addrs, "active")).To(Succeed())
 
 			found, err := s.NodeGetByID(ctx, n.ID)
 			Expect(err).NotTo(HaveOccurred())
@@ -246,6 +250,25 @@ var _ = Describe("Gorm Store", func() {
 			Expect(found.AgentVersion).To(Equal("v0.5.0"))
 			Expect(found.OSRelease).To(HaveKeyWithValue("name", "Kairos"))
 			Expect(found.LastHeartbeat).NotTo(BeNil())
+			Expect(found.Addresses).To(Equal(addrs))
+			Expect(found.BootState).To(Equal("active"))
+		})
+
+		It("preserves addresses and boot state when a heartbeat omits them", func() {
+			n := &store.ManagedNode{
+				MachineID: "hb2",
+				Addresses: []store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.22"}},
+				BootState: "active",
+			}
+			Expect(s.Register(ctx, n)).To(Succeed())
+
+			// An older agent (or the WS heartbeat path) sends nil/"" — must not wipe.
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "")).To(Succeed())
+
+			found, err := s.NodeGetByID(ctx, n.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found.Addresses).To(Equal([]store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.22"}}))
+			Expect(found.BootState).To(Equal("active"))
 		})
 
 		It("updates phase", func() {

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -60,7 +60,7 @@ func (f *fakeNodeStore) ListByLabels(_ context.Context, _ map[string]string) ([]
 func (f *fakeNodeStore) ListBySelector(_ context.Context, _ store.CommandSelector) ([]*store.ManagedNode, error) {
 	return nil, nil
 }
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string) error {
 	return nil
 }
 func (f *fakeNodeStore) UpdatePhase(_ context.Context, _ string, _ string) error { return nil }

--- a/pkg/handlers/api_dto.go
+++ b/pkg/handlers/api_dto.go
@@ -33,6 +33,12 @@ type APIRegisterRequest struct {
 	MachineID         string `json:"machineID" example:"a1b2c3d4e5f6"`
 	Hostname          string `json:"hostname" example:"kairos-node-01"`
 	AgentVersion      string `json:"agentVersion" example:"v2.27.0"`
+	// Addresses are the node's reported network addresses (optional, multi-NIC).
+	// Stored exactly as received; interface filtering is the agent's job.
+	Addresses []store.NodeAddress `json:"addresses,omitempty"`
+	// BootState is the node's reported boot state (optional): one of
+	// active | passive | recovery | autoreset (unknown values pass through).
+	BootState string `json:"bootState,omitempty" example:"active"`
 }
 
 // APIRegisterResponse is the JSON body returned by POST /api/v1/nodes/register.
@@ -46,6 +52,13 @@ type APIHeartbeatRequest struct {
 	AgentVersion string            `json:"agentVersion" example:"v2.27.0"`
 	OSRelease    map[string]string `json:"osRelease"`
 	Labels       map[string]string `json:"labels"`
+	// Addresses are the node's current network addresses (optional, multi-NIC).
+	// When present they replace the stored list (e.g. after a DHCP change); when
+	// omitted the stored list is preserved.
+	Addresses []store.NodeAddress `json:"addresses,omitempty"`
+	// BootState is the node's current boot state (optional): one of
+	// active | passive | recovery | autoreset (unknown values pass through).
+	BootState string `json:"bootState,omitempty" example:"active"`
 }
 
 // APISetLabelsRequest is the JSON body of PUT /api/v1/nodes/:nodeID/labels.

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -118,13 +118,20 @@ func (f *fakeNodeStore) ListBySelector(_ context.Context, sel store.CommandSelec
 	return f.nodes, nil
 }
 
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, id string, agentVersion string, osRelease map[string]string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, n := range f.nodes {
 		if n.ID == id {
 			n.AgentVersion = agentVersion
 			n.OSRelease = osRelease
+			// Mirror the gorm store: only overwrite when the heartbeat carries them.
+			if addresses != nil {
+				n.Addresses = addresses
+			}
+			if bootState != "" {
+				n.BootState = bootState
+			}
 			return nil
 		}
 	}

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -87,10 +87,12 @@ func (h *NodeHandler) triggerFinalize(nodeID string) {
 
 // registerRequest is the expected body for node registration.
 type registerRequest struct {
-	RegistrationToken string `json:"registrationToken"`
-	MachineID         string `json:"machineID"`
-	Hostname          string `json:"hostname"`
-	AgentVersion      string `json:"agentVersion"`
+	RegistrationToken string              `json:"registrationToken"`
+	MachineID         string              `json:"machineID"`
+	Hostname          string              `json:"hostname"`
+	AgentVersion      string              `json:"agentVersion"`
+	Addresses         []store.NodeAddress `json:"addresses,omitempty"`
+	BootState         string              `json:"bootState,omitempty"`
 }
 
 // Register handles POST /api/v1/nodes/register.
@@ -137,6 +139,10 @@ func (h *NodeHandler) Register(c echo.Context) error {
 		Phase:        store.PhaseRegistered,
 		APIKey:       uuid.New().String(),
 		Labels:       make(map[string]string),
+		// Optional; empty when an older agent does not report them. Stored exactly
+		// as received — interface filtering is the agent's responsibility.
+		Addresses: req.Addresses,
+		BootState: req.BootState,
 	}
 
 	if err := h.nodes.Register(c.Request().Context(), node); err != nil {
@@ -375,7 +381,9 @@ func (h *NodeHandler) SetGroup(c echo.Context) error {
 // heartbeatRequest is the expected body for a heartbeat.
 type heartbeatRequest struct {
 	AgentVersion string            `json:"agentVersion"`
-	OSRelease    map[string]string `json:"osRelease"`
+	OSRelease    map[string]string   `json:"osRelease"`
+	Addresses    []store.NodeAddress `json:"addresses,omitempty"`
+	BootState    string              `json:"bootState,omitempty"`
 }
 
 // Heartbeat handles POST /api/v1/nodes/:nodeID/heartbeat.
@@ -395,7 +403,7 @@ func (h *NodeHandler) Heartbeat(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 	}
-	if err := h.nodes.UpdateHeartbeat(c.Request().Context(), nodeID, req.AgentVersion, req.OSRelease); err != nil {
+	if err := h.nodes.UpdateHeartbeat(c.Request().Context(), nodeID, req.AgentVersion, req.OSRelease, req.Addresses, req.BootState); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update heartbeat"})
 	}
 	if err := h.nodes.UpdatePhase(c.Request().Context(), nodeID, store.PhaseOnline); err != nil {

--- a/pkg/handlers/nodes_test.go
+++ b/pkg/handlers/nodes_test.go
@@ -88,6 +88,29 @@ var _ = Describe("NodeHandler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rec.Code).To(Equal(http.StatusBadRequest))
 		})
+
+		It("should persist addresses and bootState and expose them on GET", func() {
+			body := `{"registrationToken":"reg-token","machineID":"machine-addr","hostname":"n1",` +
+				`"addresses":[{"type":"InternalIP","address":"10.0.10.21"},{"type":"Hostname","address":"n1"}],` +
+				`"bootState":"active"}`
+			id := registerNode(e, handler, body)
+
+			node := getNode(e, handler, id)
+			Expect(node.Addresses).To(Equal([]store.NodeAddress{
+				{Type: "InternalIP", Address: "10.0.10.21"},
+				{Type: "Hostname", Address: "n1"},
+			}))
+			Expect(node.BootState).To(Equal("active"))
+		})
+
+		It("should register without addresses/bootState (backward compat) and leave them empty", func() {
+			body := `{"registrationToken":"reg-token","machineID":"machine-old","hostname":"n2","agentVersion":"v2.29.4"}`
+			id := registerNode(e, handler, body)
+
+			node := getNode(e, handler, id)
+			Expect(node.Addresses).To(BeEmpty())
+			Expect(node.BootState).To(BeEmpty())
+		})
 	})
 
 	Describe("List", func() {
@@ -287,6 +310,41 @@ var _ = Describe("NodeHandler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rec.Code).To(Equal(http.StatusOK))
 			Expect(ns.nodes[0].Phase).To(Equal(store.PhaseOnline))
+		})
+
+		It("should update addresses and bootState on heartbeat (e.g. a DHCP change)", func() {
+			ns.nodes = []*store.ManagedNode{{
+				ID:        "node-1",
+				Phase:     store.PhaseRegistered,
+				Addresses: []store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.21"}},
+				BootState: "active",
+			}}
+			body := `{"agentVersion":"1.1",` +
+				`"addresses":[{"type":"InternalIP","address":"10.0.10.99"},{"type":"Hostname","address":"n1"}],` +
+				`"bootState":"passive"}`
+			heartbeat(e, handler, "node-1", body)
+
+			node := getNode(e, handler, "node-1")
+			Expect(node.Addresses).To(Equal([]store.NodeAddress{
+				{Type: "InternalIP", Address: "10.0.10.99"},
+				{Type: "Hostname", Address: "n1"},
+			}))
+			Expect(node.BootState).To(Equal("passive"))
+		})
+
+		It("should preserve addresses and bootState when a heartbeat omits them", func() {
+			ns.nodes = []*store.ManagedNode{{
+				ID:        "node-1",
+				Phase:     store.PhaseRegistered,
+				Addresses: []store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.21"}},
+				BootState: "active",
+			}}
+			// An older agent sends neither field — must not wipe existing values.
+			heartbeat(e, handler, "node-1", `{"agentVersion":"1.1","osRelease":{"ID":"ubuntu"}}`)
+
+			node := getNode(e, handler, "node-1")
+			Expect(node.Addresses).To(Equal([]store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.21"}}))
+			Expect(node.BootState).To(Equal("active"))
 		})
 	})
 
@@ -532,3 +590,49 @@ var _ = Describe("NodeHandler", func() {
 		})
 	})
 })
+
+// registerNode POSTs a registration body and returns the new node's id.
+func registerNode(e *echo.Echo, handler *handlers.NodeHandler, body string) string {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	ExpectWithOffset(1, handler.Register(c)).To(Succeed())
+	ExpectWithOffset(1, rec.Code).To(Equal(http.StatusCreated))
+
+	var resp map[string]any
+	ExpectWithOffset(1, json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+	id, _ := resp["id"].(string)
+	ExpectWithOffset(1, id).NotTo(BeEmpty())
+	return id
+}
+
+// heartbeat POSTs a heartbeat body for the given node id and asserts 200.
+func heartbeat(e *echo.Echo, handler *handlers.NodeHandler, id, body string) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/"+id+"/heartbeat", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("nodeID")
+	c.SetParamValues(id)
+
+	ExpectWithOffset(1, handler.Heartbeat(c)).To(Succeed())
+	ExpectWithOffset(1, rec.Code).To(Equal(http.StatusOK))
+}
+
+// getNode GETs /api/v1/nodes/:id and decodes the ManagedNode the API returns.
+func getNode(e *echo.Echo, handler *handlers.NodeHandler, id string) store.ManagedNode {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/nodes/"+id, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("nodeID")
+	c.SetParamValues(id)
+
+	ExpectWithOffset(1, handler.Get(c)).To(Succeed())
+	ExpectWithOffset(1, rec.Code).To(Equal(http.StatusOK))
+
+	var node store.ManagedNode
+	ExpectWithOffset(1, json.Unmarshal(rec.Body.Bytes(), &node)).To(Succeed())
+	return node
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -71,7 +71,7 @@ func (f *fakeNodeStore) ListByLabels(_ context.Context, _ map[string]string) ([]
 func (f *fakeNodeStore) ListBySelector(_ context.Context, _ store.CommandSelector) ([]*store.ManagedNode, error) {
 	return nil, nil
 }
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string) error {
 	return nil
 }
 func (f *fakeNodeStore) UpdatePhase(_ context.Context, _ string, _ string) error { return nil }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -22,6 +22,21 @@ type NodeGroup struct {
 }
 
 // ManagedNode represents a Kairos node managed by auroraboot.
+// NodeAddress is one network address a node reports, mirroring CAPI's
+// MachineAddress (a {type, address} pair) so a CAPI infrastructure provider can
+// pass it straight through to Machine.status.addresses. Nodes report a LIST:
+// multi-NIC is normal. Type is one of InternalIP | ExternalIP | Hostname (kept as
+// a plain string so a future type passes through without a server change).
+//
+// The agent decides which interfaces to report (loopback/bridge/veth/bond
+// filtering is the agent's job); the server stores the list exactly as received.
+// The shape also leaves room for a future externally-supplied ExternalIP that is
+// not on any NIC — no injection path is built for that here.
+type NodeAddress struct {
+	Type    string `json:"type"`
+	Address string `json:"address"`
+}
+
 type ManagedNode struct {
 	ID            string            `json:"id" gorm:"primaryKey"`
 	MachineID     string            `json:"machineID" gorm:"uniqueIndex"`
@@ -33,9 +48,18 @@ type ManagedNode struct {
 	AgentVersion  string            `json:"agentVersion"`
 	OSRelease     map[string]string `json:"osRelease" gorm:"serializer:json"`
 	Labels        map[string]string `json:"labels" gorm:"serializer:json"`
-	APIKey        string            `json:"-" gorm:"index"`
-	CreatedAt     time.Time         `json:"createdAt"`
-	UpdatedAt     time.Time         `json:"updatedAt"`
+	// Addresses are the node's reported network addresses (multi-NIC). Optional
+	// and backward-compatible: an agent that does not send them leaves the list
+	// empty. Stored as JSON, mirroring OSRelease/Labels.
+	Addresses []NodeAddress `json:"addresses,omitempty" gorm:"serializer:json"`
+	// BootState is the node's reported boot state for day-2 lifecycle (e.g. a node
+	// that booted the passive image signals a broken active image). Known values:
+	// active | passive | recovery | autoreset — but unknown values are accepted
+	// and stored as-is so future boot states pass through without a server change.
+	BootState string    `json:"bootState,omitempty"`
+	APIKey    string    `json:"-" gorm:"index"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 // Node phases.
@@ -107,7 +131,7 @@ type NodeStore interface {
 	ListByGroup(ctx context.Context, groupID string) ([]*ManagedNode, error)
 	ListByLabels(ctx context.Context, labels map[string]string) ([]*ManagedNode, error)
 	ListBySelector(ctx context.Context, sel CommandSelector) ([]*ManagedNode, error)
-	UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string) error
+	UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []NodeAddress, bootState string) error
 	UpdatePhase(ctx context.Context, id string, phase string) error
 	SetGroup(ctx context.Context, nodeID string, groupID string) error
 	SetLabels(ctx context.Context, nodeID string, labels map[string]string) error

--- a/pkg/ws/handler.go
+++ b/pkg/ws/handler.go
@@ -160,7 +160,10 @@ func (h *AgentHandler) handleHeartbeat(nodeID string, data json.RawMessage) {
 	// context.Background() is correct here: handleHeartbeat is called from the
 	// WS read loop which outlives the original HTTP request context.
 	ctx := context.Background()
-	if err := h.Nodes.UpdateHeartbeat(ctx, nodeID, hb.AgentVersion, hb.OSRelease); err != nil {
+	// The WebSocket heartbeat does not carry network addresses or boot state
+	// (those ride the REST register/heartbeat contract); pass nil/"" so the store
+	// preserves whatever the node reported there.
+	if err := h.Nodes.UpdateHeartbeat(ctx, nodeID, hb.AgentVersion, hb.OSRelease, nil, ""); err != nil {
 		log.Printf("ws: failed to update heartbeat for node %s: %v", nodeID, err)
 	}
 	if err := h.Nodes.UpdatePhase(ctx, nodeID, store.PhaseOnline); err != nil {


### PR DESCRIPTION
Implements the **AuroraBoot (server) side** of node address + boot-state reporting.

Tracking issue: kairos-io/kairos#4253 (AuroraBoot has GitHub issues disabled, so the issue lives in the kairos repo). The field shape below was proposed there and approved by the maintainers (Itxaka, jimmykarily).

## Why

A CAPI infrastructure provider built on AuroraBoot needs each managed node's **network addresses** (to publish `Machine.status.addresses` and derive the `controlPlaneEndpoint`) and its **boot state** (day-2 lifecycle: *booted the passive image ⇒ the active image is broken*). `store.ManagedNode` carried neither.

## Scope — this PR is the server side only

This is a two-repo feature. **This PR defines the wire contract and does accept + persist + expose.** A **companion kairos-agent PR (separate, to follow)** will make the agent actually collect and send the data, including the interface filtering.

Consequences honored here:

- **Backward-compatible / optional.** The new request fields are `omitempty`. An older agent that doesn't send them keeps working, leaving `addresses`/`bootState` empty on the node until the agent PR lands.
- **Permissive server.** The address list is stored **exactly as received** — no server-side interface filtering. Dropping loopback/bridge/veth/bond is the *agent's* responsibility (Itxaka's question — it belongs in the companion PR, not here).

## Field shape (as agreed)

`store.ManagedNode` gains, using the same gorm JSON-serializer pattern as `OSRelease`/`Labels`:

```go
Addresses []NodeAddress `json:"addresses,omitempty" gorm:"serializer:json"`
BootState string        `json:"bootState,omitempty"`

type NodeAddress struct {
    Type    string `json:"type"`    // InternalIP | ExternalIP | Hostname
    Address string `json:"address"`
}
```

- `NodeAddress` mirrors CAPI's `MachineAddress` (a `{type, address}` **list** — multi-NIC is normal) so a provider can pass it straight through.
- `BootState` is a plain string. Known values are documented in a comment (`active | passive | recovery | autoreset`) but unknown values are **not** rejected — future boot states pass through. Light/no validation.
- No new type was introduced where one existed — the repo had no equivalent address type, so `NodeAddress` is new. The shape already leaves room for a future externally-supplied `ExternalIP` not on any NIC (jimmykarily's cloud-VM case); **no injection path is built now.**

## What changed

1. **`pkg/store/store.go`** — the two fields + `NodeAddress`; `NodeStore.UpdateHeartbeat` signature extended to carry them.
2. **`internal/store/gorm/{store,adapters}.go`** — `AutoMigrate` already covers `ManagedNode`, so the new columns are created automatically. `UpdateHeartbeat` **only overwrites the two fields when the heartbeat carries them** — so an older agent, or the WebSocket heartbeat path (which does not collect them), never clobbers values a node reported via register or a richer heartbeat. A real update (e.g. a DHCP change) sends the full current list, which replaces the stored one.
3. **`pkg/handlers/api_dto.go`** — `Addresses` + `BootState` added to `APIRegisterRequest` and `APIHeartbeatRequest` with swag tags.
4. **`pkg/handlers/nodes.go`** — `Register` and `Heartbeat` map the fields onto the node. `GET /api/v1/nodes` and `/nodes/:id` return `ManagedNode` directly, so exposure is automatic.
5. **`pkg/ws/handler.go`** — the one other `UpdateHeartbeat` caller, updated to pass `nil,""` (the WS heartbeat doesn't carry these).
6. **`docs/`** — regenerated with `make openapi`.

## Tests

- **gorm store:** heartbeat round-trips addresses + bootState; a heartbeat that omits them preserves the stored values.
- **handlers:** register **with** the fields and assert `GET /nodes/:id` returns them; heartbeat that **updates** the address list (a DHCP change) and assert the node reflects the new list; register **and** heartbeat **without** the fields succeed and leave them empty.

All existing suites stay green (`go build ./...`, `go vet`, `go test ./pkg/handlers/... ./internal/store/gorm/... ./pkg/ws/... ./pkg/server/... ./pkg/auth/...`).

## Validated on real infra (no agent needed)

Ran the built server and exercised the contract with `curl`:

- register **with** `addresses` + `bootState` → `GET /nodes/:id` returns them verbatim;
- heartbeat with a new address list + boot state → node reflects the change (`10.0.10.21` → `10.0.10.99`, `active` → `passive`);
- register **without** the fields → `201`, fields omitted from the node JSON;
- the served OpenAPI documents `store.NodeAddress` and the new `ManagedNode` fields.

## Note on the docs diff

`make openapi` regenerates the whole spec, so this diff also **incidentally refreshes pre-existing stale entries** unrelated to this feature: `APICreateArtifactRequest` and `store.ArtifactRecord` gain `hadronBase/Extra/Firmware/Layers` + `kubernetesEnabled` (a previously-merged feature that never re-ran `make openapi`). All additive, no deletions — it brings the committed spec back in line with the code.
