### PR TITLE
feat: atomic idempotent node claim/release for a group (kairos#4252)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -260,6 +260,63 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/artifacts/{id}/upload/{filename}": {
+            "put": {
+                "description": "Per-build endpoint the operator backend's exporter uses to ship finished artifacts back to AuroraBoot. Bearer is the UploadToken minted at Create time; the admin bearer does not grant access.",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Upload a single artifact file for a build",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Artifact filename (single-segment; no path separators)",
+                        "name": "filename",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/groups": {
             "get": {
                 "security": [
@@ -439,6 +496,69 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/api/v1/groups/{id}/claim": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Groups"
+                ],
+                "summary": "Claim a node from a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Claim payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIClaimRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/store.ManagedNode"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "409": {
+                        "description": "No unclaimed node available (code=NoCapacity)",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
                     }
                 }
             }
@@ -816,6 +936,69 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/nodes/{nodeID}/release": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Release a node's claim",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Node ID",
+                        "name": "nodeID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Release payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIReleaseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIReleaseResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "409": {
+                        "description": "Claimed by a different key (code=ClaimMismatch)",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/secureboot-keys": {
             "get": {
                 "security": [
@@ -1089,6 +1272,30 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/system/builder": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Report the active builder backend",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APISystemBuilder"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1191,6 +1398,15 @@ const docTemplate = `{
                 },
                 "ukiTpmPcrKey": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.APIClaimRequest": {
+            "type": "object",
+            "properties": {
+                "claimKey": {
+                    "type": "string",
+                    "example": "machine-abc123"
                 }
             }
         },
@@ -1324,6 +1540,9 @@ const docTemplate = `{
         "handlers.APIError": {
             "type": "object",
             "properties": {
+                "code": {
+                    "type": "string"
+                },
                 "detail": {
                     "type": "string"
                 },
@@ -1437,6 +1656,23 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.APIReleaseRequest": {
+            "type": "object",
+            "properties": {
+                "claimKey": {
+                    "type": "string",
+                    "example": "machine-abc123"
+                }
+            }
+        },
+        "handlers.APIReleaseResponse": {
+            "type": "object",
+            "properties": {
+                "released": {
+                    "type": "boolean"
+                }
+            }
+        },
         "handlers.APISetGroupRequest": {
             "type": "object",
             "properties": {
@@ -1454,6 +1690,30 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "handlers.APISystemBuilder": {
+            "type": "object",
+            "properties": {
+                "backend": {
+                    "type": "string",
+                    "enum": [
+                        "local",
+                        "operator"
+                    ],
+                    "example": "operator"
+                },
+                "cluster": {
+                    "type": "string",
+                    "example": "https://kind.example"
+                },
+                "downloadSupported": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "kairos-builds"
                 }
             }
         },
@@ -1668,6 +1928,14 @@ const docTemplate = `{
                 },
                 "bootState": {
                     "description": "BootState is the node's reported boot state for day-2 lifecycle (e.g. a node\nthat booted the passive image signals a broken active image). Known values:\nactive | passive | recovery | autoreset — but unknown values are accepted\nand stored as-is so future boot states pass through without a server change.",
+                    "type": "string"
+                },
+                "claimKey": {
+                    "description": "ClaimKey, when non-nil, is the opaque caller-owned key that has claimed this\nnode via POST /api/v1/groups/:id/claim (e.g. a CAPI machine's identity). A\nnil ClaimKey means the node is unclaimed and available. It is a pointer, not\na string, on purpose: \"unclaimed\" must be SQL NULL, because the composite\nunique index idx_node_group_claim on (group_id, claim_key) makes a claimKey\nown at most one node per group, and NULLs are exempt from unique indexes on\nboth SQLite and PostgreSQL — so many unclaimed nodes coexist while a second\nnode can never take an already-used claimKey in the same group.",
+                    "type": "string"
+                },
+                "claimedAt": {
+                    "description": "ClaimedAt is when ClaimKey was set; nil when unclaimed.",
                     "type": "string"
                 },
                 "createdAt": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1314,6 +1314,9 @@ const docTemplate = `{
                 "iso": {
                     "type": "boolean"
                 },
+                "maas": {
+                    "type": "boolean"
+                },
                 "netboot": {
                     "type": "boolean"
                 },
@@ -1862,6 +1865,9 @@ const docTemplate = `{
                 },
                 "kubernetesVersion": {
                     "type": "string"
+                },
+                "maas": {
+                    "type": "boolean"
                 },
                 "message": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1307,6 +1307,9 @@
                 "iso": {
                     "type": "boolean"
                 },
+                "maas": {
+                    "type": "boolean"
+                },
                 "netboot": {
                     "type": "boolean"
                 },
@@ -1855,6 +1858,9 @@
                 },
                 "kubernetesVersion": {
                     "type": "string"
+                },
+                "maas": {
+                    "type": "boolean"
                 },
                 "message": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -253,6 +253,63 @@
                 }
             }
         },
+        "/api/v1/artifacts/{id}/upload/{filename}": {
+            "put": {
+                "description": "Per-build endpoint the operator backend's exporter uses to ship finished artifacts back to AuroraBoot. Bearer is the UploadToken minted at Create time; the admin bearer does not grant access.",
+                "consumes": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Artifacts"
+                ],
+                "summary": "Upload a single artifact file for a build",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Artifact ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Artifact filename (single-segment; no path separators)",
+                        "name": "filename",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "413": {
+                        "description": "Request Entity Too Large",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/groups": {
             "get": {
                 "security": [
@@ -432,6 +489,69 @@
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/api/v1/groups/{id}/claim": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Groups"
+                ],
+                "summary": "Claim a node from a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Claim payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIClaimRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/store.ManagedNode"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "409": {
+                        "description": "No unclaimed node available (code=NoCapacity)",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
                     }
                 }
             }
@@ -809,6 +929,69 @@
                 }
             }
         },
+        "/api/v1/nodes/{nodeID}/release": {
+            "post": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Nodes"
+                ],
+                "summary": "Release a node's claim",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Node ID",
+                        "name": "nodeID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Release payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIReleaseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIReleaseResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    },
+                    "409": {
+                        "description": "Claimed by a different key (code=ClaimMismatch)",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APIError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/secureboot-keys": {
             "get": {
                 "security": [
@@ -1082,6 +1265,30 @@
                     }
                 }
             }
+        },
+        "/api/v1/system/builder": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Report the active builder backend",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.APISystemBuilder"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1184,6 +1391,15 @@
                 },
                 "ukiTpmPcrKey": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.APIClaimRequest": {
+            "type": "object",
+            "properties": {
+                "claimKey": {
+                    "type": "string",
+                    "example": "machine-abc123"
                 }
             }
         },
@@ -1317,6 +1533,9 @@
         "handlers.APIError": {
             "type": "object",
             "properties": {
+                "code": {
+                    "type": "string"
+                },
                 "detail": {
                     "type": "string"
                 },
@@ -1430,6 +1649,23 @@
                 }
             }
         },
+        "handlers.APIReleaseRequest": {
+            "type": "object",
+            "properties": {
+                "claimKey": {
+                    "type": "string",
+                    "example": "machine-abc123"
+                }
+            }
+        },
+        "handlers.APIReleaseResponse": {
+            "type": "object",
+            "properties": {
+                "released": {
+                    "type": "boolean"
+                }
+            }
+        },
         "handlers.APISetGroupRequest": {
             "type": "object",
             "properties": {
@@ -1447,6 +1683,30 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "handlers.APISystemBuilder": {
+            "type": "object",
+            "properties": {
+                "backend": {
+                    "type": "string",
+                    "enum": [
+                        "local",
+                        "operator"
+                    ],
+                    "example": "operator"
+                },
+                "cluster": {
+                    "type": "string",
+                    "example": "https://kind.example"
+                },
+                "downloadSupported": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string",
+                    "example": "kairos-builds"
                 }
             }
         },
@@ -1661,6 +1921,14 @@
                 },
                 "bootState": {
                     "description": "BootState is the node's reported boot state for day-2 lifecycle (e.g. a node\nthat booted the passive image signals a broken active image). Known values:\nactive | passive | recovery | autoreset — but unknown values are accepted\nand stored as-is so future boot states pass through without a server change.",
+                    "type": "string"
+                },
+                "claimKey": {
+                    "description": "ClaimKey, when non-nil, is the opaque caller-owned key that has claimed this\nnode via POST /api/v1/groups/:id/claim (e.g. a CAPI machine's identity). A\nnil ClaimKey means the node is unclaimed and available. It is a pointer, not\na string, on purpose: \"unclaimed\" must be SQL NULL, because the composite\nunique index idx_node_group_claim on (group_id, claim_key) makes a claimKey\nown at most one node per group, and NULLs are exempt from unique indexes on\nboth SQLite and PostgreSQL — so many unclaimed nodes coexist while a second\nnode can never take an already-used claimKey in the same group.",
+                    "type": "string"
+                },
+                "claimedAt": {
+                    "description": "ClaimedAt is when ClaimKey was set; nil when unclaimed.",
                     "type": "string"
                 },
                 "createdAt": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -72,6 +72,12 @@ definitions:
       ukiTpmPcrKey:
         type: string
     type: object
