### PR TITLE
feat: add a boot-to-RAM submenu to the live menu

### DIFF
--- a/pkg/constants/grub_live_bios.cfg
+++ b/pkg/constants/grub_live_bios.cfg
@@ -61,6 +61,32 @@ menuentry "Kairos (debug)" --class os --unrestricted {
     initrd ($root)/boot/initrd
 }
 
+# The in-RAM workflow (kairos.ram) is only useful when a cloud config with at
+# least one user reaches the system, and it writes a partition table to an
+# empty disk on first boot (kairos.ram.create_partitions), so it hides behind
+# a submenu that explains all that before booting. The warning is rendered as
+# informational menu lines (no-op bodies) because that is the only way to keep
+# text on screen that works on every grub: echo output is cleared when the
+# menu redraws, and pausing needs the sleep/read modules, which are not
+# guaranteed to be built into the EFI grub image taken from the rootfs.
+# The last entry is the one that actually boots; ESC goes back.
+submenu "Kairos (boot to RAM)" --class os --unrestricted {
+    menuentry "'Boot to RAM' runs the OS entirely from memory, nothing is installed" --unrestricted { set _info=1 }
+    menuentry "immucore mounts COS_OEM and COS_PERSISTENT from the system disk; on an" --unrestricted { set _info=1 }
+    menuentry "empty disk it CREATES them, writing a new partition table on first boot" --unrestricted { set _info=1 }
+    menuentry "The image ships with no users: unless a cloud config defining at least" --unrestricted { set _info=1 }
+    menuentry "one user reaches the system, you will not be able to log in. Provide it" --unrestricted { set _info=1 }
+    menuentry "via a config bundled in the image, a datasource (user-data on a cloud" --unrestricted { set _info=1 }
+    menuentry "provider or attached cdrom/usb), or a remote config_url stanza" --unrestricted { set _info=1 }
+    menuentry "" --unrestricted { set _info=1 }
+    menuentry "Boot Kairos to RAM now" --class os --unrestricted {
+        echo Loading kernel...
+        linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs net.ifnames=1 {{LIVE_CONSOLE}} kairos.ram kairos.ram.create_partitions vga=795{{NOMODESET}} selinux=0 $thor_options rd.live.overlay.overlayfs{{EXTEND_CMDLINE}}
+        echo Loading initrd...
+        initrd ($root)/boot/initrd
+    }
+}
+
 if [ "${grub_platform}" = "efi" ]; then
     hiddenentry "Text mode" --hotkey "t" {
         set textmode=true

--- a/pkg/ops/iso_test.go
+++ b/pkg/ops/iso_test.go
@@ -41,7 +41,7 @@ var _ = Describe("applyGrubTemplate", Label("iso"), func() {
 	It("replaces live consoles while preserving the debug console", func() {
 		result := applyGrubTemplate(constants.GrubLiveBiosCfg, "", "", "console=ttyUSB0,115200")
 		Expect(string(result)).ToNot(ContainSubstring("console=ttyS0 console=tty1"))
-		Expect(strings.Count(string(result), "console=ttyUSB0,115200")).To(Equal(5))
+		Expect(strings.Count(string(result), "console=ttyUSB0,115200")).To(Equal(6))
 		Expect(string(result)).To(ContainSubstring("console=tty0 rd.debug"))
 	})
 


### PR DESCRIPTION
Adds a live grub entry for immucore's kairos.ram workflow: the OS runs
from memory while immucore mounts COS_OEM + COS_PERSISTENT from the local
disk, creating them on first boot if the disk is empty
(kairos.ram.create_partitions).

Layout:

- "Kairos (boot to RAM)" is the last of the normal live entries
- it is a submenu, so selecting it boots nothing
- it opens with the caveats — new partition table on an empty disk, and
  no users in the image, so a cloud config defining one has to reach the
  system somehow (bundled, datasource, or config_url)
- the last line, "Boot Kairos to RAM now", is what actually boots
- ESC goes back to the main menu

Since this path can write a fresh partition table to the system disk,
having to step through the warnings to get to it is deliberate.

The caveats are rendered as menuentries with no-op bodies. That looks odd
but is the only thing that works everywhere. A previous version echoed
the text and paused on `sleep --verbose --interruptible 30`; that worked
on BIOS only, because we control eltorito.img and had rebuilt it with the
sleep module, while grub.efi comes from the rootfs distro and may not
ship it — Hadron's does not, giving "can't find command `sleep`" on EFI.
Echo without a pause is useless too, grub clears the screen the moment a
menuentry body returns without booting. Menu lines need nothing beyond
normal.mod, and the patched eltorito.img can go away.