### PR TITLE
feat: AuroraBoot post-reboot reset lifecycle (kairos#4255)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1968,6 +1968,10 @@ const docTemplate = `{
                 "lastHeartbeat": {
                     "type": "string"
                 },
+                "lastReset": {
+                    "description": "LastReset is when the most recent automatic reset completed successfully.",
+                    "type": "string"
+                },
                 "machineID": {
                     "type": "string"
                 },
@@ -1978,6 +1982,14 @@ const docTemplate = `{
                     }
                 },
                 "phase": {
+                    "type": "string"
+                },
+                "resetRequestedAt": {
+                    "description": "ResetRequestedAt is when the reset command was issued (ResetState set to\npending); nil when no reset has been requested.",
+                    "type": "string"
+                },
+                "resetState": {
+                    "description": "ResetState tracks the day-2 automatic-reset lifecycle across the reboot a\nreset command triggers (kairos-io/kairos#4255). A reset can't complete\nsynchronously — the agent selects the statereset boot entry and reboots — so\nthe command acks immediately and the real outcome is resolved here when the\nnode re-registers and reports its post-reboot boot state. One of:\n\"\" (none) | pending | in-progress | done | failed.",
                     "type": "string"
                 },
                 "updatedAt": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1961,6 +1961,10 @@
                 "lastHeartbeat": {
                     "type": "string"
                 },
+                "lastReset": {
+                    "description": "LastReset is when the most recent automatic reset completed successfully.",
+                    "type": "string"
+                },
                 "machineID": {
                     "type": "string"
                 },
@@ -1971,6 +1975,14 @@
                     }
                 },
                 "phase": {
+                    "type": "string"
+                },
+                "resetRequestedAt": {
+                    "description": "ResetRequestedAt is when the reset command was issued (ResetState set to\npending); nil when no reset has been requested.",
+                    "type": "string"
+                },
+                "resetState": {
+                    "description": "ResetState tracks the day-2 automatic-reset lifecycle across the reboot a\nreset command triggers (kairos-io/kairos#4255). A reset can't complete\nsynchronously — the agent selects the statereset boot entry and reboots — so\nthe command acks immediately and the real outcome is resolved here when the\nnode re-registers and reports its post-reboot boot state. One of:\n\"\" (none) | pending | in-progress | done | failed.",
                     "type": "string"
                 },
                 "updatedAt": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -486,6 +486,9 @@ definitions:
         type: object
       lastHeartbeat:
         type: string
+      lastReset:
+        description: LastReset is when the most recent automatic reset completed successfully.
+        type: string
       machineID:
         type: string
       osRelease:
@@ -493,6 +496,20 @@ definitions:
           type: string
         type: object
       phase:
+        type: string
+      resetRequestedAt:
+        description: |-
+          ResetRequestedAt is when the reset command was issued (ResetState set to
+          pending); nil when no reset has been requested.
+        type: string
+      resetState:
+        description: |-
+          ResetState tracks the day-2 automatic-reset lifecycle across the reboot a
+          reset command triggers (kairos-io/kairos#4255). A reset can't complete
+          synchronously — the agent selects the statereset boot entry and reboots — so
+          the command acks immediately and the real outcome is resolved here when the
+          node re-registers and reports its post-reboot boot state. One of:
+          "" (none) | pending | in-progress | done | failed.
         type: string
       updatedAt:
         type: string

--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -51,6 +51,12 @@ func (a *NodeStoreAdapter) ClaimNode(ctx context.Context, groupID, claimKey stri
 func (a *NodeStoreAdapter) ReleaseNode(ctx context.Context, nodeID, claimKey string) (bool, error) {
 	return a.S.ReleaseNode(ctx, nodeID, claimKey)
 }
+func (a *NodeStoreAdapter) SetResetPending(ctx context.Context, nodeID string) error {
+	return a.S.SetResetPending(ctx, nodeID)
+}
+func (a *NodeStoreAdapter) AdvanceReset(ctx context.Context, nodeID string, fromStates []string, to string, stampLastReset bool) (bool, error) {
+	return a.S.AdvanceReset(ctx, nodeID, fromStates, to, stampLastReset)
+}
 func (a *NodeStoreAdapter) Delete(ctx context.Context, id string) error {
 	return a.S.NodeDelete(ctx, id)
 }

--- a/internal/store/gorm/node_reset_test.go
+++ b/internal/store/gorm/node_reset_test.go
@@ -1,0 +1,129 @@
+package gorm_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+)
+
+var _ = Describe("Gorm Store reset lifecycle", func() {
+	var (
+		s   *gormstore.Store
+		ctx context.Context
+	)
+
+	register := func(machineID string) *store.ManagedNode {
+		n := &store.ManagedNode{MachineID: machineID}
+		Expect(s.Register(ctx, n)).To(Succeed())
+		return n
+	}
+
+	BeforeEach(func() {
+		var err error
+		s, err = gormstore.New(filepath.Join(GinkgoT().TempDir(), "reset.db"))
+		Expect(err).NotTo(HaveOccurred())
+		ctx = context.Background()
+	})
+
+	AfterEach(func() { Expect(s.Close()).To(Succeed()) })
+
+	It("SetResetPending marks the node pending and stamps the request time", func() {
+		n := register("n1")
+		Expect(s.SetResetPending(ctx, n.ID)).To(Succeed())
+
+		got, err := s.NodeGetByID(ctx, n.ID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.ResetState).To(Equal(store.ResetStatePending))
+		Expect(got.ResetRequestedAt).NotTo(BeNil())
+		Expect(got.LastReset).To(BeNil())
+	})
+
+	It("advances pending -> in-progress without stamping LastReset", func() {
+		n := register("n1")
+		Expect(s.SetResetPending(ctx, n.ID)).To(Succeed())
+
+		ok, err := s.AdvanceReset(ctx, n.ID, []string{store.ResetStatePending}, store.ResetStateInProgress, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		got, _ := s.NodeGetByID(ctx, n.ID)
+		Expect(got.ResetState).To(Equal(store.ResetStateInProgress))
+		Expect(got.LastReset).To(BeNil())
+	})
+
+	It("advances an in-flight reset -> done and stamps LastReset", func() {
+		n := register("n1")
+		Expect(s.SetResetPending(ctx, n.ID)).To(Succeed())
+
+		ok, err := s.AdvanceReset(ctx, n.ID,
+			[]string{store.ResetStatePending, store.ResetStateInProgress}, store.ResetStateDone, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		got, _ := s.NodeGetByID(ctx, n.ID)
+		Expect(got.ResetState).To(Equal(store.ResetStateDone))
+		Expect(got.LastReset).NotTo(BeNil())
+	})
+
+	It("advances an in-flight reset -> failed", func() {
+		n := register("n1")
+		Expect(s.SetResetPending(ctx, n.ID)).To(Succeed())
+
+		ok, err := s.AdvanceReset(ctx, n.ID,
+			[]string{store.ResetStatePending, store.ResetStateInProgress}, store.ResetStateFailed, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		got, _ := s.NodeGetByID(ctx, n.ID)
+		Expect(got.ResetState).To(Equal(store.ResetStateFailed))
+		Expect(got.LastReset).To(BeNil())
+	})
+
+	It("does not transition when the current state is not in fromStates", func() {
+		n := register("n1") // ResetState == "" (no reset requested)
+		ok, err := s.AdvanceReset(ctx, n.ID,
+			[]string{store.ResetStatePending, store.ResetStateInProgress}, store.ResetStateDone, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeFalse())
+
+		got, _ := s.NodeGetByID(ctx, n.ID)
+		Expect(got.ResetState).To(Equal(""))
+		Expect(got.LastReset).To(BeNil())
+	})
+
+	It("resolves exactly once under concurrent AdvanceReset", func() {
+		n := register("n1")
+		Expect(s.SetResetPending(ctx, n.ID)).To(Succeed())
+
+		const workers = 12
+		wins := make(chan bool, workers)
+		var wg sync.WaitGroup
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				ok, err := s.AdvanceReset(ctx, n.ID,
+					[]string{store.ResetStatePending, store.ResetStateInProgress}, store.ResetStateDone, true)
+				Expect(err).NotTo(HaveOccurred())
+				wins <- ok
+			}()
+		}
+		wg.Wait()
+		close(wins)
+
+		won := 0
+		for w := range wins {
+			if w {
+				won++
+			}
+		}
+		Expect(won).To(Equal(1), "exactly one concurrent resolver must perform the transition")
+	})
+})

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -419,6 +419,38 @@ func (s *Store) ReleaseNode(ctx context.Context, nodeID, claimKey string) (bool,
 	return res.RowsAffected == 1, nil
 }
 
+// SetResetPending marks a node as awaiting an automatic reset.
+func (s *Store) SetResetPending(ctx context.Context, nodeID string) error {
+	now := time.Now()
+	return s.db.WithContext(ctx).Model(&store.ManagedNode{}).
+		Where("id = ?", nodeID).
+		Updates(map[string]any{
+			"reset_state":        store.ResetStatePending,
+			"reset_requested_at": &now,
+		}).Error
+}
+
+// AdvanceReset compare-and-sets a node's ResetState. The conditional UPDATE
+// (... WHERE id = ? AND reset_state IN fromStates) means exactly one of several
+// concurrent re-register resolvers performs any given transition; the losers see
+// RowsAffected == 0. When stampLastReset is set, last_reset is written in the same
+// statement so the "done" transition and its timestamp land atomically. This
+// mirrors the store's existing CAS idiom (ClaimForDelivery / CASEjectState).
+func (s *Store) AdvanceReset(ctx context.Context, nodeID string, fromStates []string, to string, stampLastReset bool) (bool, error) {
+	updates := map[string]any{"reset_state": to}
+	if stampLastReset {
+		now := time.Now()
+		updates["last_reset"] = &now
+	}
+	res := s.db.WithContext(ctx).Model(&store.ManagedNode{}).
+		Where("id = ? AND reset_state IN ?", nodeID, fromStates).
+		Updates(updates)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
 // --- CommandStore ---
 
 func (s *Store) CommandCreate(ctx context.Context, cmd *store.NodeCommand) error {

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -72,7 +72,11 @@ func (f *fakeNodeStore) ClaimNode(_ context.Context, _, _ string) (*store.Manage
 	return nil, store.ErrNoClaimCapacity
 }
 func (f *fakeNodeStore) ReleaseNode(_ context.Context, _, _ string) (bool, error) { return false, nil }
-func (f *fakeNodeStore) Delete(_ context.Context, _ string) error                 { return nil }
+func (f *fakeNodeStore) SetResetPending(_ context.Context, _ string) error        { return nil }
+func (f *fakeNodeStore) AdvanceReset(_ context.Context, _ string, _ []string, _ string, _ bool) (bool, error) {
+	return false, nil
+}
+func (f *fakeNodeStore) Delete(_ context.Context, _ string) error { return nil }
 
 var _ = Describe("AdminMiddleware", func() {
 	var (

--- a/pkg/handlers/commands.go
+++ b/pkg/handlers/commands.go
@@ -68,6 +68,15 @@ func (h *CommandHandler) Create(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create command"})
 	}
 
+	// A reset reboots the node (the agent selects the statereset boot entry), so it
+	// can't complete synchronously. Mark the node as awaiting reset so the
+	// re-register resolver reports the real outcome from the post-reboot boot state
+	// (kairos-io/kairos#4255). Best-effort: a failure here doesn't invalidate the
+	// queued command.
+	if cmd.Command == store.CmdReset {
+		_ = h.nodes.SetResetPending(c.Request().Context(), nodeID)
+	}
+
 	// Push command via WebSocket if node is online.
 	h.pushCommand(c.Request().Context(), cmd)
 

--- a/pkg/handlers/commands.go
+++ b/pkg/handlers/commands.go
@@ -123,6 +123,12 @@ func (h *CommandHandler) CreateBulk(c echo.Context) error {
 		if err := h.commands.Create(ctx, cmd); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create command"})
 		}
+		// A reset reboots the node, so mark it pending here too — the bulk and
+		// group command paths must track resets the same as the single-node
+		// Create (kairos-io/kairos#4255). Best-effort.
+		if req.Command == store.CmdReset {
+			_ = h.nodes.SetResetPending(ctx, node.ID)
+		}
 		h.pushCommand(ctx, cmd)
 		created = append(created, cmd)
 	}
@@ -159,6 +165,12 @@ func (h *CommandHandler) CreateForGroup(c echo.Context) error {
 		}
 		if err := h.commands.Create(ctx, cmd); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to create command"})
+		}
+		// A reset reboots the node, so mark it pending here too — the bulk and
+		// group command paths must track resets the same as the single-node
+		// Create (kairos-io/kairos#4255). Best-effort.
+		if req.Command == store.CmdReset {
+			_ = h.nodes.SetResetPending(ctx, node.ID)
 		}
 		h.pushCommand(ctx, cmd)
 		created = append(created, cmd)

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -210,6 +210,40 @@ func (f *fakeNodeStore) ReleaseNode(_ context.Context, nodeID, claimKey string) 
 	return false, nil
 }
 
+func (f *fakeNodeStore) SetResetPending(_ context.Context, nodeID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range f.nodes {
+		if n.ID == nodeID {
+			now := time.Now()
+			n.ResetState = store.ResetStatePending
+			n.ResetRequestedAt = &now
+			return nil
+		}
+	}
+	return fmt.Errorf("not found")
+}
+func (f *fakeNodeStore) AdvanceReset(_ context.Context, nodeID string, fromStates []string, to string, stampLastReset bool) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, n := range f.nodes {
+		if n.ID != nodeID {
+			continue
+		}
+		for _, from := range fromStates {
+			if n.ResetState == from {
+				n.ResetState = to
+				if stampLastReset {
+					now := time.Now()
+					n.LastReset = &now
+				}
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return false, nil
+}
 func (f *fakeNodeStore) Delete(_ context.Context, id string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -86,6 +86,34 @@ func (h *NodeHandler) triggerFinalize(nodeID string) {
 	}()
 }
 
+// resolveReset advances a node's automatic-reset lifecycle (kairos-io/kairos#4255)
+// when it re-registers after the reset reboot. The phonehome agent calls Register
+// on every boot, so a Register from a node whose ResetState is pending/in-progress
+// means it rebooted; the reported boot state gives the outcome:
+//   - autoreset        → in-progress (the node booted the statereset entry and is
+//     mid-reset; the following boot will be active)
+//   - active           → done (the reset finished and the node is healthy again),
+//     stamping LastReset
+//   - passive/recovery → failed (the active image did not survive the reset)
+//
+// Transitions are compare-and-set so concurrent re-registers resolve exactly once.
+// Best-effort: a store error is ignored — the next boot/heartbeat retries. A node
+// not awaiting a reset is left untouched.
+func (h *NodeHandler) resolveReset(ctx context.Context, node *store.ManagedNode, bootState string) {
+	if node.ResetState != store.ResetStatePending && node.ResetState != store.ResetStateInProgress {
+		return
+	}
+	inFlight := []string{store.ResetStatePending, store.ResetStateInProgress}
+	switch bootState {
+	case store.BootStateAutoReset:
+		_, _ = h.nodes.AdvanceReset(ctx, node.ID, []string{store.ResetStatePending}, store.ResetStateInProgress, false)
+	case store.BootStateActive:
+		_, _ = h.nodes.AdvanceReset(ctx, node.ID, inFlight, store.ResetStateDone, true)
+	case store.BootStatePassive, store.BootStateRecovery:
+		_, _ = h.nodes.AdvanceReset(ctx, node.ID, inFlight, store.ResetStateFailed, false)
+	}
+}
+
 // registerRequest is the expected body for node registration.
 type registerRequest struct {
 	RegistrationToken string              `json:"registrationToken"`
@@ -125,6 +153,9 @@ func (h *NodeHandler) Register(c echo.Context) error {
 		// A re-register is a strong "OS is up" signal too (a freshly-installed node
 		// phones home on first boot): attempt the auto eject-on-phone-home.
 		h.triggerFinalize(existing.ID)
+		// If this node is coming back from a reset reboot, resolve the reset
+		// lifecycle from the reported boot state (kairos-io/kairos#4255).
+		h.resolveReset(c.Request().Context(), existing, req.BootState)
 		// Return existing node info
 		return c.JSON(http.StatusOK, map[string]any{
 			"id":     existing.ID,

--- a/pkg/handlers/nodes_reset_test.go
+++ b/pkg/handlers/nodes_reset_test.go
@@ -56,6 +56,58 @@ var _ = Describe("Reset lifecycle", func() {
 		})
 	})
 
+	Describe("issuing a reset via the bulk and group paths marks nodes pending", func() {
+		var cmdHandler *handlers.CommandHandler
+
+		BeforeEach(func() {
+			ns.nodes = []*store.ManagedNode{
+				{ID: "node-1", GroupID: "grp-1"},
+				{ID: "node-2", GroupID: "grp-1"},
+			}
+			cmdHandler = handlers.NewCommandHandler(&fakeCommandStore{}, ns, nil)
+		})
+
+		expectAllPending := func() {
+			for _, n := range ns.nodes {
+				Expect(n.ResetState).To(Equal(store.ResetStatePending))
+				Expect(n.ResetRequestedAt).NotTo(BeNil())
+			}
+		}
+
+		It("CreateBulk marks every selected node pending", func() {
+			body := `{"selector":{"nodeIDs":["node-1","node-2"]},"command":"reset"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/commands", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			Expect(cmdHandler.CreateBulk(e.NewContext(req, rec))).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusCreated))
+			expectAllPending()
+		})
+
+		It("CreateForGroup marks every group node pending", func() {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/groups/grp-1/commands", strings.NewReader(`{"command":"reset"}`))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues("grp-1")
+			Expect(cmdHandler.CreateForGroup(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusCreated))
+			expectAllPending()
+		})
+
+		It("a non-reset bulk command leaves ResetState empty", func() {
+			body := `{"selector":{"nodeIDs":["node-1","node-2"]},"command":"upgrade"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/commands", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			Expect(cmdHandler.CreateBulk(e.NewContext(req, rec))).To(Succeed())
+			for _, n := range ns.nodes {
+				Expect(n.ResetState).To(Equal(""))
+			}
+		})
+	})
+
 	Describe("re-register resolves the reset from the reported boot state", func() {
 		var nodeHandler *handlers.NodeHandler
 

--- a/pkg/handlers/nodes_reset_test.go
+++ b/pkg/handlers/nodes_reset_test.go
@@ -1,0 +1,119 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/pkg/handlers"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/kairos-io/AuroraBoot/pkg/ws"
+	"github.com/labstack/echo/v4"
+)
+
+var _ = Describe("Reset lifecycle", func() {
+	var (
+		e  *echo.Echo
+		ns *fakeNodeStore
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		ns = &fakeNodeStore{}
+	})
+
+	Describe("issuing a reset command marks the node pending", func() {
+		var cmdHandler *handlers.CommandHandler
+
+		BeforeEach(func() {
+			ns.nodes = []*store.ManagedNode{{ID: "node-1"}}
+			cmdHandler = handlers.NewCommandHandler(&fakeCommandStore{}, ns, nil)
+		})
+
+		create := func(body string) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/node-1/commands", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("nodeID")
+			c.SetParamValues("node-1")
+			Expect(cmdHandler.Create(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusCreated))
+		}
+
+		It("sets ResetState=pending for a reset command", func() {
+			create(`{"command":"reset"}`)
+			Expect(ns.nodes[0].ResetState).To(Equal(store.ResetStatePending))
+			Expect(ns.nodes[0].ResetRequestedAt).NotTo(BeNil())
+		})
+
+		It("leaves ResetState empty for a non-reset command", func() {
+			create(`{"command":"upgrade","args":{"version":"1.2.0"}}`)
+			Expect(ns.nodes[0].ResetState).To(Equal(""))
+		})
+	})
+
+	Describe("re-register resolves the reset from the reported boot state", func() {
+		var nodeHandler *handlers.NodeHandler
+
+		// reregister drives Register for an already-known machineID (existing node).
+		reregister := func(bootState string) {
+			body := `{"machineID":"m1","bootState":"` + bootState + `"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/nodes/register", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			Expect(nodeHandler.Register(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusOK)) // existing node
+		}
+
+		seed := func(resetState string) {
+			ns.nodes = []*store.ManagedNode{{ID: "node-1", MachineID: "m1", APIKey: "k", ResetState: resetState}}
+			nodeHandler = handlers.NewNodeHandler(ns, &fakeCommandStore{}, &fakeGroupStore{}, ws.NewHub(), "reg-token", "http://localhost:8080")
+		}
+
+		It("pending + active boot => done, stamps LastReset", func() {
+			seed(store.ResetStatePending)
+			reregister("active")
+			Expect(ns.nodes[0].ResetState).To(Equal(store.ResetStateDone))
+			Expect(ns.nodes[0].LastReset).NotTo(BeNil())
+		})
+
+		It("pending + autoreset boot => in-progress", func() {
+			seed(store.ResetStatePending)
+			reregister("autoreset")
+			Expect(ns.nodes[0].ResetState).To(Equal(store.ResetStateInProgress))
+			Expect(ns.nodes[0].LastReset).To(BeNil())
+		})
+
+		It("in-progress + active boot => done", func() {
+			seed(store.ResetStateInProgress)
+			reregister("active")
+			Expect(ns.nodes[0].ResetState).To(Equal(store.ResetStateDone))
+			Expect(ns.nodes[0].LastReset).NotTo(BeNil())
+		})
+
+		It("pending + passive boot => failed (active image did not survive)", func() {
+			seed(store.ResetStatePending)
+			reregister("passive")
+			Expect(ns.nodes[0].ResetState).To(Equal(store.ResetStateFailed))
+			Expect(ns.nodes[0].LastReset).To(BeNil())
+		})
+
+		It("pending + recovery boot => failed", func() {
+			seed(store.ResetStatePending)
+			reregister("recovery")
+			Expect(ns.nodes[0].ResetState).To(Equal(store.ResetStateFailed))
+		})
+
+		It("leaves a node that is not awaiting a reset untouched", func() {
+			seed("") // no reset in flight
+			reregister("active")
+			Expect(ns.nodes[0].ResetState).To(Equal(""))
+			Expect(ns.nodes[0].LastReset).To(BeNil())
+		})
+	})
+})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -83,7 +83,11 @@ func (f *fakeNodeStore) ClaimNode(_ context.Context, _, _ string) (*store.Manage
 	return nil, store.ErrNoClaimCapacity
 }
 func (f *fakeNodeStore) ReleaseNode(_ context.Context, _, _ string) (bool, error) { return false, nil }
