### PR TITLE
fix(uki): enable initramfs networking

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -82,7 +82,7 @@ const (
 	Archaarch64 = "aarch64"
 	ArchRiscv64 = "riscv64"
 
-	UkiCmdline                    = "console=ttyS0 console=tty1 net.ifnames=1 rd.immucore.oemlabel=COS_OEM rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 panic=5 rd.shell=0 systemd.crash_reboot=yes"
+	UkiCmdline                    = "console=ttyS0 console=tty1 net.ifnames=1 rd.neednet=1 rd.immucore.oemlabel=COS_OEM rd.immucore.oemtimeout=2 rd.immucore.uki selinux=0 panic=5 rd.shell=0 systemd.crash_reboot=yes"
 	UkiCmdlineInstall             = "install-mode"
 	UkiSystemdBootx86Name         = "systemd-bootx64.efi"
 	UkiSystemdBootx86Path         = "/amd/systemd-boot/" + UkiSystemdBootx86Name

--- a/pkg/constants/constants_test.go
+++ b/pkg/constants/constants_test.go
@@ -1,0 +1,13 @@
+package constants
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestUkiCmdlineEnablesInitramfsNetworking(t *testing.T) {
+	if !slices.Contains(strings.Fields(UkiCmdline), "rd.neednet=1") {
+		t.Fatal("UkiCmdline does not enable initramfs networking")
+	}
+}


### PR DESCRIPTION
## Summary

- add `rd.neednet=1` to AuroraBoot UKI kernel command lines
- limit forced initramfs networking to UKI images instead of all dracut-based Kairos images
- add regression coverage for the UKI command line

## Tests

- `GOPROXY=direct go test ./pkg/constants ./pkg/utils`
- `git diff --check`

`go test ./pkg/uki` could not start locally because fetching the newly bumped OpenTelemetry modules returns HTTP 403 in this environment.

Fixes kairos-io/kairos#3758

Supersedes kairos-io/kairos-init#414.