### PR TITLE
feat(deploy): add helm chart for AuroraBoot web UI

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -87,3 +87,71 @@ jobs:
           sources: |
             quay.io/kairos/auroraboot:${{ github.ref_name }}-amd64
             quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
+  release-helm-chart:
+    needs:
+      - build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Derive chart version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+      - name: Log in to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Package chart with tag version
+        run: |
+          helm package deploy/helm/auroraboot \
+            --version "${{ steps.ver.outputs.version }}" \
+            --app-version "${{ steps.ver.outputs.version }}" \
+            --destination .
+      - name: Push chart to ghcr.io
+        run: helm push "auroraboot-${{ steps.ver.outputs.version }}.tgz" oci://ghcr.io/kairos-io/charts
+  bump-chart-version:
+    needs:
+      - release-helm-chart
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+      - name: Derive chart version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+      - name: Bump Chart.yaml
+        run: |
+          yq -i '.version = strenv(CHART_VERSION) | .appVersion = strenv(CHART_VERSION)' \
+            deploy/helm/auroraboot/Chart.yaml
+        env:
+          CHART_VERSION: ${{ steps.ver.outputs.version }}
+      - name: Open PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/chart-bump-${{ steps.ver.outputs.version }}
+          base: main
+          commit-message: |
+            chore(chart): bump to ${{ steps.ver.outputs.version }}
+          title: "chore(chart): bump to ${{ steps.ver.outputs.version }}"
+          body: |
+            Syncs `deploy/helm/auroraboot/Chart.yaml` to the just-released
+            tag `${{ github.ref_name }}` so `helm install` from a fresh
+            checkout of `main` targets the released image by default.
+
+            Chart artifact for this version is already published at
+            `oci://ghcr.io/kairos-io/charts/auroraboot:${{ steps.ver.outputs.version }}`.
+          labels: chart, automation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,21 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./coverage.out
+  helm-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.5.2
+      - name: Lint chart
+        run: make helm-chart-lint
+      - name: Run chart unit tests
+        run: make helm-chart-test
   build-image:
     runs-on: kvm
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,8 @@ jobs:
           files: ./coverage.out
   helm-chart:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/Makefile
+++ b/Makefile
@@ -110,3 +110,23 @@ openapi: ## Regenerate Swagger/OpenAPI documentation
 
 # Backwards-compat alias
 swagger: openapi
+
+# Helm chart targets. The chart lives in deploy/helm/auroraboot and its
+# unit tests use the helm-unittest plugin.
+HELM_CHART_DIR := deploy/helm/auroraboot
+
+helm-chart-lint: ## Lint the AuroraBoot helm chart
+	helm lint $(HELM_CHART_DIR) -f $(HELM_CHART_DIR)/examples/values-min.yaml
+
+helm-chart-template: ## Render the helm chart with example values (for eyeballing)
+	helm template ab $(HELM_CHART_DIR) -n kairos-operator -f $(HELM_CHART_DIR)/examples/values-min.yaml
+
+helm-chart-test: ## Run helm-unittest suites against the AuroraBoot chart
+	@helm plugin list 2>/dev/null | grep -q '^unittest' || { \
+		echo "helm-unittest plugin missing. Install with:"; \
+		echo "  helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.5.2"; \
+		exit 1; \
+	}
+	helm unittest $(HELM_CHART_DIR)
+
+helm-chart-check: helm-chart-lint helm-chart-test ## Lint + unit test the helm chart

--- a/deploy/helm/auroraboot/Chart.yaml
+++ b/deploy/helm/auroraboot/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: auroraboot
+description: AuroraBoot web UI wired to the kairos-operator as its build backend.
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://kairos.io
+sources:
+  - https://github.com/kairos-io/AuroraBoot
+maintainers:
+  - name: kairos-io
+    url: https://github.com/kairos-io
+keywords:
+  - kairos
+  - auroraboot
+  - netboot
+  - immutable-os

--- a/deploy/helm/auroraboot/examples/values-min.yaml
+++ b/deploy/helm/auroraboot/examples/values-min.yaml
@@ -1,0 +1,1 @@
+host: auroraboot.example.com