-func (f *fakeNodeStore) Delete(_ context.Context, _ string) error                 { return nil }
+func (f *fakeNodeStore) SetResetPending(_ context.Context, _ string) error        { return nil }
+func (f *fakeNodeStore) AdvanceReset(_ context.Context, _ string, _ []string, _ string, _ bool) (bool, error) {
+	return false, nil
+}
+func (f *fakeNodeStore) Delete(_ context.Context, _ string) error { return nil }
 
 type fakeCommandStore struct {
 	mu   sync.Mutex

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -74,10 +74,43 @@ type ManagedNode struct {
 	ClaimKey *string `json:"claimKey,omitempty" gorm:"index:idx_node_group_claim,unique,priority:2"`
 	// ClaimedAt is when ClaimKey was set; nil when unclaimed.
 	ClaimedAt *time.Time `json:"claimedAt,omitempty"`
+	// ResetState tracks the day-2 automatic-reset lifecycle across the reboot a
+	// reset command triggers (kairos-io/kairos#4255). A reset can't complete
+	// synchronously — the agent selects the statereset boot entry and reboots — so
+	// the command acks immediately and the real outcome is resolved here when the
+	// node re-registers and reports its post-reboot boot state. One of:
+	// "" (none) | pending | in-progress | done | failed.
+	ResetState string `json:"resetState,omitempty"`
+	// ResetRequestedAt is when the reset command was issued (ResetState set to
+	// pending); nil when no reset has been requested.
+	ResetRequestedAt *time.Time `json:"resetRequestedAt,omitempty"`
+	// LastReset is when the most recent automatic reset completed successfully.
+	LastReset *time.Time `json:"lastReset,omitempty"`
 	APIKey    string     `json:"-" gorm:"index"`
 	CreatedAt time.Time  `json:"createdAt"`
 	UpdatedAt time.Time  `json:"updatedAt"`
 }
+
+// Reported boot states (ManagedNode.BootState) — the short fleet vocabulary the
+// agent sends on register/heartbeat (kairos-io/kairos#4253). Unknown values are
+// still stored as-is; these are the ones the reset lifecycle reasons about.
+const (
+	BootStateActive    = "active"
+	BootStatePassive   = "passive"
+	BootStateRecovery  = "recovery"
+	BootStateAutoReset = "autoreset"
+)
+
+// Reset states (ManagedNode.ResetState) for the day-2 automatic-reset lifecycle
+// (kairos-io/kairos#4255). SetResetPending sets `pending` when a reset command is
+// issued; the re-register resolver advances it from the reported boot state:
+// autoreset → in-progress, active → done, passive/recovery → failed.
+const (
+	ResetStatePending    = "pending"
+	ResetStateInProgress = "in-progress"
+	ResetStateDone       = "done"
+	ResetStateFailed     = "failed"
+)
 
 // Node phases.
 const (
@@ -167,6 +200,17 @@ type NodeStore interface {
 	// caller inspects the node to distinguish those and must not assume ownership
 	// from a false result.
 	ReleaseNode(ctx context.Context, nodeID, claimKey string) (released bool, err error)
+	// SetResetPending marks nodeID as awaiting an automatic reset: ResetState is
+	// set to pending and ResetRequestedAt to now. Called when a reset command is
+	// issued; the outcome is resolved later by AdvanceReset when the node
+	// re-registers with its post-reboot boot state.
+	SetResetPending(ctx context.Context, nodeID string) error
+	// AdvanceReset atomically transitions nodeID's ResetState from any of
+	// fromStates to `to`, returning true only if this call performed the
+	// transition — so concurrent re-registers resolve exactly once. When
+	// stampLastReset is set (the transition to done), LastReset is set to now in
+	// the same update.
+	AdvanceReset(ctx context.Context, nodeID string, fromStates []string, to string, stampLastReset bool) (bool, error)
 	Delete(ctx context.Context, id string) error
 }
 


### PR DESCRIPTION
## Summary

Implements the AuroraBoot server-side **post-reboot reset lifecycle** — the remaining piece of kairos-io/kairos#4255 after the agent side landed (kairos-agent #1307 selects the `statereset` boot entry and reboots) and boot-state reporting landed (#1317 + #655). Design agreed on the issue; @mudler-agent confirmed they're not working on it.

**The gap:** a `reset` reboots the node, so it can't complete synchronously — the command acks immediately, meaning "reset **scheduled**", not "reset **done**". AuroraBoot stored the reported `bootState` but never acted on it, so there was no confirmation the reset actually happened and no `lastReset`.

## Design — mirrors the existing `Deployment.EjectState` CAS

- `ManagedNode` gains **`ResetState`** (`"" | pending | in-progress | done | failed`), **`ResetRequestedAt`**, and **`LastReset`**.
- Issuing a `reset` command marks the node **`pending`** (best-effort; doesn't invalidate the queued command).
- On **re-register**, the lifecycle is resolved from the reported boot state. The phonehome agent calls `Register` on every boot, so a `Register` from a `pending`/`in-progress` node means it rebooted:
  - `autoreset` → **in-progress** (booted the statereset entry, mid-reset)
  - `active` → **done**, stamping `LastReset` (reset finished, node healthy)
  - `passive` / `recovery` → **failed** (the active image didn't survive)
- Transitions are compare-and-set (`... WHERE reset_state IN fromStates`) so concurrent re-registers resolve **exactly once** — same idiom as `ClaimForDelivery` / `CASEjectState`, correct on SQLite and PostgreSQL. `ResetState`/`LastReset` now surface in `GET /nodes` and `GET /nodes/:id`.

## Tests

Store (Ginkgo, file-backed SQLite): pending stamping, every transition, the `LastReset` stamp on done, the CAS no-op when the state isn't in `fromStates`, and exactly-one-winner under concurrent `AdvanceReset` (race-clean). Handlers: the command→pending hook (and that a non-reset command doesn't set it) plus every re-register resolution branch. Backward compatible — new columns default empty.

## Left for follow-up (noted on #4255)

A timeout sweep for a node that never comes back (`pending` → `failed` after a deadline), and the analogous `upgrade` lifecycle. Kept out to keep this focused on `reset`.

Closes the code side of kairos-io/kairos#4255.
