### PR TITLE
fix: propagate hostname updates from agents to the UI

### DIFF
--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -33,8 +33,11 @@ func (a *NodeStoreAdapter) ListByLabels(ctx context.Context, labels map[string]s
 func (a *NodeStoreAdapter) ListBySelector(ctx context.Context, sel store.CommandSelector) ([]*store.ManagedNode, error) {
 	return a.S.ListBySelector(ctx, sel)
 }
-func (a *NodeStoreAdapter) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string) error {
-	return a.S.UpdateHeartbeat(ctx, id, agentVersion, osRelease, addresses, bootState)
+func (a *NodeStoreAdapter) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string) error {
+	return a.S.UpdateHeartbeat(ctx, id, agentVersion, osRelease, addresses, bootState, hostname)
+}
+func (a *NodeStoreAdapter) SetHostname(ctx context.Context, id string, hostname string) error {
+	return a.S.SetHostname(ctx, id, hostname)
 }
 func (a *NodeStoreAdapter) UpdatePhase(ctx context.Context, id string, phase string) error {
 	return a.S.UpdatePhase(ctx, id, phase)

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -253,7 +253,7 @@ func (s *Store) ListBySelector(ctx context.Context, sel store.CommandSelector) (
 	return nodes, nil
 }
 
-func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string) error {
+func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string) error {
 	var n store.ManagedNode
 	if err := s.db.WithContext(ctx).First(&n, "id = ?", id).Error; err != nil {
 		return err
@@ -263,18 +263,30 @@ func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion str
 	n.AgentVersion = agentVersion
 	n.OSRelease = osRelease
 	n.Phase = store.PhaseOnline
-	// Addresses and boot state are only updated when the heartbeat actually
-	// carries them: an older agent (or the WebSocket heartbeat path, which does
-	// not collect them) omits the fields, and must not clobber values a node
-	// supplied via register or a richer heartbeat. A real update — e.g. a DHCP
-	// change — sends the full current list, which replaces the stored one.
+	// Addresses, boot state and hostname are only updated when the heartbeat
+	// actually carries them: an older agent (or the WebSocket heartbeat path,
+	// which does not collect every field) omits them, and must not clobber
+	// values a node supplied via register or a richer heartbeat. A real update
+	// — a DHCP change, a cloud-config-templated hostname applied after first
+	// boot (kairos-io/kairos#4196) — sends the current value, which replaces
+	// the stored one.
 	if addresses != nil {
 		n.Addresses = addresses
 	}
 	if bootState != "" {
 		n.BootState = bootState
 	}
+	if hostname != "" {
+		n.Hostname = hostname
+	}
 	return s.db.WithContext(ctx).Save(&n).Error
+}
+
+func (s *Store) SetHostname(ctx context.Context, id string, hostname string) error {
+	if hostname == "" {
+		return nil
+	}
+	return s.db.WithContext(ctx).Model(&store.ManagedNode{}).Where("id = ?", id).Update("hostname", hostname).Error
 }
 
 func (s *Store) UpdatePhase(ctx context.Context, id string, phase string) error {

--- a/internal/store/gorm/store_test.go
+++ b/internal/store/gorm/store_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Gorm Store", func() {
 				{Type: "InternalIP", Address: "10.0.10.21"},
 				{Type: "Hostname", Address: "hb1"},
 			}
-			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.5.0", osRel, addrs, "active")).To(Succeed())
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.5.0", osRel, addrs, "active", "")).To(Succeed())
 
 			found, err := s.NodeGetByID(ctx, n.ID)
 			Expect(err).NotTo(HaveOccurred())
@@ -263,12 +263,38 @@ var _ = Describe("Gorm Store", func() {
 			Expect(s.Register(ctx, n)).To(Succeed())
 
 			// An older agent (or the WS heartbeat path) sends nil/"" — must not wipe.
-			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "")).To(Succeed())
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "")).To(Succeed())
 
 			found, err := s.NodeGetByID(ctx, n.ID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found.Addresses).To(Equal([]store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.22"}}))
 			Expect(found.BootState).To(Equal("active"))
+		})
+
+		// Regression for kairos-io/kairos#4196: nodes register with the boot-time
+		// default hostname (e.g. `kairos`) before cloud-config templates apply the
+		// final one. The heartbeat store must upsert the reported hostname so the
+		// UI reflects the current value.
+		It("updates hostname when the heartbeat carries a new one", func() {
+			n := &store.ManagedNode{MachineID: "hb3", Hostname: "kairos"}
+			Expect(s.Register(ctx, n)).To(Succeed())
+
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.7.0", nil, nil, "", "kairos-a1b2")).To(Succeed())
+
+			found, err := s.NodeGetByID(ctx, n.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found.Hostname).To(Equal("kairos-a1b2"))
+		})
+
+		It("preserves hostname when the heartbeat omits it", func() {
+			n := &store.ManagedNode{MachineID: "hb4", Hostname: "kairos-a1b2"}
+			Expect(s.Register(ctx, n)).To(Succeed())
+
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.7.0", nil, nil, "", "")).To(Succeed())
+
+			found, err := s.NodeGetByID(ctx, n.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found.Hostname).To(Equal("kairos-a1b2"))
 		})
 
 		It("updates phase", func() {

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -60,10 +60,11 @@ func (f *fakeNodeStore) ListByLabels(_ context.Context, _ map[string]string) ([]
 func (f *fakeNodeStore) ListBySelector(_ context.Context, _ store.CommandSelector) ([]*store.ManagedNode, error) {
 	return nil, nil
 }
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string, _ string) error {
 	return nil
 }
-func (f *fakeNodeStore) UpdatePhase(_ context.Context, _ string, _ string) error { return nil }
+func (f *fakeNodeStore) SetHostname(_ context.Context, _ string, _ string) error { return nil }
+func (f *fakeNodeStore) UpdatePhase(_ context.Context, _ string, _ string) error  { return nil }
 func (f *fakeNodeStore) SetGroup(_ context.Context, _ string, _ string) error    { return nil }
 func (f *fakeNodeStore) SetLabels(_ context.Context, _ string, _ map[string]string) error {
 	return nil

--- a/pkg/handlers/api_dto.go
+++ b/pkg/handlers/api_dto.go
@@ -59,6 +59,12 @@ type APIHeartbeatRequest struct {
 	// BootState is the node's current boot state (optional): one of
 	// active | passive | recovery | autoreset (unknown values pass through).
 	BootState string `json:"bootState,omitempty" example:"active"`
+	// Hostname is the node's current OS hostname (optional). When non-empty
+	// it replaces the stored value; omitted preserves it. Present so nodes
+	// that register with a boot-time default and later apply a
+	// cloud-config-templated hostname (e.g. `kairos-{{ trunc 4 .MachineID }}`)
+	// see the UI refresh on the next heartbeat (kairos-io/kairos#4196).
+	Hostname string `json:"hostname,omitempty" example:"kairos-a1b2"`
 }
 
 // APISetLabelsRequest is the JSON body of PUT /api/v1/nodes/:nodeID/labels.

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -118,7 +118,7 @@ func (f *fakeNodeStore) ListBySelector(_ context.Context, sel store.CommandSelec
 	return f.nodes, nil
 }
 
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, n := range f.nodes {
@@ -132,6 +132,24 @@ func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, id string, agentVersi
 			if bootState != "" {
 				n.BootState = bootState
 			}
+			if hostname != "" {
+				n.Hostname = hostname
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("not found")
+}
+
+func (f *fakeNodeStore) SetHostname(_ context.Context, id string, hostname string) error {
+	if hostname == "" {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range f.nodes {
+		if n.ID == id {
+			n.Hostname = hostname
 			return nil
 		}
 	}

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -124,6 +124,18 @@ func (h *NodeHandler) Register(c echo.Context) error {
 		// A re-register is a strong "OS is up" signal too (a freshly-installed node
 		// phones home on first boot): attempt the auto eject-on-phone-home.
 		h.triggerFinalize(existing.ID)
+		// Upsert the reported hostname on the existing record when it changed.
+		// A node whose credentials survive across reboots does not re-register
+		// often, so the heartbeat path is the primary hostname-refresh channel,
+		// but re-register hitting first (fresh install, restored disk) should
+		// not leave the record stuck at the boot-time default either
+		// (kairos-io/kairos#4196). Only overwrite when non-empty so an older
+		// agent that does not report it preserves the stored value.
+		if req.Hostname != "" && req.Hostname != existing.Hostname {
+			// Best-effort: a heartbeat will retry, and the register response
+			// itself must not fail just because a hostname refresh failed.
+			_ = h.nodes.SetHostname(c.Request().Context(), existing.ID, req.Hostname)
+		}
 		// Return existing node info
 		return c.JSON(http.StatusOK, map[string]any{
 			"id":     existing.ID,
@@ -380,10 +392,17 @@ func (h *NodeHandler) SetGroup(c echo.Context) error {
 
 // heartbeatRequest is the expected body for a heartbeat.
 type heartbeatRequest struct {
-	AgentVersion string            `json:"agentVersion"`
+	AgentVersion string              `json:"agentVersion"`
 	OSRelease    map[string]string   `json:"osRelease"`
 	Addresses    []store.NodeAddress `json:"addresses,omitempty"`
 	BootState    string              `json:"bootState,omitempty"`
+	// Hostname is the node's current OS hostname. Optional and only upserted
+	// when non-empty so an older agent that doesn't report it does not wipe
+	// the value stored at register time. Fixes kairos-io/kairos#4196 — nodes
+	// booted with a templated `hostname: kairos-{{ trunc 4 .MachineID }}`
+	// register before cloud-config applies the final name, so the UI would
+	// otherwise be stuck at the boot-time default forever.
+	Hostname string `json:"hostname,omitempty"`
 }
 
 // Heartbeat handles POST /api/v1/nodes/:nodeID/heartbeat.
@@ -403,7 +422,7 @@ func (h *NodeHandler) Heartbeat(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 	}
-	if err := h.nodes.UpdateHeartbeat(c.Request().Context(), nodeID, req.AgentVersion, req.OSRelease, req.Addresses, req.BootState); err != nil {
+	if err := h.nodes.UpdateHeartbeat(c.Request().Context(), nodeID, req.AgentVersion, req.OSRelease, req.Addresses, req.BootState, req.Hostname); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update heartbeat"})
 	}
 	if err := h.nodes.UpdatePhase(c.Request().Context(), nodeID, store.PhaseOnline); err != nil {

--- a/pkg/handlers/nodes_test.go
+++ b/pkg/handlers/nodes_test.go
@@ -111,6 +111,39 @@ var _ = Describe("NodeHandler", func() {
 			Expect(node.Addresses).To(BeEmpty())
 			Expect(node.BootState).To(BeEmpty())
 		})
+
+		// Regression for kairos-io/kairos#4196: an idempotent re-register (same
+		// machineID) must upsert the reported hostname on the existing record
+		// instead of returning early with the boot-time default still stored.
+		It("should update hostname on re-register when it changed", func() {
+			ns.nodes = []*store.ManagedNode{
+				{ID: "existing-id", MachineID: "machine-1", APIKey: "existing-key", Hostname: "kairos"},
+			}
+			body := `{"registrationToken":"reg-token","machineID":"machine-1","hostname":"kairos-a1b2"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/register", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			Expect(handler.Register(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(ns.nodes[0].Hostname).To(Equal("kairos-a1b2"))
+		})
+
+		It("should preserve hostname on re-register when the client sends empty", func() {
+			ns.nodes = []*store.ManagedNode{
+				{ID: "existing-id", MachineID: "machine-1", APIKey: "existing-key", Hostname: "kairos-a1b2"},
+			}
+			body := `{"registrationToken":"reg-token","machineID":"machine-1"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/register", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			Expect(handler.Register(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(ns.nodes[0].Hostname).To(Equal("kairos-a1b2"))
+		})
 	})
 
 	Describe("List", func() {
@@ -345,6 +378,35 @@ var _ = Describe("NodeHandler", func() {
 			node := getNode(e, handler, "node-1")
 			Expect(node.Addresses).To(Equal([]store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.21"}}))
 			Expect(node.BootState).To(Equal("active"))
+		})
+
+		// Regression for kairos-io/kairos#4196: nodes register with the default
+		// hostname before cloud-config applies the templated one. The heartbeat
+		// path must carry the current hostname and upsert it on the record so the
+		// UI reflects the final `kairos-<id>` name instead of the boot-time default.
+		It("should update hostname when the agent reports a new one on heartbeat", func() {
+			ns.nodes = []*store.ManagedNode{{
+				ID:       "node-1",
+				Phase:    store.PhaseRegistered,
+				Hostname: "kairos",
+			}}
+			heartbeat(e, handler, "node-1",
+				`{"agentVersion":"1.1","hostname":"kairos-a1b2"}`)
+
+			node := getNode(e, handler, "node-1")
+			Expect(node.Hostname).To(Equal("kairos-a1b2"))
+		})
+
+		It("should preserve hostname when a heartbeat omits it (old agent)", func() {
+			ns.nodes = []*store.ManagedNode{{
+				ID:       "node-1",
+				Phase:    store.PhaseRegistered,
+				Hostname: "kairos-a1b2",
+			}}
+			heartbeat(e, handler, "node-1", `{"agentVersion":"1.1"}`)
+
+			node := getNode(e, handler, "node-1")
+			Expect(node.Hostname).To(Equal("kairos-a1b2"))
 		})
 	})
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -71,10 +71,11 @@ func (f *fakeNodeStore) ListByLabels(_ context.Context, _ map[string]string) ([]
 func (f *fakeNodeStore) ListBySelector(_ context.Context, _ store.CommandSelector) ([]*store.ManagedNode, error) {
 	return nil, nil
 }
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string, _ string) error {
 	return nil
 }
-func (f *fakeNodeStore) UpdatePhase(_ context.Context, _ string, _ string) error { return nil }
+func (f *fakeNodeStore) SetHostname(_ context.Context, _ string, _ string) error { return nil }
+func (f *fakeNodeStore) UpdatePhase(_ context.Context, _ string, _ string) error  { return nil }
 func (f *fakeNodeStore) SetGroup(_ context.Context, _ string, _ string) error    { return nil }
 func (f *fakeNodeStore) SetLabels(_ context.Context, _ string, _ map[string]string) error {
 	return nil

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -131,7 +131,17 @@ type NodeStore interface {
 	ListByGroup(ctx context.Context, groupID string) ([]*ManagedNode, error)
 	ListByLabels(ctx context.Context, labels map[string]string) ([]*ManagedNode, error)
 	ListBySelector(ctx context.Context, sel CommandSelector) ([]*ManagedNode, error)
-	UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []NodeAddress, bootState string) error
+	// UpdateHeartbeat writes the fields the agent reports on a periodic
+	// heartbeat. Empty/nil arguments preserve whatever the record already has —
+	// an older agent that does not report a given field must not wipe values
+	// the node supplied via register or a richer heartbeat.
+	UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []NodeAddress, bootState string, hostname string) error
+	// SetHostname upserts the node's hostname without touching heartbeat/phase
+	// fields. Used by the re-register path so a machine that shows up with its
+	// cloud-config-templated name after an earlier register with the boot-time
+	// default (kairos-io/kairos#4196) refreshes the stored value straight away
+	// instead of waiting for the first heartbeat. Empty hostname is a no-op.
+	SetHostname(ctx context.Context, id string, hostname string) error
 	UpdatePhase(ctx context.Context, id string, phase string) error
 	SetGroup(ctx context.Context, nodeID string, groupID string) error
 	SetLabels(ctx context.Context, nodeID string, labels map[string]string) error

--- a/pkg/ws/handler.go
+++ b/pkg/ws/handler.go
@@ -24,6 +24,10 @@ type heartbeatData struct {
 	AgentVersion string            `json:"agentVersion"`
 	OSRelease    map[string]string `json:"osRelease,omitempty"`
 	Labels       map[string]string `json:"labels,omitempty"`
+	// Hostname is the node's current OS hostname. Optional and only upserted
+	// when non-empty so an older agent that omits it does not wipe the value
+	// stored at register time. Fixes kairos-io/kairos#4196.
+	Hostname string `json:"hostname,omitempty"`
 }
 
 // commandData is sent to the agent.
@@ -162,8 +166,10 @@ func (h *AgentHandler) handleHeartbeat(nodeID string, data json.RawMessage) {
 	ctx := context.Background()
 	// The WebSocket heartbeat does not carry network addresses or boot state
 	// (those ride the REST register/heartbeat contract); pass nil/"" so the store
-	// preserves whatever the node reported there.
-	if err := h.Nodes.UpdateHeartbeat(ctx, nodeID, hb.AgentVersion, hb.OSRelease, nil, ""); err != nil {
+	// preserves whatever the node reported there. Hostname does ride the WS
+	// heartbeat so the UI reflects cloud-config-templated names applied after
+	// first boot (kairos-io/kairos#4196).
+	if err := h.Nodes.UpdateHeartbeat(ctx, nodeID, hb.AgentVersion, hb.OSRelease, nil, "", hb.Hostname); err != nil {
 		log.Printf("ws: failed to update heartbeat for node %s: %v", nodeID, err)
 	}
 	if err := h.Nodes.UpdatePhase(ctx, nodeID, store.PhaseOnline); err != nil {


### PR DESCRIPTION
Nodes showed the boot-time default hostname (`kairos`) in the UI forever because the server only stored `Hostname` on first register. Re-registers with the same `machineID` returned early with the existing credentials, and REST/WS heartbeats carried `agentVersion` + `osRelease` but no hostname. Cloud-config templated names like `hostname: kairos-{{ trunc 4 .MachineID }}` applied by cloud-init after the first phone-home never reached the UI.

Server side:

- Add `hostname` to the REST and WS heartbeat payloads and to `APIHeartbeatRequest`. Empty preserves, non-empty upserts — same pattern as `addresses`/`bootState`, so an older agent that omits the field never wipes a stored value.
- Extend `NodeStore.UpdateHeartbeat` with the new field; gorm store upserts only when non-empty.
- Add `NodeStore.SetHostname` for a lightweight column update with no heartbeat/phase side effects, so the REST Register handler can refresh the hostname on an idempotent re-register (same `machineID`) without pretending to be a heartbeat.
- Register handler calls `SetHostname` best-effort on the existing-node path when the reported hostname changed. Covers the edge case where credentials on disk expired and the node re-registers; heartbeats remain the primary refresh channel.
- Regression tests on the gorm store and the REST handler, both register and heartbeat paths, both "should update" and "must preserve when empty".
- Fakes in `server_test.go`, `middleware_test.go` and handlers `fakes_test.go` updated for the new signatures.

Agent-side change to send the hostname on every heartbeat is a separate kairos-agent PR.

Fixes kairos-io/kairos#4196

Signed-off-by: Itxaka <itxaka@kairos.io>