### PR TITLE
fix(raw-disk): make recovery image size configurable

### DIFF
--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -25,4 +25,12 @@ var _ = Describe("LoadByte", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg.AllowInsecureRegistriesBool()).To(BeFalse())
 	})
+
+	It("reads raw disk size overrides", func() {
+		cfg, _, err := deployer.LoadByte([]byte("disk:\n  size: \"65000\"\n  state_size: \"30000\"\n  system_size: \"12000\"\n"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg.Disk.Size).To(Equal("65000"))
+		Expect(cfg.Disk.StateSize).To(Equal("30000"))
+		Expect(cfg.Disk.SystemSize).To(Equal("12000"))
+	})
 })

--- a/deployer/deployer_test.go
+++ b/deployer/deployer_test.go
@@ -27,10 +27,10 @@ var _ = Describe("LoadByte", func() {
 	})
 
 	It("reads raw disk size overrides", func() {
-		cfg, _, err := deployer.LoadByte([]byte("disk:\n  size: \"65000\"\n  state_size: \"30000\"\n  system_size: \"12000\"\n"))
+		cfg, _, err := deployer.LoadByte([]byte("disk:\n  size: \"65000\"\n  state_size: \"30000\"\n  recovery_image_size: \"12000\"\n"))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfg.Disk.Size).To(Equal("65000"))
 		Expect(cfg.Disk.StateSize).To(Equal("30000"))
-		Expect(cfg.Disk.SystemSize).To(Equal("12000"))
+		Expect(cfg.Disk.RecoveryImageSize).To(Equal("12000"))
 	})
 })

--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -147,14 +147,14 @@ func (d *Deployer) StepGenRawDisk() error {
 			return d.Config.Disk.EFI || d.Config.Disk.GCE || d.Config.Disk.VHD || d.Config.Disk.Partitions || d.Config.Disk.MAAS
 		}),
 		herd.WithDeps(constants.OpDumpSource),