+  handlers.APIClaimRequest:
+    properties:
+      claimKey:
+        example: machine-abc123
+        type: string
+    type: object
   handlers.APICreateArtifactRequest:
     properties:
       allow-insecure-registries:
@@ -163,6 +169,8 @@ definitions:
     type: object
   handlers.APIError:
     properties:
+      code:
+        type: string
       detail:
         type: string
       error:
@@ -251,6 +259,17 @@ definitions:
       registrationToken:
         type: string
     type: object
+  handlers.APIReleaseRequest:
+    properties:
+      claimKey:
+        example: machine-abc123
+        type: string
+    type: object
+  handlers.APIReleaseResponse:
+    properties:
+      released:
+        type: boolean
+    type: object
   handlers.APISetGroupRequest:
     properties:
       groupID:
@@ -263,6 +282,23 @@ definitions:
         additionalProperties:
           type: string
         type: object
+    type: object
+  handlers.APISystemBuilder:
+    properties:
+      backend:
+        enum:
+        - local
+        - operator
+        example: operator
+        type: string
+      cluster:
+        example: https://kind.example
+        type: string
+      downloadSupported:
+        type: boolean
+      namespace:
+        example: kairos-builds
+        type: string
     type: object
   handlers.APIUpdateArtifactRequest:
     properties:
@@ -415,6 +451,20 @@ definitions:
           that booted the passive image signals a broken active image). Known values:
           active | passive | recovery | autoreset — but unknown values are accepted
           and stored as-is so future boot states pass through without a server change.
