### PR TITLE
fix(iso): make live ISOs boot on strict UEFI firmware

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,6 +53,11 @@ const (
 	BuildImgName              = "elemental"
 	GrubCfg                   = "grub.cfg"
 	GrubPrefixDir             = "/boot/grub2"
+	// CdGrubPrefixDir is the prefix baked into Debian/Ubuntu's CD grub
+	// binary (gcdx64.efi.signed / gcdaa64.efi.signed). When we ship the CD
+	// grub on an ISO we must place a grub.cfg at this path so it can find
+	// its config regardless of what the firmware sets $root to.
+	CdGrubPrefixDir = "/boot/grub"
 	GrubEfiCfg                = "search --no-floppy --file --set=root " + IsoKernelPath +
 		"\nset prefix=($root)" + GrubPrefixDir +
 		"\nconfigfile $prefix/" + GrubCfg
@@ -141,6 +146,12 @@ func GetXorrisoBooloaderArgs(root string) []string {
 		"-boot_image", "any", "emul_type=no_emulation",
 		"-append_partition", "2", "0xef", filepath.Join(root, IsoEFIPath),
 		"-boot_image", "any", "efi_path=--interval:appended_partition_2:all::",
+		// Publish appended partitions in a GPT header (with a protective MBR)
+		// so strict UEFI firmwares (VMware ESXi, some OVMF/BMC stacks) that
+		// enumerate the ESP via GPT can find and boot the ISO. Without this
+		// the ISO carries an MBR-only partition table and boot fails on
+		// those firmwares.
+		"-boot_image", "any", "appended_part_as=gpt",
 	}
 	return args
 }

--- a/pkg/constants/constants_test.go
+++ b/pkg/constants/constants_test.go
@@ -1,0 +1,49 @@
+package constants_test
+
+import (
+	"github.com/kairos-io/AuroraBoot/pkg/constants"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetXorrisoBooloaderArgs", Label("constants"), func() {
+	var args []string
+
+	BeforeEach(func() {
+		args = constants.GetXorrisoBooloaderArgs("/tmp/root")
+	})
+
+	It("appends the ESP as EFI partition #2", func() {
+		Expect(args).To(ContainElements("-append_partition", "2", "0xef"))
+	})
+
+	It("emits a GPT header alongside the protective MBR", func() {
+		// Without appended_part_as=gpt, xorriso produces an MBR-only ISO
+		// where the ESP is not exposed as a GPT partition. Strict UEFI
+		// firmware (VMware ESXi, some OVMF/BMC stacks) refuses to boot
+		// such ISOs because it enumerates ESPs via GPT only.
+		Expect(pairedFlagValues(args, "-boot_image", "any")).To(
+			ContainElement("appended_part_as=gpt"),
+		)
+	})
+
+	It("keeps the isohybrid grub2 MBR wired up", func() {
+		Expect(pairedFlagValues(args, "-boot_image", "grub")).To(
+			ContainElement(MatchRegexp(`^grub2_mbr=/tmp/root/+boot/boot_hybrid\.img$`)),
+		)
+	})
+})
+
+// pairedFlagValues walks the args list and returns every value that follows a
+// (flag, group) pair. xorriso arguments come as repeated "-boot_image <group>
+// <k=v>" triples, so this lets tests assert on the k=v values for a given
+// (flag, group) without caring about ordering.
+func pairedFlagValues(args []string, flag, group string) []string {
+	var values []string
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == flag && args[i+1] == group {
+			values = append(values, args[i+2])
+		}
+	}
+	return values
+}

--- a/pkg/constants/suite_test.go
+++ b/pkg/constants/suite_test.go
@@ -1,0 +1,13 @@
+package constants_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConstants(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Constants Suite")
+}

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -461,6 +461,18 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 		b.cfg.Logger.Errorf("Failed writing grub.cfg: %v", err)
 		return err
 	}
+	// The CD grub (gcd*.efi.signed) has its prefix baked to /boot/grub, so
+	// also drop a grub.cfg there. Placed both in the EFI image (USB case,
+	// where $root is the FAT ESP) and in the ISO root (CD case, where $root
+	// is the ISO9660 device).
+	if err = b.writeCdGrubEfiCfg(temp); err != nil {
+		b.cfg.Logger.Errorf("Failed writing CD grub.cfg: %v", err)
+		return err
+	}
+	if err = b.writeCdGrubEfiCfg(isoDir); err != nil {
+		b.cfg.Logger.Errorf("Failed writing CD grub.cfg: %v", err)
+		return err
+	}
 
 	// For RISC-V, create startup.nsh to auto-boot since some UEFI implementations
 	// don't automatically load the fallback boot path (BOOTRISCV64.EFI)
