### PR TITLE
fix(ci): install libpcsclite-dev for the riscv64 build

### DIFF
--- a/.github/workflows/test-riscv64.yml
+++ b/.github/workflows/test-riscv64.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install build deps
+        # libpcsclite-dev is required by github.com/go-piv/piv-go/v2 (transitive
+        # via sbctl), same as the amd64 tests.yml jobs and the Dockerfiles.
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
+
       - name: Build binary
         run: |
           go build -v -o auroraboot .

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -28,6 +28,8 @@ ADD . .
 # UI is pre-built and included in the build context
 COPY --from=swagger /app/docs ./docs
 ENV VERSION=$VERSION
+# libpcsclite-dev is required by github.com/go-piv/piv-go/v2 (transitive via sbctl)
+RUN apt-get update && apt-get install -y --no-install-recommends libpcsclite-dev && rm -rf /var/lib/apt/lists/*
 RUN go build -ldflags "-X main.version=${VERSION}" -o auroraboot
 
 # RISC-V 64 stage - uses fedorariscv/base since official fedora:42 lacks riscv64


### PR DESCRIPTION
## Summary

`build-linux-riscv64` has failed on **every** open PR since #683 bumped sbctl, which pulls in `github.com/go-piv/piv-go/v2` (a CGO PIV/smartcard library) transitively via `pkg/secureboot`. That dependency needs `libpcsclite` at build time:

```
# github.com/go-piv/piv-go/v2/piv
Package libpcsclite was not found in the pkg-config search path
```

#683 added the `libpcsclite-dev` install to the **amd64** `Dockerfile` and `tests.yml`, but the two **riscv64** build paths were missed. This mirrors that same fix where it was omitted:

- **`test-riscv64.yml`** — install `libpcsclite-dev` before the native `go build` / `go test` on the `ubuntu-24.04-riscv` runner.
- **`Dockerfile.riscv64`** — install `libpcsclite-dev` in the builder stage before `go build`, matching `Dockerfile` (amd64).

No dependency or code change — this only adds the missing system build dep, restoring the riscv64 build to green. It unblocks the `build-linux-riscv64` gate across all open PRs.
