### PR TITLE
fix(grub): quote the model test and export thor_options

### DIFF
--- a/pkg/constants/grub_live_bios.cfg
+++ b/pkg/constants/grub_live_bios.cfg
@@ -12,9 +12,17 @@ fi
 # Get model
 smbios --type 4 --get-string 5 --set model
 # For Thor we need to set the ignored clk and pd, otherwise devices will die during boot
-if test $model == "Thor"; then
+# The expansion must be quoted: unquoted, an empty model (smbios missing or the
+# lookup failing) or a multi-word one (QEMU host CPU strings) splits into
+# multiple test arguments and the comparison wrongly evaluates to true,
+# leaking $thor_options into the cmdline.
+if [ "${model}" = "Thor" ]; then
   echo "Thor device detected, setting ignored clocks and power domains and proper console output"
   set thor_options="pd_ignore_unused clk_ignore_unused console=ttyUTC0,115200 earlycon=tegra_utc,mmio32,0xc5a0000"
+  # Entering a submenu opens a new grub variable context where non-exported
+  # variables are not visible, so entries nested under a submenu would expand
+  # $thor_options to nothing without this.
+  export thor_options
 fi
 
 # Add nomodeset only on x86/amd64-class arches.


### PR DESCRIPTION
Two bugs in the Thor cmdline block in `pkg/constants/grub_live_bios.cfg`,
pulling in opposite directions.

The gate was `if test $model == "Thor"` with $model unquoted. With $model
empty, `test` gets two arguments, misparses, and returns true. Our EFI
grub comes from the Alpine fallback grubartifacts and has no smbios
command at all, so $model is always empty there and every boot "detected"
Thor — meaning $thor_options (pd_ignore_unused, clk_ignore_unused,
console=ttyUTC0,115200, earlycon=tegra_utc) went into the kernel cmdline
on every non-Thor machine and VM. Found while QEMU-testing #685: the EFI
serial console on a plain x86 guest was showing the tegra options.

Meanwhile thor_options was set without `export`. A submenu opens a fresh
grub variable context where non-exported variables are invisible, so any
submenu-nested entry — such as the boot-to-RAM entry added in #685 —
expanded it to nothing. Actual Thor hardware would have quietly lost its
options.

Fixed both: `if [ "${model}" = "Thor" ]`, where an empty value is one
argument and compares false, plus `export thor_options` inside the if.
Comments on both so neither looks removable later.

Probed on the ISO's own grub 2.12 console under QEMU EFI: the unquoted
test returns true with $model unset while the quoted one returns false,
and an unexported variable reads empty inside a submenu where an exported
one survives. A full EFI ISO boot then comes up with a clean cmdline.