@@ -548,6 +560,19 @@ func (b BuildISOAction) createEFI(rootdir string, isoDir string) error {
 // writeDefaultGrubEfiCfg writes the default grub.cfg for the EFI image in teh given path
 func (b *BuildISOAction) writeDefaultGrubEfiCfg(path string) error {
 	calculatedPath := filepath.Join(path, constants.EfiBootPath, constants.GrubCfg)
+	return b.cfg.Fs.WriteFile(calculatedPath, []byte(constants.GrubEfiCfg), constants.FilePerm)
+}
+
+// writeCdGrubEfiCfg writes grub.cfg at /boot/grub/grub.cfg to match the prefix
+// baked into gcdx64.efi.signed / gcdaa64.efi.signed. Without this, the CD grub
+// (which we prefer for ISO builds) drops to the rescue prompt on firmwares
+// where $root resolves to the ISO9660 root at boot.
+func (b *BuildISOAction) writeCdGrubEfiCfg(path string) error {
+	calculatedPath := filepath.Join(path, constants.CdGrubPrefixDir, constants.GrubCfg)
+	if err := utils.MkdirAll(b.cfg.Fs, filepath.Dir(calculatedPath), constants.DirPerm); err != nil {
+		b.cfg.Logger.Errorf("Failed creating base dir for CD grub.cfg: %v", err)
+		return err
+	}
 	return b.cfg.Fs.WriteFile(calculatedPath, []byte(constants.GrubEfiCfg), constants.FilePerm)
 }
 
@@ -642,16 +667,26 @@ func (b BuildISOAction) copyShim(tempdir, rootdir string) error {
 	return err
 }
 
-// getEfiGrubFilesForArch returns the possible grub EFI file paths for the given architecture.
-// For riscv64, prepend the openSUSE layout then delegate to the SDK (Debian/Ubuntu monolithic paths, ESP fallbacks, etc.).
+// getEfiGrubFilesForArch returns the possible grub EFI file paths for the given
+// architecture, ordered by preference for building a live ISO.
+//
+// Debian and Ubuntu ship two signed grub binaries: gcd*.efi.signed (prefix
+// /boot/grub, iso9660 baked in, meant for CD/removable media) and
+// grub*.efi.signed (prefix /EFI/<distro>, meant for on-disk installs). The SDK
+// list returns the disk one first because it is what raw-disk builds want.
+// For ISOs we prefer the CD variant, so we prepend it here. The disk variant
+// stays in the list as a fallback for rootfs images that only ship it.
 func getEfiGrubFilesForArch(arch string) []string {
-	if utils.IsRiscv64(arch) {
-		return append(
-			[]string{"/usr/share/efi/riscv64/grub.efi"},
-			sdkutils.GetEfiGrubFiles(arch)...,
-		)
+	sdkPaths := sdkutils.GetEfiGrubFiles(arch)
+	switch {
+	case utils.IsRiscv64(arch):
+		return append([]string{"/usr/share/efi/riscv64/grub.efi"}, sdkPaths...)
+	case arch == constants.ArchAmd64 || arch == constants.Archx86:
+		return append([]string{"/usr/lib/grub/x86_64-efi-signed/gcdx64.efi.signed"}, sdkPaths...)
+	case arch == constants.ArchArm64 || arch == constants.Archaarch64:
+		return append([]string{"/usr/lib/grub/arm64-efi-signed/gcdaa64.efi.signed"}, sdkPaths...)
 	}
-	return sdkutils.GetEfiGrubFiles(arch)
+	return sdkPaths
 }
 
 // copyGrub copies the shim files into the EFI partition
@@ -802,17 +837,25 @@ func (b BuildISOAction) applySources(target string, sources ...*imagetypes.Image
 	return nil
 }
 
-// cleanupGrubName will cleanup the grub name to provide a proper grub named file
-// As the original name can contain several suffixes to indicate its signed status
-// we need to clean them up before using them as the shim will look for a file with
-// no suffixes
+// cleanupGrubName normalises a grub EFI filename so shim can chainload it.
+//
+// Two things happen here:
+//  1. Signing suffixes (.signed, .dualsigned, .signed.latest) are stripped,
+//     because shim looks up its grub payload by the unsuffixed name.
+//  2. The CD-media grub (gcdx64.efi / gcdaa64.efi) is renamed to the
+//     corresponding grub*.efi name. Ubuntu's shim is compiled to load
+//     grub{x64,aa64}.efi from the same directory, so we cannot leave the
+//     "gcd" name on disk or Secure Boot chainloading fails.
 func cleanupGrubName(name string) string {
-	// remove the .signed suffix if present
-	clean := strings.TrimSuffix(name, ".signed")
-	// remove the .dualsigned suffix if present
+	clean := strings.TrimSuffix(name, ".signed.latest")
 	clean = strings.TrimSuffix(clean, ".dualsigned")
-	// remove the .signed.latest suffix if present
-	clean = strings.TrimSuffix(clean, ".signed.latest")
+	clean = strings.TrimSuffix(clean, ".signed")
+	switch clean {
+	case "gcdx64.efi":
+		return "grubx64.efi"
+	case "gcdaa64.efi":
+		return "grubaa64.efi"
+	}
 	return clean
 }
 

--- a/pkg/ops/iso_test.go
+++ b/pkg/ops/iso_test.go
@@ -1,12 +1,17 @@
 package ops
 
 import (
+	"path/filepath"
 	"strings"
+
+	sdkConfig "github.com/kairos-io/kairos-sdk/types/config"
+	"github.com/kairos-io/kairos-sdk/types/logger"
 
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
 	sdkutils "github.com/kairos-io/kairos-sdk/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/twpayne/go-vfs/v5/vfst"
 )
 
 var _ = Describe("applyGrubTemplate", Label("iso"), func() {
@@ -60,7 +65,93 @@ var _ = Describe("getEfiGrubFilesForArch", Label("iso"), func() {
 		Expect(paths).To(Equal(append([]string{"/usr/share/efi/riscv64/grub.efi"}, sdkPaths...)))
 	})
 
-	It("returns the SDK path list for non-riscv64 arches", func() {
-		Expect(getEfiGrubFilesForArch("arm64")).To(Equal(sdkutils.GetEfiGrubFiles("arm64")))
+	It("prepends gcdx64.efi.signed on amd64 so the ISO uses the CD grub, not the disk one", func() {
+		// gcdx64.efi.signed has iso9660 baked in and its prefix set to
+		// /boot/grub, which is what a live ISO needs. grubx64.efi.signed
+		// is built for disk installs and its /EFI/ubuntu prefix breaks on
+		// firmware that sets $root to the ISO9660 partition.
+		paths := getEfiGrubFilesForArch("amd64")
+		Expect(paths[0]).To(Equal("/usr/lib/grub/x86_64-efi-signed/gcdx64.efi.signed"))
+		Expect(paths).To(ContainElement("/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed"))
+		Expect(indexOf(paths, "/usr/lib/grub/x86_64-efi-signed/gcdx64.efi.signed")).To(
+			BeNumerically("<", indexOf(paths, "/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed")),
+		)
 	})
+
+	It("prepends gcdaa64.efi.signed on arm64 for the same reason", func() {
+		paths := getEfiGrubFilesForArch("arm64")
+		Expect(paths[0]).To(Equal("/usr/lib/grub/arm64-efi-signed/gcdaa64.efi.signed"))
+		Expect(paths).To(ContainElement("/usr/lib/grub/arm64-efi-signed/grubaa64.efi.signed"))
+		Expect(indexOf(paths, "/usr/lib/grub/arm64-efi-signed/gcdaa64.efi.signed")).To(
+			BeNumerically("<", indexOf(paths, "/usr/lib/grub/arm64-efi-signed/grubaa64.efi.signed")),
+		)
+	})
+
+	It("keeps the full SDK path list after the CD-grub prepends", func() {
+		amd64Paths := getEfiGrubFilesForArch("amd64")
+		for _, p := range sdkutils.GetEfiGrubFiles("amd64") {
+			Expect(amd64Paths).To(ContainElement(p))
+		}
+	})
+})
+
+func indexOf(list []string, target string) int {
+	for i, s := range list {
+		if s == target {
+			return i
+		}
+	}
+	return -1
+}
+
+var _ = Describe("writeCdGrubEfiCfg", Label("iso"), func() {
+	// gcdx64.efi.signed (and its arm64 equivalent) is compiled with prefix
+	// /boot/grub. When the CD-media grub is loaded it looks for its config at
+	// ($root)/boot/grub/grub.cfg. Without a file at that path the ISO drops
+	// to the grub rescue prompt on firmwares where $root is the ISO device.
+	It("writes grub.cfg at /boot/grub/grub.cfg with the chainloader stub", func() {
+		fs, cleanup, err := vfst.NewTestFS(nil)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanup)
+
+		b := &BuildISOAction{cfg: &BuildConfig{Config: sdkConfig.Config{
+			Fs:     fs,
+			Logger: logger.NewNullLogger(),
+		}}}
+
+		root := "/iso"
+		Expect(fs.Mkdir(root, 0o755)).To(Succeed())
+
+		Expect(b.writeCdGrubEfiCfg(root)).To(Succeed())
+
+		out, err := fs.ReadFile(filepath.Join(root, "boot", "grub", constants.GrubCfg))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(out)).To(Equal(constants.GrubEfiCfg))
+	})
+})
+
+var _ = Describe("cleanupGrubName", Label("iso"), func() {
+	DescribeTable("strips signature suffixes",
+		func(in, want string) {
+			Expect(cleanupGrubName(in)).To(Equal(want))
+		},
+		Entry("plain grubx64.efi", "grubx64.efi", "grubx64.efi"),
+		Entry("Ubuntu grubx64.efi.signed", "grubx64.efi.signed", "grubx64.efi"),
+		Entry("Ubuntu grubaa64.efi.signed", "grubaa64.efi.signed", "grubaa64.efi"),
+		Entry("Ubuntu grubaa64.efi.dualsigned", "grubaa64.efi.dualsigned", "grubaa64.efi"),
+		Entry("Ubuntu grubaa64.efi.signed.latest", "grubaa64.efi.signed.latest", "grubaa64.efi"),
+	)
+
+	DescribeTable("renames the CD grub to the name shim chainloads",
+		func(in, want string) {
+			// Ubuntu's shim is compiled to load grub{x64,aa64}.efi from the
+			// same directory. When we ship the CD variant of grub, its
+			// filename is gcd*.efi.signed. We must rename it so shim finds
+			// it under Secure Boot.
+			Expect(cleanupGrubName(in)).To(Equal(want))
+		},
+		Entry("gcdx64.efi.signed becomes grubx64.efi", "gcdx64.efi.signed", "grubx64.efi"),
+		Entry("gcdaa64.efi.signed becomes grubaa64.efi", "gcdaa64.efi.signed", "grubaa64.efi"),
+		Entry("plain gcdx64.efi (unsigned build) also renames", "gcdx64.efi", "grubx64.efi"),
+	)
 })


### PR DESCRIPTION
Two independent defects were preventing the live ISO from booting on some UEFI stacks (VMware ESXi/Workstation, some OVMF/BMC virtual media). Both manifest as "no bootable device" or a silent drop through the boot manager, so the reporter hit them together.

1. MBR-only ISO xorriso was invoked without appended_part_as=gpt, so the ESP was only exposed via MBR partition entries. Strict firmware enumerates ESPs via GPT only and refuses to boot such ISOs. Add the flag so xorriso emits a GPT header alongside the protective MBR, matching Ubuntu's layout.

2. Wrong grub EFI binary The rootfs search list preferred grubx64.efi.signed (the disk-installer grub whose prefix is /EFI/ubuntu and which lacks iso9660 baked in). On firmware that sets \$root to the ISO9660 device, that grub cannot read its own filesystem, let alone find its config, and drops to rescue. Prefer gcdx64.efi.signed / gcdaa64.efi.signed for live media, which have iso9660 baked in and prefix /boot/grub.

   To keep shim chainloading working under Secure Boot, cleanupGrubName now renames gcd*.efi to grub*.efi on copy (shim looks for grubx64.efi next to itself). A grub.cfg is also written at /boot/grub/grub.cfg (both in the EFI image for the USB case and on the ISO root for the CD case) so the CD grub finds its config regardless of what the firmware set \$root to.