--- a/deploy/helm/auroraboot/templates/NOTES.txt
+++ b/deploy/helm/auroraboot/templates/NOTES.txt
@@ -1,0 +1,56 @@
+AuroraBoot is installed. A few things to check before it becomes reachable.
+
+1. DNS
+
+   Point {{ .Values.host }} at your ingress controller's external
+   IP or hostname. That is the LoadBalancer address (or MetalLB VIP,
+   or a node's port), not the cluster API server IP.
+
+2. Ingress class
+
+{{- if .Values.ingress.className }}
+   Using ingressClassName: {{ .Values.ingress.className }}
+{{- else }}
+   No ingressClassName set. The cluster default IngressClass will be
+   used. If your cluster has none, set ingress.className to your
+   controller (e.g. nginx, traefik).
+{{- end }}
+
+3. TLS
+{{- if .Values.ingress.tls.enabled }}
+{{- if .Values.ingress.tls.existingSecret }}
+   Ingress uses the existing secret: {{ .Values.ingress.tls.existingSecret }}
+{{- else if .Values.ingress.tls.issuerName }}
+   Ingress requests a cert from cert-manager issuer {{ .Values.ingress.tls.issuerName }}.
+   Once the certificate is Ready, the UI is reachable at:
+
+     {{ include "auroraboot.url" . }}
+{{- else }}
+   TLS is enabled but neither existingSecret nor issuerName is set.
+   Provide one of ingress.tls.existingSecret or ingress.tls.issuerName.
+{{- end }}
+{{- else }}
+   TLS is not enabled in the chart. The URL used for cloud-config
+   injection is:
+
+     {{ include "auroraboot.url" . }}
+
+   If your ingress terminates TLS externally, set ingress.tls.enabled
+   so the injected URL uses https.
+{{- end }}
+
+4. Builder backend
+
+   AuroraBoot talks to the kairos-operator in namespace
+   {{ include "auroraboot.builderNamespace" . }}. The operator must
+   already be installed there and its OSArtifact CRD must be
+   registered. This chart does not install the operator.
+
+5. Registration token
+
+   Node enrollments use the token stored in secret
+   {{ include "auroraboot.registrationSecretName" . }}. Fetch it with:
+
+     kubectl -n {{ .Release.Namespace }} get secret \
+       {{ include "auroraboot.registrationSecretName" . }} \
+       -o jsonpath='{.data.token}' | base64 -d

--- a/deploy/helm/auroraboot/templates/NOTES.txt
+++ b/deploy/helm/auroraboot/templates/NOTES.txt
@@ -30,13 +30,16 @@ AuroraBoot is installed. A few things to check before it becomes reachable.
    Provide one of ingress.tls.existingSecret or ingress.tls.issuerName.
 {{- end }}
 {{- else }}
-   TLS is not enabled in the chart. The URL used for cloud-config
-   injection is:
+   TLS is not managed by this chart. The URL advertised in cloud-configs is:
 
      {{ include "auroraboot.url" . }}
 
-   If your ingress terminates TLS externally, set ingress.tls.enabled
-   so the injected URL uses https.
+   For a production deployment, enable chart-managed TLS via
+   ingress.tls.enabled (with ingress.tls.existingSecret or
+   ingress.tls.issuerName) so the injected URL uses https. If your
+   upstream LB or reverse proxy already terminates TLS, either set
+   ingress.tls.enabled with an existingSecret pointer, or override the
+   advertised URL via --url in extraArgs.
 {{- end }}
 
 4. Builder backend

--- a/deploy/helm/auroraboot/templates/_helpers.tpl
+++ b/deploy/helm/auroraboot/templates/_helpers.tpl
@@ -87,3 +87,22 @@ this themselves without TLS.
 {{- printf "http://%s" .Values.host -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolves the registration token that ends up in the Secret. Both the
+Secret template and the Deployment's checksum annotation use this,
+so a token change ripples through the pod annotation and forces a
+rolling restart on the next helm upgrade.
+*/}}
+{{- define "auroraboot.registrationToken" -}}
+{{- if .Values.registrationToken.value -}}
+{{- .Values.registrationToken.value -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "auroraboot.registrationSecretName" .) -}}
+{{- if and $existing $existing.data (hasKey $existing.data "token") -}}
+{{- index $existing.data "token" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 48 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/auroraboot/templates/_helpers.tpl
+++ b/deploy/helm/auroraboot/templates/_helpers.tpl
@@ -75,13 +75,15 @@ render failures.
 {{- end -}}
 
 {{/*
-The base URL derived from host. Defaults to https since most clusters
-put a TLS-terminating ingress or LB in front. When ingress is disabled
-entirely, fall back to http on the assumption the user is fronting
-this themselves without TLS.
+The base URL derived from host. Uses https when the chart is managing
+TLS on the Ingress (ingress.tls.enabled), http otherwise. Users whose
+TLS is terminated upstream by an LB or reverse proxy without a chart-
+managed cert should either set ingress.tls.enabled with existingSecret,
+or override the injected URL via extraArgs (--url=...) until a
+first-class url override is added.
 */}}
 {{- define "auroraboot.url" -}}
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.tls.enabled -}}
 {{- printf "https://%s" .Values.host -}}
 {{- else -}}
 {{- printf "http://%s" .Values.host -}}