+        type: string
+      claimKey:
+        description: |-
+          ClaimKey, when non-nil, is the opaque caller-owned key that has claimed this
+          node via POST /api/v1/groups/:id/claim (e.g. a CAPI machine's identity). A
+          nil ClaimKey means the node is unclaimed and available. It is a pointer, not
+          a string, on purpose: "unclaimed" must be SQL NULL, because the composite
+          unique index idx_node_group_claim on (group_id, claim_key) makes a claimKey
+          own at most one node per group, and NULLs are exempt from unique indexes on
+          both SQLite and PostgreSQL — so many unclaimed nodes coexist while a second
+          node can never take an already-used claimKey in the same group.
+        type: string
+      claimedAt:
+        description: ClaimedAt is when ClaimKey was set; nil when unclaimed.
         type: string
       createdAt:
         type: string
@@ -675,6 +725,46 @@ paths:
       summary: Get build log snapshot
       tags:
       - Artifacts
+  /api/v1/artifacts/{id}/upload/{filename}:
+    put:
+      consumes:
+      - application/octet-stream
+      description: Per-build endpoint the operator backend's exporter uses to ship
+        finished artifacts back to AuroraBoot. Bearer is the UploadToken minted at
+        Create time; the admin bearer does not grant access.
+      parameters:
+      - description: Artifact ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Artifact filename (single-segment; no path separators)
+        in: path
+        name: filename
+        required: true
+        type: string
+      responses:
+        "201":
+          description: Created
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+        "413":
+          description: Request Entity Too Large
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+      summary: Upload a single artifact file for a build
+      tags:
+      - Artifacts
   /api/v1/groups:
     get:
       produces:
@@ -787,6 +877,46 @@ paths:
       security:
       - AdminBearer: []
       summary: Update a group
+      tags:
+      - Groups
+  /api/v1/groups/{id}/claim:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Group ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Claim payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.APIClaimRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/store.ManagedNode'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+        "409":
+          description: No unclaimed node available (code=NoCapacity)
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+      security:
+      - AdminBearer: []
+      summary: Claim a node from a group
       tags:
       - Groups
   /api/v1/nodes:
@@ -994,6 +1124,46 @@ paths:
       summary: Replace a node's labels
       tags:
       - Nodes
+  /api/v1/nodes/{nodeID}/release:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Node ID
+        in: path
+        name: nodeID
+        required: true
+        type: string
+      - description: Release payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.APIReleaseRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.APIReleaseResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+        "409":
+          description: Claimed by a different key (code=ClaimMismatch)
+          schema:
+            $ref: '#/definitions/handlers.APIError'
+      security:
+      - AdminBearer: []
+      summary: Release a node's claim
+      tags:
+      - Nodes
   /api/v1/nodes/register:
     post:
       consumes:
@@ -1199,6 +1369,20 @@ paths:
       summary: Rotate the registration token
       tags:
       - Settings
+  /api/v1/system/builder:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.APISystemBuilder'
+      security:
+      - AdminBearer: []
+      summary: Report the active builder backend
+      tags:
+      - System
 securityDefinitions:
   AdminBearer:
     description: Supply as "Bearer <admin-password>".

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -10,6 +10,8 @@ definitions:
         type: boolean
       iso:
         type: boolean
+      maas:
+        type: boolean
       netboot:
         type: boolean
       rawDisk:
@@ -400,6 +402,8 @@ definitions:
         type: boolean
       kubernetesVersion:
         type: string
+      maas:
+        type: boolean
       message:
         type: string
       model:

--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -45,6 +45,12 @@ func (a *NodeStoreAdapter) SetGroup(ctx context.Context, nodeID string, groupID 
 func (a *NodeStoreAdapter) SetLabels(ctx context.Context, nodeID string, labels map[string]string) error {
 	return a.S.SetLabels(ctx, nodeID, labels)
 }
+func (a *NodeStoreAdapter) ClaimNode(ctx context.Context, groupID, claimKey string) (*store.ManagedNode, error) {
+	return a.S.ClaimNode(ctx, groupID, claimKey)
+}
+func (a *NodeStoreAdapter) ReleaseNode(ctx context.Context, nodeID, claimKey string) (bool, error) {
+	return a.S.ReleaseNode(ctx, nodeID, claimKey)
+}
 func (a *NodeStoreAdapter) Delete(ctx context.Context, id string) error {
 	return a.S.NodeDelete(ctx, id)
 }

--- a/internal/store/gorm/node_claim_test.go
+++ b/internal/store/gorm/node_claim_test.go
@@ -1,0 +1,253 @@
+package gorm_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+)
+
+var _ = Describe("Gorm Store node claim", func() {
+	var (
+		s   *gormstore.Store
+		ctx context.Context
+	)
+
+	// register adds a node to groupID and returns it (with its generated ID).
+	register := func(groupID, machineID string) *store.ManagedNode {
+		n := &store.ManagedNode{MachineID: machineID, GroupID: groupID}
+		Expect(s.Register(ctx, n)).To(Succeed())
+		return n
+	}
+
+	BeforeEach(func() {
+		var err error
+		// File-backed so concurrent goroutines share one SQLite DB (WAL +
+		// busy_timeout), matching the existing concurrency tests.
+		s, err = gormstore.New(filepath.Join(GinkgoT().TempDir(), "claim.db"))
+		Expect(err).NotTo(HaveOccurred())
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		Expect(s.Close()).To(Succeed())
+	})
+
+	It("claims an unclaimed node and stamps the key and time", func() {
+		register("g1", "n1")
+
+		got, err := s.ClaimNode(ctx, "g1", "machine-a")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).NotTo(BeNil())
+		Expect(got.ClaimKey).NotTo(BeNil())
+		Expect(*got.ClaimKey).To(Equal("machine-a"))
+		Expect(got.ClaimedAt).NotTo(BeNil())
+	})
+
+	It("is idempotent: the same key re-claims the same node, not a second one", func() {
+		register("g1", "n1")
+		register("g1", "n2")
+
+		first, err := s.ClaimNode(ctx, "g1", "machine-a")
+		Expect(err).NotTo(HaveOccurred())
+
+		second, err := s.ClaimNode(ctx, "g1", "machine-a")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(second.ID).To(Equal(first.ID), "replaying a claim must return the same node")
+
+		// The other node must still be free.
+		nodes, err := s.ListByGroup(ctx, "g1")
+		Expect(err).NotTo(HaveOccurred())
+		claimed := 0
+		for _, n := range nodes {
+			if n.ClaimKey != nil {
+				claimed++
+			}
+		}
+		Expect(claimed).To(Equal(1))
+	})
+
+	It("gives distinct keys distinct nodes", func() {
+		register("g1", "n1")
+		register("g1", "n2")
+
+		a, err := s.ClaimNode(ctx, "g1", "machine-a")
+		Expect(err).NotTo(HaveOccurred())
+		b, err := s.ClaimNode(ctx, "g1", "machine-b")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(a.ID).NotTo(Equal(b.ID))
+	})
+
+	It("returns ErrNoClaimCapacity when the group is fully claimed", func() {
+		register("g1", "n1")
+		_, err := s.ClaimNode(ctx, "g1", "machine-a")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = s.ClaimNode(ctx, "g1", "machine-b")
+		Expect(errors.Is(err, store.ErrNoClaimCapacity)).To(BeTrue())
+	})
+
+	It("returns ErrNoClaimCapacity for an empty or unknown group", func() {
+		_, err := s.ClaimNode(ctx, "does-not-exist", "machine-a")
+		Expect(errors.Is(err, store.ErrNoClaimCapacity)).To(BeTrue())
+	})
+
+	It("does not claim a node from a different group", func() {
+		register("g1", "n1")
+		_, err := s.ClaimNode(ctx, "g2", "machine-a")
+		Expect(errors.Is(err, store.ErrNoClaimCapacity)).To(BeTrue())
+	})
+
+	Describe("release", func() {
+		It("frees a node so it can be claimed again", func() {
+			register("g1", "n1")
+			claimed, err := s.ClaimNode(ctx, "g1", "machine-a")
+			Expect(err).NotTo(HaveOccurred())
+
+			released, err := s.ReleaseNode(ctx, claimed.ID, "machine-a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(released).To(BeTrue())
+
+			// Now free: a re-read shows no claim, and a fresh claim picks it.
+			reread, err := s.NodeGetByID(ctx, claimed.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reread.ClaimKey).To(BeNil())
+			Expect(reread.ClaimedAt).To(BeNil())
+
+			again, err := s.ClaimNode(ctx, "g1", "machine-b")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(again.ID).To(Equal(claimed.ID))
+			Expect(*again.ClaimKey).To(Equal("machine-b"))
+		})
+
+		It("does not release a claim held by a different key", func() {
+			register("g1", "n1")
+			claimed, err := s.ClaimNode(ctx, "g1", "machine-a")
+			Expect(err).NotTo(HaveOccurred())
+
+			released, err := s.ReleaseNode(ctx, claimed.ID, "machine-b")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(released).To(BeFalse())
+
+			// Still owned by machine-a.
+			reread, err := s.NodeGetByID(ctx, claimed.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reread.ClaimKey).NotTo(BeNil())
+			Expect(*reread.ClaimKey).To(Equal("machine-a"))
+		})
+
+		It("reports false when releasing an unclaimed node", func() {
+			n := register("g1", "n1")
+			released, err := s.ReleaseNode(ctx, n.ID, "machine-a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(released).To(BeFalse())
+		})
+	})
+
+	It("gives every distinct key a distinct node under concurrent claims", func() {
+		const nodes = 5
+		const claimers = 16 // more claimers than nodes
+		for i := 0; i < nodes; i++ {
+			register("g1", fmt.Sprintf("node-%d", i))
+		}
+
+		type result struct {
+			nodeID string
+			err    error
+		}
+		results := make(chan result, claimers)
+		var wg sync.WaitGroup
+		for i := 0; i < claimers; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				got, err := s.ClaimNode(ctx, "g1", fmt.Sprintf("machine-%d", idx))
+				if err != nil {
+					results <- result{err: err}
+					return
+				}
+				results <- result{nodeID: got.ID}
+			}(i)
+		}
+		wg.Wait()
+		close(results)
+
+		claimedIDs := map[string]int{}
+		noCapacity := 0
+		for r := range results {
+			if r.err != nil {
+				Expect(errors.Is(r.err, store.ErrNoClaimCapacity)).To(BeTrue(),
+					"the only acceptable error is no-capacity, got: %v", r.err)
+				noCapacity++
+				continue
+			}
+			claimedIDs[r.nodeID]++
+		}
+		// Exactly `nodes` distinct nodes were claimed, each by exactly one winner,
+		// and every other claimer got a clean no-capacity signal.
+		Expect(claimedIDs).To(HaveLen(nodes))
+		for id, n := range claimedIDs {
+			Expect(n).To(Equal(1), "node %s was handed to more than one claimer", id)
+		}
+		Expect(noCapacity).To(Equal(claimers - nodes))
+	})
+
+	It("hands the same node to every concurrent claim that shares a key", func() {
+		const nodes = 5
+		const claimers = 16
+		for i := 0; i < nodes; i++ {
+			register("g1", fmt.Sprintf("node-%d", i))
+		}
+
+		results := make(chan string, claimers)
+		errs := make(chan error, claimers)
+		var wg sync.WaitGroup
+		for i := 0; i < claimers; i++ {
+			wg.Add(1)
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				got, err := s.ClaimNode(ctx, "g1", "same-key")
+				if err != nil {
+					errs <- err
+					return
+				}
+				results <- got.ID
+			}()
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for err := range errs {
+			Expect(err).NotTo(HaveOccurred())
+		}
+		ids := map[string]struct{}{}
+		count := 0
+		for id := range results {
+			ids[id] = struct{}{}
+			count++
+		}
+		Expect(count).To(Equal(claimers))
+		Expect(ids).To(HaveLen(1), "a single claimKey must never own more than one node")
+
+		// And only that one node is claimed in the group.
+		grp, err := s.ListByGroup(ctx, "g1")
+		Expect(err).NotTo(HaveOccurred())
+		claimed := 0
+		for _, n := range grp {
+			if n.ClaimKey != nil {
+				claimed++
+			}
+		}
+		Expect(claimed).To(Equal(1))
+	})
+})

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -43,7 +43,12 @@ func (s *Store) WithCipher(c *secrets.Cipher) *Store {
 //   - anything else → SQLite (file path or ":memory:")
 func New(dsn string) (*Store, error) {
 	dialector := openDialector(dsn)
-	db, err := gorm.Open(dialector, &gorm.Config{})
+	// TranslateError makes GORM return its portable sentinel errors (e.g.
+	// gorm.ErrDuplicatedKey, gorm.ErrRecordNotFound) instead of raw driver
+	// errors, so store code can branch on them without SQLite/PostgreSQL string
+	// matching. ClaimNode relies on ErrDuplicatedKey to arbitrate a concurrent
+	// same-key claim against the (group_id, claim_key) unique index.
+	db, err := gorm.Open(dialector, &gorm.Config{TranslateError: true})
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
@@ -300,6 +305,105 @@ func (s *Store) NodeDelete(ctx context.Context, id string) error {
 		return err
 	}
 	return s.db.WithContext(ctx).Delete(&store.ManagedNode{}, "id = ?", id).Error
+}
+
+// nodeClaimedByKey returns the node in groupID currently claimed by claimKey, or
+// (nil, nil) when there is none. It is the idempotent-replay lookup for ClaimNode.
+func (s *Store) nodeClaimedByKey(ctx context.Context, groupID, claimKey string) (*store.ManagedNode, error) {
+	var n store.ManagedNode
+	err := s.db.WithContext(ctx).Preload("Group").
+		Where("group_id = ? AND claim_key = ?", groupID, claimKey).
+		First(&n).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &n, nil
+}
+
+// ClaimNode atomically assigns one unclaimed node in groupID to claimKey.
+//
+// Idempotency comes first: if claimKey already owns a node in the group, that
+// same node is returned without claiming a second one — so a controller that
+// crashed mid-provision and reconciles again re-finds its own node.
+//
+// Otherwise it walks a snapshot of the group's currently-unclaimed nodes and
+// tries to claim each with a conditional UPDATE (... WHERE id = ? AND claim_key
+// IS NULL). Exactly one of several concurrent callers wins any given node — a
+// lost race yields RowsAffected == 0 and moves to the next candidate — so two
+// callers never receive the same node. This mirrors the store's existing
+// compare-and-set claim idiom (ClaimForDelivery / CASEjectState) and needs no
+// FOR UPDATE / SKIP LOCKED, so it is correct on both SQLite and PostgreSQL.
+//
+// A concurrent claim with the SAME new claimKey is caught by the (group_id,
+// claim_key) unique index: the second UPDATE fails with ErrDuplicatedKey, and we
+// resolve it to the node the first call claimed. When the snapshot is exhausted
+// with nothing won, the group is at capacity and we return ErrNoClaimCapacity.
+func (s *Store) ClaimNode(ctx context.Context, groupID, claimKey string) (*store.ManagedNode, error) {
+	if existing, err := s.nodeClaimedByKey(ctx, groupID, claimKey); err != nil {
+		return nil, err
+	} else if existing != nil {
+		return existing, nil
+	}
+
+	// Snapshot unclaimed candidate IDs (oldest first) so the loop is bounded.
+	var candidateIDs []string
+	if err := s.db.WithContext(ctx).Model(&store.ManagedNode{}).
+		Where("group_id = ? AND claim_key IS NULL", groupID).
+		Order("created_at asc").
+		Pluck("id", &candidateIDs).Error; err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	for _, id := range candidateIDs {
+		res := s.db.WithContext(ctx).Model(&store.ManagedNode{}).
+			Where("id = ? AND claim_key IS NULL", id).
+			Updates(map[string]any{"claim_key": claimKey, "claimed_at": &now})
+		if res.Error != nil {
+			// A concurrent claim with this same key already took another node in
+			// the group; the unique index rejected this one. Return that node.
+			if errors.Is(res.Error, gorm.ErrDuplicatedKey) {
+				if mine, err := s.nodeClaimedByKey(ctx, groupID, claimKey); err != nil {
+					return nil, err
+				} else if mine != nil {
+					return mine, nil
+				}
+			}
+			return nil, res.Error
+		}
+		if res.RowsAffected == 1 {
+			return s.NodeGetByID(ctx, id)
+		}
+		// RowsAffected == 0: another caller claimed this node between the snapshot
+		// and now — try the next candidate.
+	}
+
+	// Snapshot exhausted. One last idempotent check covers the case where our own
+	// key won a node via a concurrent call while we were losing races here.
+	if mine, err := s.nodeClaimedByKey(ctx, groupID, claimKey); err != nil {
+		return nil, err
+	} else if mine != nil {
+		return mine, nil
+	}
+	return nil, store.ErrNoClaimCapacity
+}
+
+// ReleaseNode clears the claim on nodeID and returns it to the pool, but only if
+// the claim is currently held by claimKey. The conditional UPDATE (... WHERE id =
+// ? AND claim_key = ?) means a caller can only release its own claim: a node that
+// is unclaimed or owned by a different key is left untouched and released is
+// false. Setting claim_key back to NULL frees it for a future ClaimNode.
+func (s *Store) ReleaseNode(ctx context.Context, nodeID, claimKey string) (bool, error) {
+	res := s.db.WithContext(ctx).Model(&store.ManagedNode{}).
+		Where("id = ? AND claim_key = ?", nodeID, claimKey).
+		Updates(map[string]any{"claim_key": nil, "claimed_at": nil})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
 }
 
 // --- CommandStore ---

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -325,6 +325,14 @@ func (s *Store) nodeClaimedByKey(ctx context.Context, groupID, claimKey string) 
 
 // ClaimNode atomically assigns one unclaimed node in groupID to claimKey.
 //
+// The three identifiers have distinct roles. groupID is the id of a NodeGroup —
+// a pool of interchangeable nodes an operator has bucketed (e.g. by architecture
+// or capability, like "arm64" or "gpu-nodes"); the caller claims from a pool, not
+// a named machine. claimKey is an opaque, caller-owned label for the claim (e.g. a
+// CAPI Machine's UID) — the naming logic lives entirely on the caller's side, and
+// it need not be a secret. The returned node's own ID is the store-assigned
+// identifier of whichever node the pool handed back.
+//
 // Idempotency comes first: if claimKey already owns a node in the group, that
 // same node is returned without claiming a second one — so a controller that
 // crashed mid-provision and reconciles again re-finds its own node.
@@ -393,9 +401,14 @@ func (s *Store) ClaimNode(ctx context.Context, groupID, claimKey string) (*store
 
 // ReleaseNode clears the claim on nodeID and returns it to the pool, but only if
 // the claim is currently held by claimKey. The conditional UPDATE (... WHERE id =
-// ? AND claim_key = ?) means a caller can only release its own claim: a node that
+// ? AND claim_key = ?) ensures callers only release their own claims: a node that
 // is unclaimed or owned by a different key is left untouched and released is
 // false. Setting claim_key back to NULL frees it for a future ClaimNode.
+//
+// The claimKey match is an accident-prevention guard, not a security boundary:
+// claimKey is not a secret (any admin-authenticated caller can read it from
+// GET /nodes), so this only stops well-behaved callers from releasing each
+// other's claims by mistake — it is not an authorization control.
 func (s *Store) ReleaseNode(ctx context.Context, nodeID, claimKey string) (bool, error) {
 	res := s.db.WithContext(ctx).Model(&store.ManagedNode{}).
 		Where("id = ? AND claim_key = ?", nodeID, claimKey).

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -68,7 +68,11 @@ func (f *fakeNodeStore) SetGroup(_ context.Context, _ string, _ string) error   
 func (f *fakeNodeStore) SetLabels(_ context.Context, _ string, _ map[string]string) error {
 	return nil
 }
-func (f *fakeNodeStore) Delete(_ context.Context, _ string) error { return nil }
+func (f *fakeNodeStore) ClaimNode(_ context.Context, _, _ string) (*store.ManagedNode, error) {
+	return nil, store.ErrNoClaimCapacity
+}
+func (f *fakeNodeStore) ReleaseNode(_ context.Context, _, _ string) (bool, error) { return false, nil }
+func (f *fakeNodeStore) Delete(_ context.Context, _ string) error                 { return nil }
 
 var _ = Describe("AdminMiddleware", func() {
 	var (

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -126,6 +126,9 @@ type APIError struct {
 	StatusCode int    `json:"-"`
 	ErrorMsg   string `json:"error"`
 	Detail     string `json:"detail,omitempty"`
+	// Code is the server's stable, machine-readable discriminator (e.g.
+	// "NoCapacity", "ClaimMismatch") when several conditions share one status.
+	Code string `json:"code,omitempty"`
 }
 
 // Error implements the error interface.
@@ -155,6 +158,14 @@ func IsConflict(err error) bool {
 func IsUnauthorized(err error) bool {
 	var e *APIError
 	return errorsAs(err, &e) && e.StatusCode == http.StatusUnauthorized
+}
+
+// IsNoCapacity reports whether err is a claim rejected because the group has no
+// unclaimed node (HTTP 409, code "NoCapacity"). A caller can branch on this to
+// wait and retry rather than treat it as a hard failure.
+func IsNoCapacity(err error) bool {
+	var e *APIError
+	return errorsAs(err, &e) && e.Code == "NoCapacity"
 }
 
 // errorsAs is a tiny stdlib shim so the helpers above don't need to

--- a/pkg/client/groups.go
+++ b/pkg/client/groups.go
@@ -60,3 +60,17 @@ func (s *GroupsService) SendCommand(ctx context.Context, groupID string, req Cre
 	}
 	return out, nil
 }
+
+// Claim atomically assigns one unclaimed node in the group to claimKey and
+// returns it. It is idempotent: calling it again with the same claimKey returns
+// the same node, so a retried or restarted reconcile re-finds its own node. When
+// the group has no unclaimed node the returned error satisfies IsNoCapacity, so
+// a caller can wait for capacity instead of failing.
+func (s *GroupsService) Claim(ctx context.Context, groupID, claimKey string) (*Node, error) {
+	var out Node
+	body := map[string]string{"claimKey": claimKey}
+	if err := s.c.do(ctx, http.MethodPost, "/api/v1/groups/"+groupID+"/claim", nil, body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/pkg/client/nodes.go
+++ b/pkg/client/nodes.go
@@ -73,6 +73,21 @@ func (s *NodesService) SetGroup(ctx context.Context, nodeID, groupID string) err
 	return s.c.do(ctx, http.MethodPut, "/api/v1/nodes/"+nodeID+"/group", nil, body, nil)
 }
 
+// Release clears the node's claim, returning it to its group's pool, but only if
+// the claim is held by claimKey. released reports whether a claim was actually
+// cleared: false means the node was already unclaimed. A node claimed by a
+// different key yields an error satisfying IsConflict.
+func (s *NodesService) Release(ctx context.Context, nodeID, claimKey string) (released bool, err error) {
+	body := map[string]string{"claimKey": claimKey}
+	var out struct {
+		Released bool `json:"released"`
+	}
+	if err := s.c.do(ctx, http.MethodPost, "/api/v1/nodes/"+nodeID+"/release", nil, body, &out); err != nil {
+		return false, err
+	}
+	return out.Released, nil
+}
+
 // Heartbeat reports a periodic liveness update from a registered
 // node. Transitions the node to Online server-side.
 func (s *NodesService) Heartbeat(ctx context.Context, nodeID string, req NodeHeartbeatRequest) error {

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -32,8 +32,12 @@ type Node struct {
 	AgentVersion  string            `json:"agentVersion"`
 	OSRelease     map[string]string `json:"osRelease,omitempty"`
 	Labels        map[string]string `json:"labels,omitempty"`
-	CreatedAt     time.Time         `json:"createdAt"`
-	UpdatedAt     time.Time         `json:"updatedAt"`
+	// ClaimKey is the opaque key that has claimed this node (nil when unclaimed);
+	// ClaimedAt is when it was claimed. See GroupsService.Claim.
+	ClaimKey  *string    `json:"claimKey,omitempty"`
+	ClaimedAt *time.Time `json:"claimedAt,omitempty"`
+	CreatedAt time.Time  `json:"createdAt"`
+	UpdatedAt time.Time  `json:"updatedAt"`
 }
 
 // Group is a logical bucket of nodes (environment, cluster, role...).

--- a/pkg/handlers/api_dto.go
+++ b/pkg/handlers/api_dto.go
@@ -19,11 +19,44 @@ import (
 // --- Error envelope ---
 
 // APIError is the standard error body returned when a handler rejects a
-// request.
+// request. Code is an optional stable, machine-readable discriminator (e.g.
+// "NoCapacity") that lets a programmatic client branch on the specific
+// condition without parsing the human-facing Error text.
 type APIError struct {
 	Error  string `json:"error"`
 	Detail string `json:"detail,omitempty"`
+	Code   string `json:"code,omitempty"`
 }
+
+// --- Node claim (kairos-io/kairos#4252) ---
+
+// APIClaimRequest is the JSON body of POST /api/v1/groups/:id/claim. ClaimKey is
+// an opaque, caller-owned identifier (e.g. a CAPI machine's UID): re-issuing a
+// claim with the same key returns the same node, which is what makes a
+// level-triggered reconcile safe.
+type APIClaimRequest struct {
+	ClaimKey string `json:"claimKey" example:"machine-abc123"`
+}
+
+// APIReleaseRequest is the JSON body of POST /api/v1/nodes/:nodeID/release. The
+// claim is only cleared if it is currently held by ClaimKey.
+type APIReleaseRequest struct {
+	ClaimKey string `json:"claimKey" example:"machine-abc123"`
+}
+
+// APIReleaseResponse reports whether the release cleared a claim. Released is
+// false (with 200) when the node was already unclaimed — release is idempotent.
+type APIReleaseResponse struct {
+	Released bool `json:"released"`
+}
+
+// ClaimErrorCodeNoCapacity is the APIError.Code returned (with HTTP 409) when a
+// claim finds no unclaimed node in the group.
+const ClaimErrorCodeNoCapacity = "NoCapacity"
+
+// ClaimErrorCodeClaimMismatch is the APIError.Code returned (with HTTP 409) when
+// a release names a node that is claimed by a different key.
+const ClaimErrorCodeClaimMismatch = "ClaimMismatch"
 
 // --- Nodes ---
 

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/kairos-io/AuroraBoot/pkg/builder"
 	"github.com/kairos-io/AuroraBoot/pkg/store"
@@ -172,6 +173,41 @@ func (f *fakeNodeStore) SetLabels(_ context.Context, nodeID string, labels map[s
 		}
 	}
 	return fmt.Errorf("not found")
+}
+
+func (f *fakeNodeStore) ClaimNode(_ context.Context, groupID, claimKey string) (*store.ManagedNode, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Idempotent replay: this key already owns a node in the group.
+	for _, n := range f.nodes {
+		if n.GroupID == groupID && n.ClaimKey != nil && *n.ClaimKey == claimKey {
+			return n, nil
+		}
+	}
+	// Claim the first unclaimed node in the group.
+	for _, n := range f.nodes {
+		if n.GroupID == groupID && n.ClaimKey == nil {
+			key := claimKey
+			now := time.Now()
+			n.ClaimKey = &key
+			n.ClaimedAt = &now
+			return n, nil
+		}
+	}
+	return nil, store.ErrNoClaimCapacity
+}
+
+func (f *fakeNodeStore) ReleaseNode(_ context.Context, nodeID, claimKey string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range f.nodes {
+		if n.ID == nodeID && n.ClaimKey != nil && *n.ClaimKey == claimKey {
+			n.ClaimKey = nil
+			n.ClaimedAt = nil
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (f *fakeNodeStore) Delete(_ context.Context, id string) error {

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -378,9 +379,119 @@ func (h *NodeHandler) SetGroup(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// Claim handles POST /api/v1/groups/:id/claim.
+//
+// It atomically assigns one unclaimed node in the group to the caller-supplied
+// claimKey and returns it. The operation is idempotent: replaying with the same
+// claimKey returns the same node, so a controller that crashed mid-provision and
+// reconciles again re-finds its own node instead of grabbing a second. When the
+// group has no unclaimed node, it returns 409 with code "NoCapacity" so the
+// caller can surface "waiting for capacity" and requeue rather than treat it as
+// a hard error.
+//
+//	@Summary		Claim a node from a group
+//	@Tags			Groups
+//	@Accept			json
+//	@Produce		json
+//	@Security		AdminBearer
+//	@Param			id		path		string				true	"Group ID"
+//	@Param			body	body		APIClaimRequest		true	"Claim payload"
+//	@Success		200		{object}	store.ManagedNode
+//	@Failure		400		{object}	APIError
+//	@Failure		404		{object}	APIError
+//	@Failure		409		{object}	APIError	"No unclaimed node available (code=NoCapacity)"
+//	@Router			/api/v1/groups/{id}/claim [post]
+func (h *NodeHandler) Claim(c echo.Context) error {
+	groupID := c.Param("id")
+	ctx := c.Request().Context()
+
+	var req APIClaimRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, APIError{Error: "invalid request body"})
+	}
+	if req.ClaimKey == "" {
+		return c.JSON(http.StatusBadRequest, APIError{Error: "claimKey is required"})
+	}
+
+	// Reject an unknown group up front so the caller gets 404 rather than an
+	// indistinguishable "no capacity" for a group that does not exist.
+	if _, err := h.groups.GetByID(ctx, groupID); err != nil {
+		return c.JSON(http.StatusNotFound, APIError{Error: "group not found"})
+	}
+
+	node, err := h.nodes.ClaimNode(ctx, groupID, req.ClaimKey)
+	if err != nil {
+		if errors.Is(err, store.ErrNoClaimCapacity) {
+			return c.JSON(http.StatusConflict, APIError{
+				Error: "no unclaimed node available in group",
+				Code:  ClaimErrorCodeNoCapacity,
+			})
+		}
+		return c.JSON(http.StatusInternalServerError, APIError{Error: "failed to claim node"})
+	}
+	return c.JSON(http.StatusOK, node)
+}
+
+// Release handles POST /api/v1/nodes/:nodeID/release.
+//
+// It clears the claim on the node and returns it to the group's pool, but only
+// if the claim is currently held by the supplied claimKey. Releasing an already
+// unclaimed node is a no-op that still returns 200 with released=false
+// (idempotent). A node claimed by a DIFFERENT key returns 409 with code
+// "ClaimMismatch" so a caller cannot release someone else's claim by accident.
+//
+//	@Summary		Release a node's claim
+//	@Tags			Nodes
+//	@Accept			json
+//	@Produce		json
+//	@Security		AdminBearer
+//	@Param			nodeID	path		string				true	"Node ID"
+//	@Param			body	body		APIReleaseRequest	true	"Release payload"
+//	@Success		200		{object}	APIReleaseResponse
+//	@Failure		400		{object}	APIError
+//	@Failure		404		{object}	APIError
+//	@Failure		409		{object}	APIError	"Claimed by a different key (code=ClaimMismatch)"
+//	@Router			/api/v1/nodes/{nodeID}/release [post]
+func (h *NodeHandler) Release(c echo.Context) error {
+	nodeID := c.Param("nodeID")
+	ctx := c.Request().Context()
+
+	var req APIReleaseRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, APIError{Error: "invalid request body"})
+	}
+	if req.ClaimKey == "" {
+		return c.JSON(http.StatusBadRequest, APIError{Error: "claimKey is required"})
+	}
+
+	node, err := h.nodes.GetByID(ctx, nodeID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, APIError{Error: "node not found"})
+	}
+
+	// Already unclaimed: nothing to do, report it plainly (idempotent).
+	if node.ClaimKey == nil {
+		return c.JSON(http.StatusOK, APIReleaseResponse{Released: false})
+	}
+	// Claimed by someone else: refuse rather than silently no-op, so the caller
+	// learns it does not own this node.
+	if *node.ClaimKey != req.ClaimKey {
+		return c.JSON(http.StatusConflict, APIError{
+			Error: "node is claimed by a different key",
+			Code:  ClaimErrorCodeClaimMismatch,
+		})
+	}
+
+	released, err := h.nodes.ReleaseNode(ctx, nodeID, req.ClaimKey)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, APIError{Error: "failed to release node"})
+	}
+	return c.JSON(http.StatusOK, APIReleaseResponse{Released: released})
+}
+
 // heartbeatRequest is the expected body for a heartbeat.
 type heartbeatRequest struct {
-	AgentVersion string            `json:"agentVersion"`
+	AgentVersion string              `json:"agentVersion"`
 	OSRelease    map[string]string   `json:"osRelease"`
 	Addresses    []store.NodeAddress `json:"addresses,omitempty"`
 	BootState    string              `json:"bootState,omitempty"`

--- a/pkg/handlers/nodes_claim_test.go
+++ b/pkg/handlers/nodes_claim_test.go
@@ -1,0 +1,159 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/kairos-io/AuroraBoot/pkg/ws"
+	"github.com/labstack/echo/v4"
+)
+
+var _ = Describe("NodeHandler claim/release", func() {
+	var (
+		e       *echo.Echo
+		ns      *fakeNodeStore
+		gs      *fakeGroupStore
+		handler *handlers.NodeHandler
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		ns = &fakeNodeStore{}
+		gs = &fakeGroupStore{}
+		handler = handlers.NewNodeHandler(ns, &fakeCommandStore{}, gs, ws.NewHub(), "reg-token", "http://localhost:8080")
+	})
+
+	// claim drives POST /api/v1/groups/:id/claim and returns the recorder.
+	claim := func(groupID, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/groups/"+groupID+"/claim", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(groupID)
+		Expect(handler.Claim(c)).To(Succeed())
+		return rec
+	}
+
+	// release drives POST /api/v1/nodes/:nodeID/release.
+	release := func(nodeID, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/"+nodeID+"/release", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("nodeID")
+		c.SetParamValues(nodeID)
+		Expect(handler.Release(c)).To(Succeed())
+		return rec
+	}
+
+	Describe("Claim", func() {
+		BeforeEach(func() {
+			gs.groups = []*store.NodeGroup{{ID: "g1", Name: "prod"}}
+		})
+
+		It("claims an unclaimed node and returns it", func() {
+			ns.nodes = []*store.ManagedNode{{ID: "n1", GroupID: "g1"}}
+
+			rec := claim("g1", `{"claimKey":"machine-a"}`)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var node store.ManagedNode
+			Expect(json.Unmarshal(rec.Body.Bytes(), &node)).To(Succeed())
+			Expect(node.ID).To(Equal("n1"))
+			Expect(node.ClaimKey).NotTo(BeNil())
+			Expect(*node.ClaimKey).To(Equal("machine-a"))
+		})
+
+		It("is idempotent for the same key", func() {
+			ns.nodes = []*store.ManagedNode{{ID: "n1", GroupID: "g1"}, {ID: "n2", GroupID: "g1"}}
+
+			first := claim("g1", `{"claimKey":"machine-a"}`)
+			second := claim("g1", `{"claimKey":"machine-a"}`)
+
+			var a, b store.ManagedNode
+			Expect(json.Unmarshal(first.Body.Bytes(), &a)).To(Succeed())
+			Expect(json.Unmarshal(second.Body.Bytes(), &b)).To(Succeed())
+			Expect(b.ID).To(Equal(a.ID))
+		})
+
+		It("returns 409 NoCapacity when the group is exhausted", func() {
+			ns.nodes = []*store.ManagedNode{{ID: "n1", GroupID: "g1"}}
+			claim("g1", `{"claimKey":"machine-a"}`) // takes the only node
+
+			rec := claim("g1", `{"claimKey":"machine-b"}`)
+			Expect(rec.Code).To(Equal(http.StatusConflict))
+
+			var apiErr handlers.APIError
+			Expect(json.Unmarshal(rec.Body.Bytes(), &apiErr)).To(Succeed())
+			Expect(apiErr.Code).To(Equal(handlers.ClaimErrorCodeNoCapacity))
+		})
+
+		It("returns 404 for an unknown group", func() {
+			rec := claim("nope", `{"claimKey":"machine-a"}`)
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns 400 when claimKey is missing", func() {
+			rec := claim("g1", `{}`)
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Describe("Release", func() {
+		It("releases a claim held by the caller", func() {
+			key := "machine-a"
+			ns.nodes = []*store.ManagedNode{{ID: "n1", GroupID: "g1", ClaimKey: &key}}
+
+			rec := release("n1", `{"claimKey":"machine-a"}`)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var resp handlers.APIReleaseResponse
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.Released).To(BeTrue())
+			Expect(ns.nodes[0].ClaimKey).To(BeNil())
+		})
+
+		It("returns 409 ClaimMismatch when a different key owns the node", func() {
+			key := "machine-a"
+			ns.nodes = []*store.ManagedNode{{ID: "n1", GroupID: "g1", ClaimKey: &key}}
+
+			rec := release("n1", `{"claimKey":"machine-b"}`)
+			Expect(rec.Code).To(Equal(http.StatusConflict))
+
+			var apiErr handlers.APIError
+			Expect(json.Unmarshal(rec.Body.Bytes(), &apiErr)).To(Succeed())
+			Expect(apiErr.Code).To(Equal(handlers.ClaimErrorCodeClaimMismatch))
+			Expect(ns.nodes[0].ClaimKey).NotTo(BeNil()) // untouched
+		})
+
+		It("is a no-op (released=false, 200) on an unclaimed node", func() {
+			ns.nodes = []*store.ManagedNode{{ID: "n1", GroupID: "g1"}}
+
+			rec := release("n1", `{"claimKey":"machine-a"}`)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+
+			var resp handlers.APIReleaseResponse
+			Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp.Released).To(BeFalse())
+		})
+
+		It("returns 404 for a missing node", func() {
+			rec := release("ghost", `{"claimKey":"machine-a"}`)
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns 400 when claimKey is missing", func() {
+			ns.nodes = []*store.ManagedNode{{ID: "n1", GroupID: "g1"}}
+			rec := release("n1", `{}`)
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -230,6 +230,7 @@ func New(cfg Config) *echo.Echo {
 	adminGroup.POST("/nodes/:nodeID/decommission", nodeHandler.Decommission)
 	adminGroup.PUT("/nodes/:nodeID/labels", nodeHandler.SetLabels)
 	adminGroup.PUT("/nodes/:nodeID/group", nodeHandler.SetGroup)
+	adminGroup.POST("/nodes/:nodeID/release", nodeHandler.Release)
 	// GET /nodes/:nodeID/commands and PUT .../commands/:commandID/status are
 	// served by the shared agent-or-admin group above (single registration to
 	// avoid Echo route shadowing); they branch on the caller's identity.
@@ -244,6 +245,7 @@ func New(cfg Config) *echo.Echo {
 	adminGroup.GET("/groups/:id", groupHandler.Get)
 	adminGroup.PUT("/groups/:id", groupHandler.Update)
 	adminGroup.DELETE("/groups/:id", groupHandler.Delete)
+	adminGroup.POST("/groups/:id/claim", nodeHandler.Claim)
 	adminGroup.POST("/groups/:id/commands", cmdHandler.CreateForGroup)
 
 	// Artifact management

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -79,7 +79,11 @@ func (f *fakeNodeStore) SetGroup(_ context.Context, _ string, _ string) error   
 func (f *fakeNodeStore) SetLabels(_ context.Context, _ string, _ map[string]string) error {
 	return nil
 }
-func (f *fakeNodeStore) Delete(_ context.Context, _ string) error { return nil }
+func (f *fakeNodeStore) ClaimNode(_ context.Context, _, _ string) (*store.ManagedNode, error) {
+	return nil, store.ErrNoClaimCapacity
+}
+func (f *fakeNodeStore) ReleaseNode(_ context.Context, _, _ string) (bool, error) { return false, nil }
+func (f *fakeNodeStore) Delete(_ context.Context, _ string) error                 { return nil }
 
 type fakeCommandStore struct {
 	mu   sync.Mutex

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -12,6 +12,12 @@ import (
 // non-existent command.
 var ErrCommandNotFound = errors.New("command not found")
 
+// ErrNoClaimCapacity is returned by NodeStore.ClaimNode when the target group
+// has no unclaimed node available. It is a distinct, expected outcome — not a
+// failure — so a caller (e.g. a CAPI infrastructure provider) can surface
+// "waiting for capacity" and requeue instead of treating it as an error.
+var ErrNoClaimCapacity = errors.New("no unclaimed node available in group")
+
 // NodeGroup represents a logical group/environment for nodes (e.g., "production", "staging").
 type NodeGroup struct {
 	ID          string    `json:"id" gorm:"primaryKey"`
@@ -41,7 +47,7 @@ type ManagedNode struct {
 	ID            string            `json:"id" gorm:"primaryKey"`
 	MachineID     string            `json:"machineID" gorm:"uniqueIndex"`
 	Hostname      string            `json:"hostname"`
-	GroupID       string            `json:"groupID" gorm:"index"`
+	GroupID       string            `json:"groupID" gorm:"index;index:idx_node_group_claim,unique,priority:1"`
 	Group         *NodeGroup        `json:"group,omitempty" gorm:"foreignKey:GroupID;constraint:OnDelete:SET NULL"`
 	Phase         string            `json:"phase"`
 	LastHeartbeat *time.Time        `json:"lastHeartbeat"`
@@ -56,10 +62,21 @@ type ManagedNode struct {
 	// that booted the passive image signals a broken active image). Known values:
 	// active | passive | recovery | autoreset — but unknown values are accepted
 	// and stored as-is so future boot states pass through without a server change.
-	BootState string    `json:"bootState,omitempty"`
-	APIKey    string    `json:"-" gorm:"index"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	BootState string `json:"bootState,omitempty"`
+	// ClaimKey, when non-nil, is the opaque caller-owned key that has claimed this
+	// node via POST /api/v1/groups/:id/claim (e.g. a CAPI machine's identity). A
+	// nil ClaimKey means the node is unclaimed and available. It is a pointer, not
+	// a string, on purpose: "unclaimed" must be SQL NULL, because the composite
+	// unique index idx_node_group_claim on (group_id, claim_key) makes a claimKey
+	// own at most one node per group, and NULLs are exempt from unique indexes on
+	// both SQLite and PostgreSQL — so many unclaimed nodes coexist while a second
+	// node can never take an already-used claimKey in the same group.
+	ClaimKey *string `json:"claimKey,omitempty" gorm:"index:idx_node_group_claim,unique,priority:2"`
+	// ClaimedAt is when ClaimKey was set; nil when unclaimed.
+	ClaimedAt *time.Time `json:"claimedAt,omitempty"`
+	APIKey    string     `json:"-" gorm:"index"`
+	CreatedAt time.Time  `json:"createdAt"`
+	UpdatedAt time.Time  `json:"updatedAt"`
 }
 
 // Node phases.
@@ -135,6 +152,21 @@ type NodeStore interface {
 	UpdatePhase(ctx context.Context, id string, phase string) error
 	SetGroup(ctx context.Context, nodeID string, groupID string) error
 	SetLabels(ctx context.Context, nodeID string, labels map[string]string) error
+	// ClaimNode atomically assigns one unclaimed node in groupID to claimKey and
+	// returns it. It is idempotent: re-issuing with the same (groupID, claimKey)
+	// returns the SAME node, never a second one — which is what makes a
+	// level-triggered CAPI reconcile safe across controller restarts and retries.
+	// Concurrent claims are arbitrated by the store so two callers never receive
+	// the same node. Returns ErrNoClaimCapacity when the group has no unclaimed
+	// node available.
+	ClaimNode(ctx context.Context, groupID, claimKey string) (*ManagedNode, error)
+	// ReleaseNode clears the claim on nodeID, returning it to the group's pool for
+	// reuse, but only if the claim is currently held by claimKey. released reports
+	// whether a claim was actually cleared: (false, nil) means the node was not
+	// claimed by this key (it is already free, or owned by a different key). The
+	// caller inspects the node to distinguish those and must not assume ownership
+	// from a false result.
+	ReleaseNode(ctx context.Context, nodeID, claimKey string) (released bool, err error)
 	Delete(ctx context.Context, id string) error
 }
 
@@ -163,45 +195,45 @@ type CommandStore interface {
 
 // ArtifactRecord stores a build artifact and its metadata.
 type ArtifactRecord struct {
-	ID                      string    `json:"id" gorm:"primaryKey"`
-	Name                    string    `json:"name,omitempty"`
-	Saved                   bool      `json:"saved,omitempty"`
-	Phase                   string    `json:"phase"`
-	Message                 string    `json:"message"`
-	BaseImage               string    `json:"baseImage"`
-	KairosVersion           string    `json:"kairosVersion"`
-	Model                   string    `json:"model"`
-	ISO                     bool      `json:"iso"`
-	CloudImage              bool      `json:"cloudImage"`
-	Netboot                 bool      `json:"netboot"`
-	FIPS                    bool      `json:"fips"`
-	TrustedBoot             bool      `json:"trustedBoot"`
-	Arch                    string    `json:"arch,omitempty"`
-	Variant                 string    `json:"variant,omitempty"`
-	AllowInsecureRegistries bool      `json:"allow-insecure-registries" gorm:"column:insecure"`
-	RawDisk                 bool      `json:"rawDisk"`
-	Tar                     bool      `json:"tar"`
-	GCE                     bool      `json:"gce"`
-	VHD                     bool      `json:"vhd"`
-	MAAS                    bool      `json:"maas"`
-	UKI                     bool      `json:"uki"`
-	KairosInitImage         string    `json:"kairosInitImage,omitempty"`
-	AutoInstall             bool      `json:"autoInstall"`
-	RegisterAuroraBoot      bool      `json:"registerAuroraBoot"`
-	Dockerfile              string    `json:"dockerfile,omitempty"`
-	HadronBase              string    `json:"hadronBase,omitempty"`
-	HadronFirmware          []string  `json:"hadronFirmware,omitempty" gorm:"serializer:json"`
-	HadronLayers            []string  `json:"hadronLayers,omitempty" gorm:"serializer:json"`
-	HadronExtra             string    `json:"hadronExtra,omitempty" gorm:"type:text"`
-	CloudConfig             string    `json:"cloudConfig,omitempty" gorm:"type:text"`
-	KubernetesDistro        string    `json:"kubernetesDistro,omitempty"`
-	KubernetesVersion       string    `json:"kubernetesVersion,omitempty"`
-	KubernetesEnabled       *bool     `json:"kubernetesEnabled,omitempty"`
-	TargetGroupID           string    `json:"targetGroupId,omitempty"`
-	ContainerImage          string    `json:"containerImage,omitempty"`
-	OverlayRootfs           string    `json:"overlayRootfs,omitempty"`
-	ArtifactFiles           []string  `json:"artifacts" gorm:"serializer:json"`
-	Logs                    string    `json:"-" gorm:"type:text"`
+	ID                      string   `json:"id" gorm:"primaryKey"`
+	Name                    string   `json:"name,omitempty"`
+	Saved                   bool     `json:"saved,omitempty"`
+	Phase                   string   `json:"phase"`
+	Message                 string   `json:"message"`
+	BaseImage               string   `json:"baseImage"`
+	KairosVersion           string   `json:"kairosVersion"`
+	Model                   string   `json:"model"`
+	ISO                     bool     `json:"iso"`
+	CloudImage              bool     `json:"cloudImage"`
+	Netboot                 bool     `json:"netboot"`
+	FIPS                    bool     `json:"fips"`
+	TrustedBoot             bool     `json:"trustedBoot"`
+	Arch                    string   `json:"arch,omitempty"`
+	Variant                 string   `json:"variant,omitempty"`
+	AllowInsecureRegistries bool     `json:"allow-insecure-registries" gorm:"column:insecure"`
+	RawDisk                 bool     `json:"rawDisk"`
+	Tar                     bool     `json:"tar"`
+	GCE                     bool     `json:"gce"`
+	VHD                     bool     `json:"vhd"`
+	MAAS                    bool     `json:"maas"`
+	UKI                     bool     `json:"uki"`
+	KairosInitImage         string   `json:"kairosInitImage,omitempty"`
+	AutoInstall             bool     `json:"autoInstall"`
+	RegisterAuroraBoot      bool     `json:"registerAuroraBoot"`
+	Dockerfile              string   `json:"dockerfile,omitempty"`
+	HadronBase              string   `json:"hadronBase,omitempty"`
+	HadronFirmware          []string `json:"hadronFirmware,omitempty" gorm:"serializer:json"`
+	HadronLayers            []string `json:"hadronLayers,omitempty" gorm:"serializer:json"`
+	HadronExtra             string   `json:"hadronExtra,omitempty" gorm:"type:text"`
+	CloudConfig             string   `json:"cloudConfig,omitempty" gorm:"type:text"`
+	KubernetesDistro        string   `json:"kubernetesDistro,omitempty"`
+	KubernetesVersion       string   `json:"kubernetesVersion,omitempty"`
+	KubernetesEnabled       *bool    `json:"kubernetesEnabled,omitempty"`
+	TargetGroupID           string   `json:"targetGroupId,omitempty"`
+	ContainerImage          string   `json:"containerImage,omitempty"`
+	OverlayRootfs           string   `json:"overlayRootfs,omitempty"`
+	ArtifactFiles           []string `json:"artifacts" gorm:"serializer:json"`
+	Logs                    string   `json:"-" gorm:"type:text"`
 	// UploadToken holds the sha256 hex digest of the per-build bearer the
 	// operator backend's exporter Job uses to PUT /api/v1/artifacts/:id/upload/:file.
 	// The plaintext token is minted by the handler on Create, injected into
@@ -210,9 +242,9 @@ type ArtifactRecord struct {
 	// compares it against this digest, so DB read access (backup, SQLite
 	// file, SQLi elsewhere) does not surface live write tokens. The JSON
 	// tag stays "-" so nothing here is serialized to clients regardless.
-	UploadToken string `json:"-"`
-	CreatedAt               time.Time `json:"createdAt"`
-	UpdatedAt               time.Time `json:"updatedAt"`
+	UploadToken string    `json:"-"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 // Artifact phases.


### PR DESCRIPTION
## Summary

Adds an **atomic, idempotent node-claim endpoint** to the fleet API — the last hard plumbing blocker for building a Cluster API **infrastructure provider** on AuroraBoot (kairos-io/kairos#4252, epic kairos-io/kairos#120 / #4056).

Today the only ways to assign a group's node to something (`PUT /nodes/:id/group`, `PUT /nodes/:id/labels`) are last-write-wins with no compare-and-swap. That is unsafe for CAPI, whose reconcile is **level-triggered and retried**: a controller can crash mid-provision and reconcile the same machine again (must re-find *its own* node, not grab a second), and two machines reconciling concurrently can select the same node with no server-side arbitration.

## What's here

**`POST /api/v1/groups/:id/claim` `{ "claimKey": "<opaque caller key>" }`**
- Atomically assigns one **unclaimed** node in the group to `claimKey` and returns it.
- **Idempotent:** replaying with the same `claimKey` returns the **same** node, never a second — this is what makes a retried/restarted reconcile safe.
- Unknown group → `404` (told apart from capacity). Exhausted group → `409` with a machine-readable `code: "NoCapacity"` so the caller can surface "waiting for capacity" and requeue instead of failing.

**`POST /api/v1/nodes/:nodeID/release` `{ "claimKey": "..." }`**
- Returns the node to the pool for reuse, but only for the key that holds the claim.
- Already-unclaimed → `200 {released:false}` (idempotent). Held by a **different** key → `409 code:"ClaimMismatch"` so a caller can't drop someone else's claim.

The claim owner (`claimKey`/`claimedAt`) now surfaces in `GET /nodes` and `GET /nodes/:id`.

## Design

- `ManagedNode` gains `ClaimKey *string` + `ClaimedAt *time.Time`. `ClaimKey` is a **pointer** so "unclaimed" is SQL `NULL`: a composite **unique index** `idx_node_group_claim` on `(group_id, claim_key)` then makes a claimKey own **at most one** node per group, while `NULL`-exempt uniqueness lets many unclaimed nodes coexist — true on **both SQLite and PostgreSQL**.
- `NodeStore.ClaimNode` mirrors the store's existing compare-and-set idiom (`ClaimForDelivery`, `CASEjectState`): idempotent replay first, then a conditional `UPDATE ... WHERE id = ? AND claim_key IS NULL` over a bounded snapshot of unclaimed candidates. Exactly one of several concurrent callers wins a given node; a concurrent **same-key** claim is caught by the unique index (`ErrDuplicatedKey`, via newly-enabled gorm `TranslateError`) and resolved to the first winner. **No `FOR UPDATE` / `SKIP LOCKED`**, so it's correct on both drivers.
- Go client: `Groups.Claim`, `Nodes.Release`, and a `client.IsNoCapacity(err)` helper. OpenAPI spec regenerated via `make openapi` (additive only).

## Tests

Store-level (Ginkgo, file-backed WAL SQLite): idempotent replay, distinct-key isolation, no-capacity, cross-group isolation, release ownership, and two **concurrency invariants** — N distinct keys over M nodes yield exactly M single-winner claims plus N−M clean no-capacity results, and N concurrent same-key claims all return the one node. **Race-clean** under `-race`. Handler-level: claim success/idempotency/no-capacity/unknown-group/missing-key and release success/mismatch/no-op/missing-node/missing-key.

Backward compatible: the new columns default to `NULL`, and no existing behaviour changes.

Filed against kairos-io/kairos#4252 (issues are disabled on this repo).