-		herd.WithCallback(ops.GenEFIRawDisk(d.tmpRootFs(), d.rawDiskPath(), d.rawDiskSize(), d.rawDiskStateSize(), d.rawDiskSystemSize(), d.Config.NoDefaultCloudConfig, d.Config.Disk.Partitions, d.Config.Disk.MAAS)))
+		herd.WithCallback(ops.GenEFIRawDisk(d.tmpRootFs(), d.rawDiskPath(), d.rawDiskSize(), d.rawDiskStateSize(), d.rawDiskRecoveryImageSize(), d.Config.NoDefaultCloudConfig, d.Config.Disk.Partitions, d.Config.Disk.MAAS)))
 }
 
 func (d *Deployer) StepGenMBRRawDisk() error {
 	return d.Add(constants.OpGenBIOSRawDisk,
 		herd.EnableIf(func() bool { return d.Config.Disk.BIOS }),
 		herd.WithDeps(constants.OpDumpSource),
-		herd.WithCallback(ops.GenBiosRawDisk(d.tmpRootFs(), d.rawDiskPath(), d.rawDiskSize(), d.rawDiskStateSize(), d.rawDiskSystemSize(), d.Config.NoDefaultCloudConfig)))
+		herd.WithCallback(ops.GenBiosRawDisk(d.tmpRootFs(), d.rawDiskPath(), d.rawDiskSize(), d.rawDiskStateSize(), d.rawDiskRecoveryImageSize(), d.Config.NoDefaultCloudConfig)))
 }
 
 func (d *Deployer) StepConvertGCE() error {
@@ -379,13 +379,13 @@ func (d *Deployer) rawDiskStateSize() int64 {
 	return sizeInt
 }
 
-func (d *Deployer) rawDiskSystemSize() int64 {
-	if d.Config.Disk.SystemSize == "" {
+func (d *Deployer) rawDiskRecoveryImageSize() int64 {
+	if d.Config.Disk.RecoveryImageSize == "" {
 		return 0
 	}
-	sizeInt, err := strconv.ParseInt(d.Config.Disk.SystemSize, 10, 64)
+	sizeInt, err := strconv.ParseInt(d.Config.Disk.RecoveryImageSize, 10, 64)
 	if err != nil {
-		d.Log.Logger.Error().Err(err).Str("arg", d.Config.Disk.SystemSize).Msg("Failed to parse disk system size, setting value to 0")
+		d.Log.Logger.Error().Err(err).Str("arg", d.Config.Disk.RecoveryImageSize).Msg("Failed to parse disk recovery image size, setting value to 0")
 		return 0
 	}
 	return sizeInt

--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -147,14 +147,14 @@ func (d *Deployer) StepGenRawDisk() error {
 			return d.Config.Disk.EFI || d.Config.Disk.GCE || d.Config.Disk.VHD || d.Config.Disk.Partitions || d.Config.Disk.MAAS
 		}),
 		herd.WithDeps(constants.OpDumpSource),
-		herd.WithCallback(ops.GenEFIRawDisk(d.tmpRootFs(), d.rawDiskPath(), d.rawDiskSize(), d.rawDiskStateSize(), d.Config.NoDefaultCloudConfig, d.Config.Disk.Partitions, d.Config.Disk.MAAS)))
+		herd.WithCallback(ops.GenEFIRawDisk(d.tmpRootFs(), d.rawDiskPath(), d.rawDiskSize(), d.rawDiskStateSize(), d.rawDiskSystemSize(), d.Config.NoDefaultCloudConfig, d.Config.Disk.Partitions, d.Config.Disk.MAAS)))
 }
 
 func (d *Deployer) StepGenMBRRawDisk() error {
 	return d.Add(constants.OpGenBIOSRawDisk,
 		herd.EnableIf(func() bool { return d.Config.Disk.BIOS }),
 		herd.WithDeps(constants.OpDumpSource),
-		herd.WithCallback(ops.GenBiosRawDisk(d.tmpRootFs(), d.rawDiskPath(), d.rawDiskSize(), d.rawDiskStateSize(), d.Config.NoDefaultCloudConfig)))
+		herd.WithCallback(ops.GenBiosRawDisk(d.tmpRootFs(), d.rawDiskPath(), d.rawDiskSize(), d.rawDiskStateSize(), d.rawDiskSystemSize(), d.Config.NoDefaultCloudConfig)))
 }
 
 func (d *Deployer) StepConvertGCE() error {
@@ -374,6 +374,18 @@ func (d *Deployer) rawDiskStateSize() int64 {
 	sizeInt, err := strconv.ParseInt(d.Config.Disk.StateSize, 10, 64)
 	if err != nil {
 		d.Log.Logger.Error().Err(err).Str("arg", d.Config.Disk.StateSize).Msg("Failed to parse disk state size, setting value to 0")
+		return 0
+	}
+	return sizeInt
+}
+
+func (d *Deployer) rawDiskSystemSize() int64 {
+	if d.Config.Disk.SystemSize == "" {
+		return 0
+	}
+	sizeInt, err := strconv.ParseInt(d.Config.Disk.SystemSize, 10, 64)
+	if err != nil {
+		d.Log.Logger.Error().Err(err).Str("arg", d.Config.Disk.SystemSize).Msg("Failed to parse disk system size, setting value to 0")
 		return 0
 	}
 	return sizeInt

--- a/pkg/ops/disks.go
+++ b/pkg/ops/disks.go
@@ -10,12 +10,12 @@ import (
 	"github.com/kairos-io/kairos-sdk/utils"
 )
 
-func GenEFIRawDisk(src, dst string, size uint64, stateSize, systemSize int64, noDefaultCloudConfig, separatePartitionsImages, maas bool) func(ctx context.Context) error {
+func GenEFIRawDisk(src, dst string, size uint64, stateSize, recoveryImageSize int64, noDefaultCloudConfig, separatePartitionsImages, maas bool) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		internal.Log.Logger.Info().Msgf("Generating raw disk '%s' from '%s' with final size %dMb", dst, src, size)
 		// TODO: We need to talk about how the config.yaml is magically here no? is done in a previous step but maybe we should have constant that we can check?
 		// Maybe on its own function that returns the tmpdir + config.yaml or something? we need a safe way of accessing it form any step in the DAG.
-		raw := NewEFIRawImage(src, dst, filepath.Join(dst, "config.yaml"), size, stateSize, systemSize, noDefaultCloudConfig)
+		raw := NewEFIRawImage(src, dst, filepath.Join(dst, "config.yaml"), size, stateSize, recoveryImageSize, noDefaultCloudConfig)
 		raw.SeparatePartitionsImages = separatePartitionsImages
 		raw.maas = maas
 		err := raw.Build()
@@ -26,12 +26,12 @@ func GenEFIRawDisk(src, dst string, size uint64, stateSize, systemSize int64, no
 	}
 }
 
-func GenBiosRawDisk(src, dst string, size uint64, stateSize, systemSize int64, noDefaultCloudConfig bool) func(ctx context.Context) error {
+func GenBiosRawDisk(src, dst string, size uint64, stateSize, recoveryImageSize int64, noDefaultCloudConfig bool) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		internal.Log.Logger.Info().Msgf("Generating raw disk '%s' from '%s' with final size %dMb", dst, src, size)
 		// TODO: We need to talk about how the config.yaml is magically here no? is done in a previous step but maybe we should have constant that we can check?
 		// Maybe on its own function that returns the tmpdir + config.yaml or something? we need a safe way of accessing it form any step in the DAG.
-		raw := NewBiosRawImage(src, dst, filepath.Join(dst, "config.yaml"), size, stateSize, systemSize, noDefaultCloudConfig)
+		raw := NewBiosRawImage(src, dst, filepath.Join(dst, "config.yaml"), size, stateSize, recoveryImageSize, noDefaultCloudConfig)
 		err := raw.Build()
 		if err != nil {
 			internal.Log.Logger.Error().Msgf("Generating raw disk '%s' from '%s' failed with error '%s'", dst, src, err.Error())

--- a/pkg/ops/disks.go
+++ b/pkg/ops/disks.go
@@ -10,12 +10,12 @@ import (
 	"github.com/kairos-io/kairos-sdk/utils"
 )
 
-func GenEFIRawDisk(src, dst string, size uint64, stateSize int64, noDefaultCloudConfig, separatePartitionsImages, maas bool) func(ctx context.Context) error {
+func GenEFIRawDisk(src, dst string, size uint64, stateSize, systemSize int64, noDefaultCloudConfig, separatePartitionsImages, maas bool) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		internal.Log.Logger.Info().Msgf("Generating raw disk '%s' from '%s' with final size %dMb", dst, src, size)
 		// TODO: We need to talk about how the config.yaml is magically here no? is done in a previous step but maybe we should have constant that we can check?
 		// Maybe on its own function that returns the tmpdir + config.yaml or something? we need a safe way of accessing it form any step in the DAG.
-		raw := NewEFIRawImage(src, dst, filepath.Join(dst, "config.yaml"), size, stateSize, noDefaultCloudConfig)
+		raw := NewEFIRawImage(src, dst, filepath.Join(dst, "config.yaml"), size, stateSize, systemSize, noDefaultCloudConfig)
 		raw.SeparatePartitionsImages = separatePartitionsImages
 		raw.maas = maas
 		err := raw.Build()
@@ -26,12 +26,12 @@ func GenEFIRawDisk(src, dst string, size uint64, stateSize int64, noDefaultCloud
 	}
 }
 
-func GenBiosRawDisk(src, dst string, size uint64, stateSize int64, noDefaultCloudConfig bool) func(ctx context.Context) error {
+func GenBiosRawDisk(src, dst string, size uint64, stateSize, systemSize int64, noDefaultCloudConfig bool) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		internal.Log.Logger.Info().Msgf("Generating raw disk '%s' from '%s' with final size %dMb", dst, src, size)
 		// TODO: We need to talk about how the config.yaml is magically here no? is done in a previous step but maybe we should have constant that we can check?
 		// Maybe on its own function that returns the tmpdir + config.yaml or something? we need a safe way of accessing it form any step in the DAG.
-		raw := NewBiosRawImage(src, dst, filepath.Join(dst, "config.yaml"), size, stateSize, noDefaultCloudConfig)
+		raw := NewBiosRawImage(src, dst, filepath.Join(dst, "config.yaml"), size, stateSize, systemSize, noDefaultCloudConfig)
 		err := raw.Build()
 		if err != nil {
 			internal.Log.Logger.Error().Msgf("Generating raw disk '%s' from '%s' failed with error '%s'", dst, src, err.Error())

--- a/pkg/ops/partitions_test.go
+++ b/pkg/ops/partitions_test.go
@@ -20,7 +20,7 @@ var _ = Describe("RawImage emitPartitionImages", Label("raw"), func() {
 	BeforeEach(func() {
 		out = GinkgoT().TempDir()
 		src := GinkgoT().TempDir()
-		r = NewEFIRawImage(src, out, "", 0, 0, true)
+		r = NewEFIRawImage(src, out, "", 0, 0, 0, true)
 		r.SeparatePartitionsImages = true
 
 		// Stand-in partition images already built in the temp dir.

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -47,7 +47,7 @@ type RawImage struct {
 	Output               string               // Output image destination dir. Final image name will be based on the contents of the source /etc/kairos-release file
 	FinalSize            uint64               // Final size of the disk image in MB
 	StateSize            int64                // Size of the state partition in MB
-	SystemSize           int64                // Size of the system image in MB
+	RecoveryImageSize    int64                // Size of the recovery image in MB
 	tmpDir               string               // A temp dir to do all work on
 	elemental            *elemental.Elemental // Elemental instance to use for the operations
 	efi                  bool                 // If the image should be EFI or BIOS
@@ -62,7 +62,7 @@ type RawImage struct {
 
 // NewEFIRawImage creates a new RawImage struct
 // config is initialized with a default config to use the standard logger
-func NewEFIRawImage(source, output, cc string, finalsize uint64, stateSize, systemSize int64, noDefaultCloudConfig bool) *RawImage {
+func NewEFIRawImage(source, output, cc string, finalsize uint64, stateSize, recoveryImageSize int64, noDefaultCloudConfig bool) *RawImage {
 	cfg := config.NewConfig(config.WithLogger(internal.Log))
 	return &RawImage{
 		efi:                  true,
@@ -73,12 +73,12 @@ func NewEFIRawImage(source, output, cc string, finalsize uint64, stateSize, syst
 		CloudConfig:          cc,
 		FinalSize:            finalsize,
 		StateSize:            stateSize,
-		SystemSize:           systemSize,
+		RecoveryImageSize:    recoveryImageSize,
 		NoDefaultCloudConfig: noDefaultCloudConfig,
 	}
 }
 
-func NewBiosRawImage(source, output string, cc string, finalsize uint64, stateSize, systemSize int64, noDefaultCloudConfig bool) *RawImage {
+func NewBiosRawImage(source, output string, cc string, finalsize uint64, stateSize, recoveryImageSize int64, noDefaultCloudConfig bool) *RawImage {
 	cfg := config.NewConfig(config.WithLogger(internal.Log))
 	return &RawImage{efi: false,
 		config:               cfg,
@@ -88,7 +88,7 @@ func NewBiosRawImage(source, output string, cc string, finalsize uint64, stateSi
 		CloudConfig:          cc,
 		FinalSize:            finalsize,
 		StateSize:            stateSize,
-		SystemSize:           systemSize,
+		RecoveryImageSize:    recoveryImageSize,
 		NoDefaultCloudConfig: noDefaultCloudConfig,
 	}
 }
@@ -342,9 +342,12 @@ func (r *RawImage) createRecoveryPartitionImage() (string, error) {
 		MountPoint: tmpDirRecoveryImage,
 	}
 	size, _ := config.GetSourceSize(r.config, recoveryImage.Source)
-	recoveryImage.Size = systemImageSize(uint64(size), r.SystemSize)
-	if r.SystemSize > 0 {
-		internal.Log.Logger.Info().Int64("size", r.SystemSize).Msg("Using configured system image size")
+	recoveryImage.Size, err = recoveryImageSize(uint64(size), r.RecoveryImageSize)
+	if err != nil {
+		return "", err
+	}
+	if r.RecoveryImageSize > 0 {
+		internal.Log.Logger.Info().Int64("size", r.RecoveryImageSize).Msg("Using configured recovery image size")
 	}
 
 	_, err = r.elemental.DeployImage(recoveryImage, false)
@@ -404,17 +407,20 @@ func (r *RawImage) createRecoveryPartitionImage() (string, error) {
 
 }
 
-func systemImageSize(sourceSize uint64, configuredSize int64) uint {
+func recoveryImageSize(sourceSize uint64, configuredSize int64) (uint, error) {
 	if configuredSize > 0 {
-		return uint(configuredSize)
+		if uint64(configuredSize) < sourceSize {
+			return 0, fmt.Errorf("configured recovery image size %d MB is smaller than source size %d MB", configuredSize, sourceSize)
+		}
+		return uint(configuredSize), nil
 	}
-	return uint(sourceSize + 200)
+	return uint(sourceSize + 200), nil
 }
 
-func recoveryPartitionSize(systemSize uint) uint {
+func recoveryPartitionSize(recoveryImageSize uint) uint {
 	// The partition must hold both the recovery image and a transition image
 	// during recovery upgrades, plus space for copied boot artifacts.
-	return systemSize*2 + 150
+	return recoveryImageSize*2 + 150
 }
 
 // createEFIPartitionImage creates an EFI partition image with the given source

--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -47,6 +47,7 @@ type RawImage struct {
 	Output               string               // Output image destination dir. Final image name will be based on the contents of the source /etc/kairos-release file
 	FinalSize            uint64               // Final size of the disk image in MB
 	StateSize            int64                // Size of the state partition in MB
+	SystemSize           int64                // Size of the system image in MB
 	tmpDir               string               // A temp dir to do all work on
 	elemental            *elemental.Elemental // Elemental instance to use for the operations
 	efi                  bool                 // If the image should be EFI or BIOS
@@ -61,7 +62,7 @@ type RawImage struct {
 
 // NewEFIRawImage creates a new RawImage struct
 // config is initialized with a default config to use the standard logger
-func NewEFIRawImage(source, output, cc string, finalsize uint64, stateSize int64, noDefaultCloudConfig bool) *RawImage {
+func NewEFIRawImage(source, output, cc string, finalsize uint64, stateSize, systemSize int64, noDefaultCloudConfig bool) *RawImage {
 	cfg := config.NewConfig(config.WithLogger(internal.Log))
 	return &RawImage{
 		efi:                  true,
@@ -72,11 +73,12 @@ func NewEFIRawImage(source, output, cc string, finalsize uint64, stateSize int64
 		CloudConfig:          cc,
 		FinalSize:            finalsize,
 		StateSize:            stateSize,
+		SystemSize:           systemSize,
 		NoDefaultCloudConfig: noDefaultCloudConfig,
 	}
 }
 
-func NewBiosRawImage(source, output string, cc string, finalsize uint64, stateSize int64, noDefaultCloudConfig bool) *RawImage {
+func NewBiosRawImage(source, output string, cc string, finalsize uint64, stateSize, systemSize int64, noDefaultCloudConfig bool) *RawImage {
 	cfg := config.NewConfig(config.WithLogger(internal.Log))
 	return &RawImage{efi: false,
 		config:               cfg,
@@ -86,6 +88,7 @@ func NewBiosRawImage(source, output string, cc string, finalsize uint64, stateSi
 		CloudConfig:          cc,
 		FinalSize:            finalsize,
 		StateSize:            stateSize,
+		SystemSize:           systemSize,
 		NoDefaultCloudConfig: noDefaultCloudConfig,
 	}
 }
@@ -339,8 +342,10 @@ func (r *RawImage) createRecoveryPartitionImage() (string, error) {
 		MountPoint: tmpDirRecoveryImage,
 	}
 	size, _ := config.GetSourceSize(r.config, recoveryImage.Source)
-	// Add some extra space to the image in case the calculation is a bit off
-	recoveryImage.Size = uint(size + 200)
+	recoveryImage.Size = systemImageSize(uint64(size), r.SystemSize)
+	if r.SystemSize > 0 {
+		internal.Log.Logger.Info().Int64("size", r.SystemSize).Msg("Using configured system image size")
+	}
 
 	_, err = r.elemental.DeployImage(recoveryImage, false)
 	// Create recovery.squash from the rootfs into the recovery partition under cOS/
@@ -386,11 +391,7 @@ func (r *RawImage) createRecoveryPartitionImage() (string, error) {
 		MountPoint: tmpDirRecoveryImage,
 	}
 
-	size, _ = config.GetSourceSize(r.config, recoveryImage.Source)
-	// Add some extra space to the image in case the calculation is a bit off
-	// we add an extra 50Mb of top as the recovery.img has to fit in there plus any artifacts we copy
-	// Double the size as the partition needs to account for recovery and transition image during recovery upgrade
-	recoverPartitionImage.Size = uint(size*2 + 150)
+	recoverPartitionImage.Size = recoveryPartitionSize(recoveryImage.Size)
 
 	_, err = r.elemental.DeployImageNodirs(recoverPartitionImage, false)
 	// Create recovery.squash from the rootfs into the recovery partition under cOS/
@@ -401,6 +402,19 @@ func (r *RawImage) createRecoveryPartitionImage() (string, error) {
 
 	return recoverPartitionImage.File, nil
 
+}
+
+func systemImageSize(sourceSize uint64, configuredSize int64) uint {
+	if configuredSize > 0 {
+		return uint(configuredSize)
+	}
+	return uint(sourceSize + 200)
+}
+
+func recoveryPartitionSize(systemSize uint) uint {
+	// The partition must hold both the recovery image and a transition image
+	// during recovery upgrades, plus space for copied boot artifacts.
+	return systemSize*2 + 150
 }
 
 // createEFIPartitionImage creates an EFI partition image with the given source

--- a/pkg/ops/raw_disk_sizing_test.go
+++ b/pkg/ops/raw_disk_sizing_test.go
@@ -1,0 +1,33 @@
+package ops
+
+import "testing"
+
+func TestSystemImageSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceSize uint64
+		configured int64
+		want       uint
+	}{
+		{name: "automatic adds headroom", sourceSize: 7_774, want: 7_974},
+		{name: "configured override", sourceSize: 7_774, configured: 12_000, want: 12_000},
+		{name: "negative override uses automatic sizing", sourceSize: 7_774, configured: -1, want: 7_974},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := systemImageSize(tt.sourceSize, tt.configured); got != tt.want {
+				t.Fatalf("systemImageSize(%d, %d) = %d, want %d", tt.sourceSize, tt.configured, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecoveryPartitionSizeTracksSystemImage(t *testing.T) {
+	const systemSize = uint(12_000)
+	const want = uint(24_150)
+
+	if got := recoveryPartitionSize(systemSize); got != want {
+		t.Fatalf("recoveryPartitionSize(%d) = %d, want %d", systemSize, got, want)
+	}
+}

--- a/pkg/ops/raw_disk_sizing_test.go
+++ b/pkg/ops/raw_disk_sizing_test.go
@@ -2,7 +2,7 @@ package ops
 
 import "testing"
 
-func TestSystemImageSize(t *testing.T) {
+func TestRecoveryImageSize(t *testing.T) {
 	tests := []struct {
 		name       string
 		sourceSize uint64
@@ -16,18 +16,31 @@ func TestSystemImageSize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := systemImageSize(tt.sourceSize, tt.configured); got != tt.want {
-				t.Fatalf("systemImageSize(%d, %d) = %d, want %d", tt.sourceSize, tt.configured, got, tt.want)
+			got, err := recoveryImageSize(tt.sourceSize, tt.configured)
+			if err != nil {
+				t.Fatalf("recoveryImageSize(%d, %d) returned error: %v", tt.sourceSize, tt.configured, err)
+			}
+			if got != tt.want {
+				t.Fatalf("recoveryImageSize(%d, %d) = %d, want %d", tt.sourceSize, tt.configured, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestRecoveryPartitionSizeTracksSystemImage(t *testing.T) {
-	const systemSize = uint(12_000)
+func TestRecoveryImageSizeRejectsOverrideBelowSource(t *testing.T) {
+	const sourceSize = uint64(7_774)
+	const configuredSize = int64(7_000)
+
+	if _, err := recoveryImageSize(sourceSize, configuredSize); err == nil {
+		t.Fatalf("recoveryImageSize(%d, %d) returned no error", sourceSize, configuredSize)
+	}
+}
+
+func TestRecoveryPartitionSizeTracksRecoveryImage(t *testing.T) {
+	const recoveryImageSize = uint(12_000)
 	const want = uint(24_150)
 
-	if got := recoveryPartitionSize(systemSize); got != want {
-		t.Fatalf("recoveryPartitionSize(%d) = %d, want %d", systemSize, got, want)
+	if got := recoveryPartitionSize(recoveryImageSize); got != want {
+		t.Fatalf("recoveryPartitionSize(%d) = %d, want %d", recoveryImageSize, got, want)
 	}
 }

--- a/pkg/schema/config.go
+++ b/pkg/schema/config.go
@@ -82,6 +82,7 @@ type Disk struct {
 	MAAS       bool   `yaml:"maas"`
 	Size       string `yaml:"size"`
 	StateSize  string `yaml:"state_size"`
+	SystemSize string `yaml:"system_size"`
 }
 
 type NetBoot struct {

--- a/pkg/schema/config.go
+++ b/pkg/schema/config.go
@@ -78,11 +78,11 @@ type Disk struct {
 	// of merging them into a single .raw disk. Intended for flashing workflows
 	// such as Nvidia Jetson AGX Orin. Implies an EFI build and is mutually
 	// exclusive with the gce/vhd cloud-image conversions.
-	Partitions bool   `yaml:"partitions"`
-	MAAS       bool   `yaml:"maas"`
-	Size       string `yaml:"size"`
-	StateSize  string `yaml:"state_size"`
-	SystemSize string `yaml:"system_size"`
+	Partitions        bool   `yaml:"partitions"`
+	MAAS              bool   `yaml:"maas"`
+	Size              string `yaml:"size"`
+	StateSize         string `yaml:"state_size"`
+	RecoveryImageSize string `yaml:"recovery_image_size"`
 }
 
 type NetBoot struct {


### PR DESCRIPTION
## Summary

- add `disk.recovery_image_size` for EFI, BIOS, raw, GCE, and VHD generation
- preserve automatic source-size headroom when the override is unset or non-positive
- reject configured recovery images smaller than the measured source before deployment
- size the recovery partition from the selected recovery image so large overrides fit

## Testing

- `go test ./pkg/ops ./deployer`
- `go vet ./pkg/ops ./deployer`

The repository-wide `go test ./...` cannot complete in this environment because uncached module downloads return HTTP 403 and generated UI assets are absent.

Fixes kairos-io/kairos#4230