--- a/deploy/helm/auroraboot/templates/_helpers.tpl
+++ b/deploy/helm/auroraboot/templates/_helpers.tpl
@@ -1,0 +1,89 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "auroraboot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "auroraboot.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "auroraboot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "auroraboot.labels" -}}
+helm.sh/chart: {{ include "auroraboot.chart" . }}
+{{ include "auroraboot.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "auroraboot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "auroraboot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "auroraboot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "auroraboot.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "auroraboot.builderNamespace" -}}
+{{- default .Release.Namespace .Values.builder.namespace -}}
+{{- end -}}
+
+{{- define "auroraboot.registrationSecretName" -}}
+{{- printf "%s-registration" (include "auroraboot.fullname" .) -}}
+{{- end -}}
+
+{{- define "auroraboot.tlsSecretName" -}}
+{{- if .Values.ingress.tls.existingSecret -}}
+{{- .Values.ingress.tls.existingSecret -}}
+{{- else -}}
+{{- printf "%s-tls" (include "auroraboot.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Fail early if host is not set. Every top-level template calls this so
+we surface a single friendly error instead of a cascade of confusing
+render failures.
+*/}}
+{{- define "auroraboot.requireHost" -}}
+{{- if not .Values.host -}}
+{{- fail "host is required: set .Values.host to the externally reachable hostname (e.g. auroraboot.example.com)" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The base URL derived from host. Defaults to https since most clusters
+put a TLS-terminating ingress or LB in front. When ingress is disabled
+entirely, fall back to http on the assumption the user is fronting
+this themselves without TLS.
+*/}}
+{{- define "auroraboot.url" -}}
+{{- if .Values.ingress.enabled -}}
+{{- printf "https://%s" .Values.host -}}
+{{- else -}}
+{{- printf "http://%s" .Values.host -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/auroraboot/templates/_helpers.tpl
+++ b/deploy/helm/auroraboot/templates/_helpers.tpl
@@ -89,6 +89,19 @@ this themselves without TLS.
 {{- end -}}
 
 {{/*
+Cluster-internal URL that exporter pods PUT built artifacts to. Uses
+the release Service's DNS so upload traffic never leaves the cluster;
+callers who want to override can set builder.uploadURL explicitly.
+*/}}
+{{- define "auroraboot.uploadURL" -}}
+{{- if .Values.builder.uploadURL -}}
+{{- .Values.builder.uploadURL -}}
+{{- else -}}
+{{- printf "http://%s.%s.svc.cluster.local:%d" (include "auroraboot.fullname" .) .Release.Namespace (int .Values.service.port) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Resolves the registration token that ends up in the Secret. Both the
 Secret template and the Deployment's checksum annotation use this,
 so a token change ripples through the pod annotation and forces a

--- a/deploy/helm/auroraboot/templates/deployment.yaml
+++ b/deploy/helm/auroraboot/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
             - --builder-namespace={{ include "auroraboot.builderNamespace" . }}
             - --builder-upload-url={{ include "auroraboot.uploadURL" . }}
             - --url={{ include "auroraboot.url" . }}
+            {{- /* extraArgs come LAST so users can override any of the
+                    chart-supplied flags above (urfave/cli/v2 takes the
+                    last occurrence of a repeated flag). Do not reorder. */}}
             {{- range .Values.extraArgs }}
             - {{ . | quote }}
             {{- end }}

--- a/deploy/helm/auroraboot/templates/deployment.yaml
+++ b/deploy/helm/auroraboot/templates/deployment.yaml
@@ -1,0 +1,94 @@
+{{- include "auroraboot.requireHost" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "auroraboot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auroraboot.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "auroraboot.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "auroraboot.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "auroraboot.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: auroraboot
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - web
+            - --listen=:8080
+            - --data-dir=/var/lib/auroraboot
+            - --builder={{ .Values.builder.kind }}
+            - --builder-namespace={{ include "auroraboot.builderNamespace" . }}
+            - --url={{ include "auroraboot.url" . }}
+            {{- range .Values.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: AURORABOOT_REG_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "auroraboot.registrationSecretName" . }}
+                  key: token
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/auroraboot
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "auroraboot.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/auroraboot/templates/deployment.yaml
+++ b/deploy/helm/auroraboot/templates/deployment.yaml
@@ -20,10 +20,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/registration-secret: {{ include "auroraboot.registrationToken" . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "auroraboot.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}

--- a/deploy/helm/auroraboot/templates/deployment.yaml
+++ b/deploy/helm/auroraboot/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             - --data-dir=/var/lib/auroraboot
             - --builder={{ .Values.builder.kind }}
             - --builder-namespace={{ include "auroraboot.builderNamespace" . }}
+            - --builder-upload-url={{ include "auroraboot.uploadURL" . }}
             - --url={{ include "auroraboot.url" . }}
             {{- range .Values.extraArgs }}
             - {{ . | quote }}

--- a/deploy/helm/auroraboot/templates/ingress.yaml
+++ b/deploy/helm/auroraboot/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- include "auroraboot.requireHost" . -}}
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "auroraboot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auroraboot.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.issuerName (not .Values.ingress.tls.existingSecret) }}
+    {{- if eq .Values.ingress.tls.issuerKind "Issuer" }}
+    cert-manager.io/issuer: {{ .Values.ingress.tls.issuerName | quote }}
+    {{- else }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.issuerName | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.host | quote }}
+      secretName: {{ include "auroraboot.tlsSecretName" . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "auroraboot.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end -}}

--- a/deploy/helm/auroraboot/templates/pvc.yaml
+++ b/deploy/helm/auroraboot/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- include "auroraboot.requireHost" . -}}
+{{- if .Values.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "auroraboot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auroraboot.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/auroraboot/templates/rbac.yaml
+++ b/deploy/helm/auroraboot/templates/rbac.yaml
@@ -1,0 +1,42 @@
+{{- include "auroraboot.requireHost" . -}}
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "auroraboot.fullname" . }}
+  namespace: {{ include "auroraboot.builderNamespace" . }}
+  labels:
+    {{- include "auroraboot.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["build.kairos.io"]
+    resources: ["osartifacts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "auroraboot.fullname" . }}
+  namespace: {{ include "auroraboot.builderNamespace" . }}
+  labels:
+    {{- include "auroraboot.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "auroraboot.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "auroraboot.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/helm/auroraboot/templates/registration-secret.yaml
+++ b/deploy/helm/auroraboot/templates/registration-secret.yaml
@@ -1,21 +1,11 @@
 {{- include "auroraboot.requireHost" . -}}
-{{- $secretName := include "auroraboot.registrationSecretName" . -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
-{{- $token := "" -}}
-{{- if .Values.registrationToken.value -}}
-{{- $token = .Values.registrationToken.value -}}
-{{- else if and $existing $existing.data (hasKey $existing.data "token") -}}
-{{- $token = index $existing.data "token" | b64dec -}}
-{{- else -}}
-{{- $token = randAlphaNum 48 -}}
-{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ include "auroraboot.registrationSecretName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "auroraboot.labels" . | nindent 4 }}
 type: Opaque
 data:
-  token: {{ $token | b64enc | quote }}
+  token: {{ include "auroraboot.registrationToken" . | b64enc | quote }}

--- a/deploy/helm/auroraboot/templates/registration-secret.yaml
+++ b/deploy/helm/auroraboot/templates/registration-secret.yaml
@@ -1,0 +1,21 @@
+{{- include "auroraboot.requireHost" . -}}
+{{- $secretName := include "auroraboot.registrationSecretName" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $token := "" -}}
+{{- if .Values.registrationToken.value -}}
+{{- $token = .Values.registrationToken.value -}}
+{{- else if and $existing $existing.data (hasKey $existing.data "token") -}}
+{{- $token = index $existing.data "token" | b64dec -}}
+{{- else -}}
+{{- $token = randAlphaNum 48 -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auroraboot.labels" . | nindent 4 }}
+type: Opaque
+data:
+  token: {{ $token | b64enc | quote }}

--- a/deploy/helm/auroraboot/templates/service.yaml
+++ b/deploy/helm/auroraboot/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- include "auroraboot.requireHost" . -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "auroraboot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auroraboot.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "auroraboot.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/auroraboot/templates/serviceaccount.yaml
+++ b/deploy/helm/auroraboot/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- include "auroraboot.requireHost" . -}}
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "auroraboot.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "auroraboot.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/auroraboot/tests/deployment_test.yaml
+++ b/deploy/helm/auroraboot/tests/deployment_test.yaml
@@ -35,10 +35,22 @@ tests:
           content: --builder=operator
       - contains:
           path: spec.template.spec.containers[0].args
-          content: --url=https://auroraboot.example.com
+          content: --url=http://auroraboot.example.com
       - contains:
           path: spec.template.spec.containers[0].args
           content: --data-dir=/var/lib/auroraboot
+
+  - it: uses https for --url when chart-managed TLS is enabled
+    set:
+      host: auroraboot.example.com
+      ingress:
+        tls:
+          enabled: true
+          existingSecret: my-cert
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --url=https://auroraboot.example.com
 
   - it: defaults builder-namespace to the release namespace
     set:
@@ -80,6 +92,22 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --builder-upload-url=http://ab.custom.svc:9000
+
+  - it: appends extraArgs after chart-supplied flags so they win on repeated --url
+    set:
+      host: auroraboot.example.com
+      extraArgs:
+        - --url=https://external.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --url=http://auroraboot.example.com
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --url=https://external.example.com
+      - equal:
+          path: spec.template.spec.containers[0].args[7]
+          value: --url=https://external.example.com
 
   - it: mounts the persistence PVC at /var/lib/auroraboot
     set:

--- a/deploy/helm/auroraboot/tests/deployment_test.yaml
+++ b/deploy/helm/auroraboot/tests/deployment_test.yaml
@@ -114,3 +114,10 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: ab-auroraboot
+
+  - it: hashes the registration token into a pod-template annotation so rotations roll pods
+    set:
+      host: auroraboot.example.com
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/registration-secret"]

--- a/deploy/helm/auroraboot/tests/deployment_test.yaml
+++ b/deploy/helm/auroraboot/tests/deployment_test.yaml
@@ -60,6 +60,27 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --builder-namespace=some-other-ns
 
+  - it: auto-fills builder-upload-url from the release Service DNS
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+      namespace: kairos-operator
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --builder-upload-url=http://ab-auroraboot.kairos-operator.svc.cluster.local:80
+
+  - it: honours an explicit builder.uploadURL override
+    set:
+      host: auroraboot.example.com
+      builder:
+        uploadURL: http://ab.custom.svc:9000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --builder-upload-url=http://ab.custom.svc:9000
+
   - it: mounts the persistence PVC at /var/lib/auroraboot
     set:
       host: auroraboot.example.com

--- a/deploy/helm/auroraboot/tests/deployment_test.yaml
+++ b/deploy/helm/auroraboot/tests/deployment_test.yaml
@@ -1,0 +1,116 @@
+suite: deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: fails when host is empty
+    set:
+      host: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "host is required"
+
+  - it: renders a Deployment named after the release
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: ab-auroraboot
+
+  - it: runs the web subcommand with builder=operator and derives --url from host
+    set:
+      host: auroraboot.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: web
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --builder=operator
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --url=https://auroraboot.example.com
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --data-dir=/var/lib/auroraboot
+
+  - it: defaults builder-namespace to the release namespace
+    set:
+      host: auroraboot.example.com
+    release:
+      namespace: kairos-operator
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --builder-namespace=kairos-operator
+
+  - it: honours an explicit builder.namespace override
+    set:
+      host: auroraboot.example.com
+      builder:
+        namespace: some-other-ns
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --builder-namespace=some-other-ns
+
+  - it: mounts the persistence PVC at /var/lib/auroraboot
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /var/lib/auroraboot
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: ab-auroraboot
+
+  - it: uses emptyDir when persistence is disabled
+    set:
+      host: auroraboot.example.com
+      persistence:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+
+  - it: exposes the registration token as env from the generated secret
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AURORABOOT_REG_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: ab-auroraboot-registration
+                key: token
+
+  - it: uses the release SA
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: ab-auroraboot

--- a/deploy/helm/auroraboot/tests/ingress_test.yaml
+++ b/deploy/helm/auroraboot/tests/ingress_test.yaml
@@ -1,0 +1,76 @@
+suite: ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: renders an Ingress with the supplied host and no tls by default
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: auroraboot.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: ab-auroraboot
+      - notExists:
+          path: spec.tls
+
+  - it: is omitted when ingress.enabled=false
+    set:
+      host: auroraboot.example.com
+      ingress:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: references an existing TLS secret when configured
+    set:
+      host: auroraboot.example.com
+      ingress:
+        tls:
+          enabled: true
+          existingSecret: my-cert
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: my-cert
+      - contains:
+          path: spec.tls[0].hosts
+          content: auroraboot.example.com
+
+  - it: adds cert-manager annotation and derived secret name when issuerName is set
+    set:
+      host: auroraboot.example.com
+      ingress:
+        tls:
+          enabled: true
+          issuerName: letsencrypt
+    release:
+      name: ab
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt
+      - equal:
+          path: spec.tls[0].secretName
+          value: ab-auroraboot-tls
+
+  - it: uses the Issuer kind annotation when issuerKind=Issuer
+    set:
+      host: auroraboot.example.com
+      ingress:
+        tls:
+          enabled: true
+          issuerName: letsencrypt
+          issuerKind: Issuer
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/issuer"]
+          value: letsencrypt

--- a/deploy/helm/auroraboot/tests/pvc_test.yaml
+++ b/deploy/helm/auroraboot/tests/pvc_test.yaml
@@ -1,0 +1,44 @@
+suite: pvc
+templates:
+  - pvc.yaml
+tests:
+  - it: renders a PVC with the configured size and access mode
+    set:
+      host: auroraboot.example.com
+      persistence:
+        size: 50Gi
+    release:
+      name: ab
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: ab-auroraboot
+      - equal:
+          path: spec.resources.requests.storage
+          value: 50Gi
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteOnce
+
+  - it: is omitted when persistence.enabled=false
+    set:
+      host: auroraboot.example.com
+      persistence:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: honours a custom storageClass
+    set:
+      host: auroraboot.example.com
+      persistence:
+        storageClass: fast-ssd
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd

--- a/deploy/helm/auroraboot/tests/rbac_test.yaml
+++ b/deploy/helm/auroraboot/tests/rbac_test.yaml
@@ -1,0 +1,98 @@
+suite: rbac
+templates:
+  - rbac.yaml
+tests:
+  - it: renders a Role and RoleBinding in builder.namespace
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+      namespace: kairos-operator
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Role
+      - documentIndex: 0
+        equal:
+          path: metadata.namespace
+          value: kairos-operator
+      - documentIndex: 1
+        isKind:
+          of: RoleBinding
+      - documentIndex: 1
+        equal:
+          path: subjects[0].name
+          value: ab-auroraboot
+      - documentIndex: 1
+        equal:
+          path: subjects[0].namespace
+          value: kairos-operator
+
+  - it: grants access to OSArtifacts, secrets, pods, pod logs, and jobs
+    set:
+      host: auroraboot.example.com
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - contains:
+          path: rules
+          any: true
+          content:
+            apiGroups: ["build.kairos.io"]
+            resources: ["osartifacts"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      - contains:
+          path: rules
+          any: true
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      - contains:
+          path: rules
+          any: true
+          content:
+            apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          any: true
+          content:
+            apiGroups: [""]
+            resources: ["pods/log"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          any: true
+          content:
+            apiGroups: ["batch"]
+            resources: ["jobs"]
+            verbs: ["get", "list", "watch"]
+
+  - it: places the Role in an explicit builder.namespace when overridden
+    set:
+      host: auroraboot.example.com
+      builder:
+        namespace: elsewhere
+    release:
+      namespace: default
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: elsewhere
+
+  - it: skips RBAC when rbac.create=false
+    set:
+      host: auroraboot.example.com
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/auroraboot/tests/secret_test.yaml
+++ b/deploy/helm/auroraboot/tests/secret_test.yaml
@@ -1,0 +1,29 @@
+suite: registration-secret
+templates:
+  - registration-secret.yaml
+tests:
+  - it: renders a registration-token Secret with a token key
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: ab-auroraboot-registration
+      - exists:
+          path: data.token
+
+  - it: uses the provided registrationToken.value verbatim
+    set:
+      host: auroraboot.example.com
+      registrationToken:
+        value: my-static-token
+    asserts:
+      - equal:
+          path: data.token
+          value: bXktc3RhdGljLXRva2Vu

--- a/deploy/helm/auroraboot/tests/service_test.yaml
+++ b/deploy/helm/auroraboot/tests/service_test.yaml
@@ -1,0 +1,26 @@
+suite: service
+templates:
+  - service.yaml
+tests:
+  - it: renders a ClusterIP Service on port 80 targeting 8080
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: ab-auroraboot
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http

--- a/deploy/helm/auroraboot/tests/serviceaccount_test.yaml
+++ b/deploy/helm/auroraboot/tests/serviceaccount_test.yaml
@@ -1,0 +1,26 @@
+suite: serviceaccount
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: renders a ServiceAccount named after the release
+    set:
+      host: auroraboot.example.com
+    release:
+      name: ab
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ab-auroraboot
+
+  - it: is skipped when serviceAccount.create=false
+    set:
+      host: auroraboot.example.com
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/auroraboot/values.yaml
+++ b/deploy/helm/auroraboot/values.yaml
@@ -39,6 +39,11 @@ builder:
   # Namespace where OSArtifact CRs are created and their exporter pods
   # run. Empty means the release namespace.
   namespace: ""
+  # URL exporter pods PUT built artifacts to. Empty defaults to the
+  # release Service's cluster-internal DNS name so uploads never
+  # traverse the ingress. Override only when the exporter pods can't
+  # reach the release Service (e.g. cross-cluster setups).
+  uploadURL: ""
 
 persistence:
   # A single PVC mounted at /var/lib/auroraboot holds the SQLite store,

--- a/deploy/helm/auroraboot/values.yaml
+++ b/deploy/helm/auroraboot/values.yaml
@@ -1,0 +1,82 @@
+# The externally reachable hostname for the AuroraBoot web UI. Required.
+# DNS for this name must resolve to the ingress controller's external
+# IP (LoadBalancer address, MetalLB VIP, or a node's port), not the
+# cluster API server IP.
+host: ""
+
+image:
+  repository: quay.io/kairos/auroraboot
+  # If empty, the chart uses appVersion from Chart.yaml.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  tls:
+    # When true, adds a tls block to the Ingress. If issuerName is set,
+    # a cert-manager annotation is added and a secret name is generated.
+    # If existingSecret is set, that secret is referenced verbatim.
+    enabled: false
+    issuerName: ""
+    issuerKind: ClusterIssuer
+    existingSecret: ""
+
+builder:
+  # 'operator' delegates artifact builds to the kairos-operator via
+  # OSArtifact CRs. 'local' runs the build inside this pod (needs
+  # docker-in-docker; not the intended mode for in-cluster use).
+  kind: operator
+  # Namespace where OSArtifact CRs are created and their exporter pods
+  # run. Empty means the release namespace.
+  namespace: ""
+
+persistence:
+  # A single PVC mounted at /var/lib/auroraboot holds the SQLite store,
+  # keys, secrets, and built artifacts.
+  enabled: true
+  size: 20Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+rbac:
+  # Chart-managed Role + RoleBinding in builder.namespace granting the
+  # SA access to OSArtifacts, secrets, pods, pod logs, and jobs.
+  create: true
+
+registrationToken:
+  # When empty, the chart generates a random token on first install and
+  # reuses it on upgrades via helm's lookup function so agents don't
+  # need to be re-enrolled.
+  value: ""
+
+resources: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}
+podLabels: {}
+
+env: []
+
+extraArgs: []

--- a/internal/cmd/builder_upload_url_test.go
+++ b/internal/cmd/builder_upload_url_test.go
@@ -1,0 +1,33 @@
+package cmd_test
+
+import (
+	cmdpkg "github.com/kairos-io/AuroraBoot/internal/cmd"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ResolveBuilderUploadURL", Label("cmd", "builder-upload-url"), func() {
+	When("--builder-upload-url is set", func() {
+		It("returns it verbatim", func() {
+			Expect(cmdpkg.ResolveBuilderUploadURL(
+				"http://ab.kairos-operator.svc.cluster.local:80",
+				"https://auroraboot.example.com",
+			)).To(Equal("http://ab.kairos-operator.svc.cluster.local:80"))
+		})
+	})
+
+	When("--builder-upload-url is empty", func() {
+		It("falls back to the public --url", func() {
+			Expect(cmdpkg.ResolveBuilderUploadURL(
+				"",
+				"https://auroraboot.example.com",
+			)).To(Equal("https://auroraboot.example.com"))
+		})
+	})
+
+	When("both are empty", func() {
+		It("returns an empty string", func() {
+			Expect(cmdpkg.ResolveBuilderUploadURL("", "")).To(BeEmpty())
+		})
+	})
+})

--- a/internal/cmd/registration_token.go
+++ b/internal/cmd/registration_token.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ResolveRegistrationToken returns the registration token to run with,
+// treating envValue as a seed rather than a hard override.
+//
+// The seed marker at seedPath records the envValue applied on a previous
+// startup. When it matches the current envValue, the token file at
+// tokenPath is authoritative so a runtime rotation (which writes only
+// tokenPath) survives restarts. When it differs the operator is
+// supplying a new seed (fresh install, helm upgrade with a new value),
+// so both files are overwritten.
+//
+// When envValue is empty the token file wins if present, otherwise a
+// fresh token is generated and persisted to tokenPath. The seed marker
+// is left alone; a later restart with envValue set can still rotate.
+func ResolveRegistrationToken(envValue, tokenPath, seedPath string) (string, error) {
+	envValue = strings.TrimSpace(envValue)
+
+	if envValue != "" {
+		lastSeed, seedExists, err := readTrimmed(seedPath)
+		if err != nil {
+			return "", fmt.Errorf("read registration token seed marker: %w", err)
+		}
+		if !seedExists || lastSeed != envValue {
+			if err := writeSecretFile(tokenPath, envValue); err != nil {
+				return "", fmt.Errorf("persist registration token: %w", err)
+			}
+			if err := writeSecretFile(seedPath, envValue); err != nil {
+				return "", fmt.Errorf("persist registration token seed marker: %w", err)
+			}
+			return envValue, nil
+		}
+	}
+
+	token, exists, err := readTrimmed(tokenPath)
+	if err != nil {
+		return "", fmt.Errorf("read registration token: %w", err)
+	}
+	if exists && token != "" {
+		return token, nil
+	}
+
+	if envValue != "" {
+		if err := writeSecretFile(tokenPath, envValue); err != nil {
+			return "", fmt.Errorf("persist registration token: %w", err)
+		}
+		return envValue, nil
+	}
+
+	generated := generateToken(16)
+	if err := writeSecretFile(tokenPath, generated); err != nil {
+		return "", fmt.Errorf("persist registration token: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Generated registration token: %s (saved to %s)\n", generated, tokenPath)
+	return generated, nil
+}
+
+func readTrimmed(path string) (string, bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return strings.TrimRight(string(data), "\r\n"), true, nil
+}
+
+func writeSecretFile(path, contents string) error {
+	return os.WriteFile(path, []byte(contents), 0600)
+}

--- a/internal/cmd/registration_token_test.go
+++ b/internal/cmd/registration_token_test.go
@@ -1,0 +1,127 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+
+	cmdpkg "github.com/kairos-io/AuroraBoot/internal/cmd"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ResolveRegistrationToken", Label("cmd", "registration-token"), func() {
+	var (
+		dir       string
+		tokenPath string
+		seedPath  string
+	)
+
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+		tokenPath = filepath.Join(dir, "registration-token")
+		seedPath = filepath.Join(dir, "registration-token.seed")
+	})
+
+	fileContents := func(path string) string {
+		data, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		return string(data)
+	}
+
+	fileMissing := func(path string) bool {
+		_, err := os.Stat(path)
+		return os.IsNotExist(err)
+	}
+
+	When("no env value and no files exist", func() {
+		It("generates a token and persists only the token file", func() {
+			token, err := cmdpkg.ResolveRegistrationToken("", tokenPath, seedPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).NotTo(BeEmpty())
+			Expect(fileContents(tokenPath)).To(Equal(token))
+			Expect(fileMissing(seedPath)).To(BeTrue(), "seed marker must not be created without a seed")
+		})
+	})
+
+	When("no env value but token file exists", func() {
+		It("returns the file contents unchanged", func() {
+			Expect(os.WriteFile(tokenPath, []byte("existing-token"), 0600)).To(Succeed())
+
+			token, err := cmdpkg.ResolveRegistrationToken("", tokenPath, seedPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("existing-token"))
+			Expect(fileContents(tokenPath)).To(Equal("existing-token"))
+			Expect(fileMissing(seedPath)).To(BeTrue())
+		})
+	})
+
+	When("first boot with an env value", func() {
+		It("persists the token AND the seed marker", func() {
+			token, err := cmdpkg.ResolveRegistrationToken("seed-1", tokenPath, seedPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("seed-1"))
+			Expect(fileContents(tokenPath)).To(Equal("seed-1"))
+			Expect(fileContents(seedPath)).To(Equal("seed-1"))
+		})
+	})
+
+	When("the env value matches the recorded seed and the token was rotated at runtime", func() {
+		It("keeps the runtime-rotated token", func() {
+			Expect(os.WriteFile(seedPath, []byte("seed-1"), 0600)).To(Succeed())
+			Expect(os.WriteFile(tokenPath, []byte("rotated-at-runtime"), 0600)).To(Succeed())
+
+			token, err := cmdpkg.ResolveRegistrationToken("seed-1", tokenPath, seedPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("rotated-at-runtime"))
+			Expect(fileContents(tokenPath)).To(Equal("rotated-at-runtime"))
+			Expect(fileContents(seedPath)).To(Equal("seed-1"))
+		})
+	})
+
+	When("the env value differs from the recorded seed", func() {
+		It("treats the change as an operator-driven rotation and overwrites both files", func() {
+			Expect(os.WriteFile(seedPath, []byte("seed-1"), 0600)).To(Succeed())
+			Expect(os.WriteFile(tokenPath, []byte("rotated-at-runtime"), 0600)).To(Succeed())
+
+			token, err := cmdpkg.ResolveRegistrationToken("seed-2", tokenPath, seedPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("seed-2"))
+			Expect(fileContents(tokenPath)).To(Equal("seed-2"))
+			Expect(fileContents(seedPath)).To(Equal("seed-2"))
+		})
+	})
+
+	When("env value set but the token file is missing", func() {
+		It("uses the env value and writes it back", func() {
+			Expect(os.WriteFile(seedPath, []byte("seed-1"), 0600)).To(Succeed())
+
+			token, err := cmdpkg.ResolveRegistrationToken("seed-1", tokenPath, seedPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("seed-1"))
+			Expect(fileContents(tokenPath)).To(Equal("seed-1"))
+		})
+	})
+
+	When("env value is removed after a previous run", func() {
+		It("keeps the file value and does not touch the seed marker", func() {
+			Expect(os.WriteFile(seedPath, []byte("seed-1"), 0600)).To(Succeed())
+			Expect(os.WriteFile(tokenPath, []byte("still-in-use"), 0600)).To(Succeed())
+
+			token, err := cmdpkg.ResolveRegistrationToken("", tokenPath, seedPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("still-in-use"))
+			Expect(fileContents(seedPath)).To(Equal("seed-1"))
+		})
+	})
+
+	When("the env value has trailing whitespace", func() {
+		It("trims it before comparing to the seed marker", func() {
+			Expect(os.WriteFile(seedPath, []byte("seed-1"), 0600)).To(Succeed())
+			Expect(os.WriteFile(tokenPath, []byte("rotated-at-runtime"), 0600)).To(Succeed())
+
+			token, err := cmdpkg.ResolveRegistrationToken("seed-1\n", tokenPath, seedPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token).To(Equal("rotated-at-runtime"), "trimmed env value must match the seed marker")
+		})
+	})
+})

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -105,6 +105,7 @@ var WebCMD = cli.Command{
 		&cli.StringFlag{Name: "builder", Value: "local", Usage: "Which builder backend to use: 'local' or 'operator'"},
 		&cli.StringFlag{Name: "kubeconfig", Usage: "Path to a kubeconfig file for the operator builder (single file). Empty means try in-cluster config first, then the default client-go loading rules (which honour a multi-file KUBECONFIG env)"},
 		&cli.StringFlag{Name: "builder-namespace", Value: "default", Usage: "Namespace in which OSArtifact CRs are created. Used only when --builder=operator"},
+		&cli.StringFlag{Name: "builder-upload-url", Usage: "URL exporter pods PUT built artifacts to. Only needs cluster-internal reachability, so a Service DNS name is appropriate. Defaults to --url. Used only when --builder=operator", EnvVars: []string{"AURORABOOT_BUILDER_UPLOAD_URL"}},
 	},
 	Action: runWeb,
 }
@@ -228,21 +229,27 @@ func runWeb(c *cli.Context) error {
 			return err
 		}
 		// Operator builds ship the per-build upload token plus the finished
-		// artifact bytes back to AuroraBoot over --url. Over plaintext http
-		// both traverse the cluster network in the clear, so anyone with
-		// pod-network access can capture the token and overwrite artifacts
-		// while the build is Building (watchCRPhase zeroes the token on
-		// terminal transition, closing the window at Ready/Error). Left
-		// unforced so dev environments can iterate without cert setup; a
-		// production deployment should terminate --url via https.
-		if strings.HasPrefix(strings.ToLower(externalURL), "http://") {
-			fmt.Fprintf(os.Stderr, "Warning: --builder=operator with plaintext --url (%s): exporter Pods will PUT the per-build upload token and artifact bytes over http. Use https:// in production.\n", externalURL)
+		// artifact bytes back to AuroraBoot over --builder-upload-url. The
+		// exporter pods run inside the cluster, so a Service DNS name works;
+		// only cluster-internal reachability is required. When --builder-upload-url
+		// is unset we fall back to --url for back-compat, which forces the upload
+		// to traverse the public path. Over plaintext http the per-build token
+		// and artifact bytes travel in the clear, so anyone with network access
+		// on the traversed path can capture the token and overwrite artifacts
+		// while the build is Building (watchCRPhase zeroes the token on terminal
+		// transition, closing the window at Ready/Error). Left unforced so dev
+		// environments can iterate without cert setup; a production deployment
+		// should either terminate the upload path via https or scope the URL to
+		// cluster-internal Service DNS.
+		uploadURL := ResolveBuilderUploadURL(c.String("builder-upload-url"), externalURL)
+		if strings.HasPrefix(strings.ToLower(uploadURL), "http://") {
+			fmt.Fprintf(os.Stderr, "Warning: --builder=operator with plaintext upload URL (%s): exporter Pods will PUT the per-build upload token and artifact bytes over http. Fine on cluster-internal Service DNS, risky over public paths.\n", uploadURL)
 		}
 		b, err := operator.New(operator.Config{
 			RESTConfig:    cfg,
 			Namespace:     c.String("builder-namespace"),
 			Store:         artifactStore,
-			AuroraBootURL: externalURL,
+			AuroraBootURL: uploadURL,
 		})
 		if err != nil {
 			return err
@@ -387,6 +394,16 @@ func serveWith(w io.Writer, listenAddr, tlsCert, tlsKey string, startTLS, startP
 		"*****************************************************************************\n\n"
 	_, _ = io.WriteString(w, warning)
 	return startPlain()
+}
+
+// ResolveBuilderUploadURL returns the URL exporter pods should PUT built
+// artifacts to. An explicit --builder-upload-url wins; otherwise it falls
+// back to --url so single-URL deployments keep working unchanged.
+func ResolveBuilderUploadURL(builderUploadURL, externalURL string) string {
+	if builderUploadURL != "" {
+		return builderUploadURL
+	}
+	return externalURL
 }
 
 // loadOrGenerateSecret reads the secret from path if it exists, otherwise

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -143,21 +143,27 @@ func runWeb(c *cli.Context) error {
 	}
 	keysDir := filepath.Join(dataDir, "keys")
 
-	// Resolve secrets in priority order: flag/env > persisted file > generate.
 	// Persisted secrets live under <data-dir>/secrets/ so they survive restarts.
+	// Admin password resolves as flag/env > file > generate. The registration
+	// token treats the env var as a seed rather than a hard override so a
+	// runtime rotation via the settings API survives a pod restart; see
+	// ResolveRegistrationToken.
 	secretsDir := filepath.Join(dataDir, "secrets")
 	if err := os.MkdirAll(secretsDir, 0700); err != nil {
 		return fmt.Errorf("create secrets directory: %w", err)
 	}
 	adminPasswordFile := filepath.Join(secretsDir, "admin-password")
 	regTokenFile := filepath.Join(secretsDir, "registration-token")
+	regTokenSeedFile := filepath.Join(secretsDir, "registration-token.seed")
 
 	if adminPassword == "" {
 		adminPassword = loadOrGenerateSecret(adminPasswordFile, "admin password")
 	}
-	if regToken == "" {
-		regToken = loadOrGenerateSecret(regTokenFile, "registration token")
+	resolvedRegToken, err := ResolveRegistrationToken(regToken, regTokenFile, regTokenSeedFile)
+	if err != nil {
+		return fmt.Errorf("resolve registration token: %w", err)
 	}
+	regToken = resolvedRegToken
 	if externalURL == "" {
 		hostname, _ := os.Hostname()
 		if hostname == "" {

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -146,9 +146,10 @@ func runWeb(c *cli.Context) error {
 
 	// Persisted secrets live under <data-dir>/secrets/ so they survive restarts.
 	// Admin password resolves as flag/env > file > generate. The registration
-	// token treats the env var as a seed rather than a hard override so a
-	// runtime rotation via the settings API survives a pod restart; see
-	// ResolveRegistrationToken.
+	// token treats the launch-time value (from --registration-token or its
+	// AURORABOOT_REG_TOKEN env var) as a seed rather than a hard override,
+	// so a runtime rotation via the settings API survives a pod restart;
+	// see ResolveRegistrationToken.
 	secretsDir := filepath.Join(dataDir, "secrets")
 	if err := os.MkdirAll(secretsDir, 0700); err != nil {
 		return fmt.Errorf("create secrets directory: %w", err)


### PR DESCRIPTION
Ships a chart under deploy/helm/auroraboot that installs the web UI next to the kairos-operator. Only `host` is required; the chart derives --url, wires --builder=operator, grants the SA namespaced RBAC for OSArtifacts and their build pods, and mounts a PVC for /var/lib/auroraboot. Registration token is generated on first install and preserved across upgrades via helm's lookup.

Includes helm-unittest suites, Make targets (helm-chart-{lint,template,test}), and a CI job on ubuntu-latest that installs helm-unittest and runs them.

Can be seen as an alternative to: https://github.com/kairos-io/kairos/issues/1913 . See comment there.


Docs PR: https://github.com/kairos-io/kairos-docs/pull/655