### PR TITLE
feat(ui): add "Fetch releases" picker for k3s/k0s version field

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,8 @@ jobs:
           cache-dependency-path: ui/package-lock.json
       - name: Build UI bundle (embedded via go:embed)
         run: make ui-build
+      - name: Run UI tests
+        run: make ui-test
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev
       - name: Set up QEMU

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # AuroraBoot Makefile
 # Development and build targets for AuroraBoot
 
-.PHONY: help dev ui-install ui-build build-go build clean clean-ui clean-go run-docker build-docker test openapi fmt lint install-deps
+.PHONY: help dev ui-install ui-build ui-test build-go build clean clean-ui clean-go run-docker build-docker test openapi fmt lint install-deps
 
 # Default target
 help: ## Show this help message
@@ -41,6 +41,11 @@ ui-build: ui-install ## Build the React UI bundle
 	@echo "Building React UI..."
 	cd ui && npm run build
 	@echo "UI built to internal/ui/dist"
+
+# Run the React UI vitest suite
+ui-test: ui-install ## Run the React UI test suite
+	@echo "Running UI tests..."
+	cd ui && npm test
 
 # Build Go binary
 build-go: ## Build the Go binary

--- a/ui/src/components/KubernetesReleasePicker.tsx
+++ b/ui/src/components/KubernetesReleasePicker.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  fetchKubernetesDistroReleases,
+  type KubernetesDistro,
+} from "@/lib/githubReleases";
+
+type Props = {
+  distro: KubernetesDistro;
+  onSelect: (tag: string) => void;
+  limit?: number;
+};
+
+export function KubernetesReleasePicker({ distro, onSelect, limit = 5 }: Props) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [tags, setTags] = useState<string[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchKubernetesDistroReleases(distro, limit);
+      setTags(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch releases.");
+    } finally {
+      setLoading(false);
+    }
+  }, [distro, limit]);
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next && tags === null && !loading) {
+      void load();
+    }
+  };
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          {loading ? (
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4 mr-2" />
+          )}
+          Fetch releases
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[16rem]">
+        <DropdownMenuLabel>
+          Latest {distro.toUpperCase()} releases
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {loading && (
+          <div className="flex items-center gap-2 px-2 py-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Fetching from GitHub
+          </div>
+        )}
+        {!loading && error && (
+          <div className="px-2 py-2 space-y-2">
+            <p className="text-sm text-destructive">{error}</p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => void load()}
+            >
+              Retry
+            </Button>
+          </div>
+        )}
+        {!loading && !error && tags && tags.length === 0 && (
+          <div className="px-2 py-2 text-sm text-muted-foreground">
+            No releases found.
+          </div>
+        )}
+        {!loading &&
+          !error &&
+          tags &&
+          tags.length > 0 &&
+          tags.map((tag) => (
+            <DropdownMenuItem
+              key={tag}
+              onSelect={() => {
+                onSelect(tag);
+                setOpen(false);
+              }}
+              className="font-mono text-xs"
+            >
+              {tag}
+            </DropdownMenuItem>
+          ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/ui/src/lib/githubReleases.test.ts
+++ b/ui/src/lib/githubReleases.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearReleaseCache,
+  compareTagsDesc,
+  fetchKubernetesDistroReleases,
+} from "./githubReleases";
+
+type GithubRelease = {
+  tag_name: string;
+  draft?: boolean;
+  prerelease?: boolean;
+};
+
+function mockFetch(responses: Array<{ ok?: boolean; status?: number; body: unknown }>) {
+  let call = 0;
+  return vi.fn(async () => {
+    const r = responses[Math.min(call, responses.length - 1)];
+    call += 1;
+    return {
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.body,
+    } as Response;
+  });
+}
+
+const k3sReleases: GithubRelease[] = [
+  { tag_name: "v1.31.2+k3s1" },
+  { tag_name: "v1.31.2-rc1+k3s1", prerelease: true },
+  { tag_name: "v1.31.1+k3s1" },
+  { tag_name: "v1.31.0+k3s1", draft: true },
+  { tag_name: "v1.30.6+k3s1" },
+  { tag_name: "v1.30.5+k3s1" },
+  { tag_name: "v1.30.4+k3s1" },
+  { tag_name: "v1.30.3+k3s1" },
+];
+
+describe("fetchKubernetesDistroReleases", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    clearReleaseCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hits the k3s releases endpoint and returns stable tags only", async () => {
+    const fetchMock = mockFetch([{ body: k3sReleases }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tags = await fetchKubernetesDistroReleases("k3s", 5);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("api.github.com/repos/k3s-io/k3s/releases");
+    expect(tags).toEqual([
+      "v1.31.2+k3s1",
+      "v1.31.1+k3s1",
+      "v1.30.6+k3s1",
+      "v1.30.5+k3s1",
+      "v1.30.4+k3s1",
+    ]);
+  });
+
+  it("uses the k0s repo for the k0s distro", async () => {
+    const fetchMock = mockFetch([
+      { body: [{ tag_name: "v1.31.2+k0s.0" }, { tag_name: "v1.31.1+k0s.0" }] },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchKubernetesDistroReleases("k0s", 5);
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("api.github.com/repos/k0sproject/k0s/releases");
+  });
+
+  it("caches results in sessionStorage across calls", async () => {
+    const fetchMock = mockFetch([{ body: k3sReleases }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await fetchKubernetesDistroReleases("k3s", 5);
+    const second = await fetchKubernetesDistroReleases("k3s", 5);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(second).toEqual(first);
+  });
+
+  it("throws a friendly error on rate limit", async () => {
+    const fetchMock = mockFetch([
+      { ok: false, status: 403, body: { message: "API rate limit exceeded" } },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchKubernetesDistroReleases("k3s", 5)).rejects.toThrow(/rate limit/i);
+  });
+
+  it("throws on other non-OK responses", async () => {
+    const fetchMock = mockFetch([{ ok: false, status: 500, body: {} }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchKubernetesDistroReleases("k3s", 5)).rejects.toThrow(/500/);
+  });
+
+  it("sorts by semver desc even when GitHub returns backports interleaved", async () => {
+    // GitHub orders by publish date, so a v1.30.x backport can land above a
+    // higher v1.32.x release. We want the higher line at the top.
+    const interleaved: GithubRelease[] = [
+      { tag_name: "v1.30.14+k3s3" },
+      { tag_name: "v1.32.5+k3s1" },
+      { tag_name: "v1.31.10+k3s2" },
+      { tag_name: "v1.32.4+k3s1" },
+      { tag_name: "v1.31.9+k3s1" },
+    ];
+    const fetchMock = mockFetch([{ body: interleaved }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tags = await fetchKubernetesDistroReleases("k3s", 5);
+
+    expect(tags).toEqual([
+      "v1.32.5+k3s1",
+      "v1.32.4+k3s1",
+      "v1.31.10+k3s2",
+      "v1.31.9+k3s1",
+      "v1.30.14+k3s3",
+    ]);
+  });
+});
+
+describe("compareTagsDesc", () => {
+  it("orders higher MAJOR.MINOR.PATCH first", () => {
+    const tags = ["v1.30.14+k3s3", "v1.32.5+k3s1", "v1.31.10+k3s2"];
+    expect([...tags].sort(compareTagsDesc)).toEqual([
+      "v1.32.5+k3s1",
+      "v1.31.10+k3s2",
+      "v1.30.14+k3s3",
+    ]);
+  });
+
+  it("treats 10 as newer than 9 numerically, not lexically", () => {
+    expect(compareTagsDesc("v1.31.10+k3s1", "v1.31.9+k3s1")).toBeLessThan(0);
+  });
+
+  it("tie-breaks equal MAJOR.MINOR.PATCH by suffix", () => {
+    expect(compareTagsDesc("v1.32.5+k3s2", "v1.32.5+k3s1")).toBeLessThan(0);
+  });
+});

--- a/ui/src/lib/githubReleases.test.ts
+++ b/ui/src/lib/githubReleases.test.ts
@@ -96,6 +96,16 @@ describe("fetchKubernetesDistroReleases", () => {
     await expect(fetchKubernetesDistroReleases("k3s", 5)).rejects.toThrow(/rate limit/i);
   });
 
+  it("clamps per_page to GitHub's max of 100 even when limit is high", async () => {
+    const fetchMock = mockFetch([{ body: [] }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchKubernetesDistroReleases("k3s", 500);
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("per_page=100");
+  });
+
   it("throws on other non-OK responses", async () => {
     const fetchMock = mockFetch([{ ok: false, status: 500, body: {} }]);
     vi.stubGlobal("fetch", fetchMock);
@@ -144,5 +154,15 @@ describe("compareTagsDesc", () => {
 
   it("tie-breaks equal MAJOR.MINOR.PATCH by suffix", () => {
     expect(compareTagsDesc("v1.32.5+k3s2", "v1.32.5+k3s1")).toBeLessThan(0);
+  });
+
+  it("compares suffix numerically so k3s10 outranks k3s9", () => {
+    expect(compareTagsDesc("v1.32.5+k3s10", "v1.32.5+k3s9")).toBeLessThan(0);
+    const tags = ["v1.32.5+k3s9", "v1.32.5+k3s10", "v1.32.5+k3s2"];
+    expect([...tags].sort(compareTagsDesc)).toEqual([
+      "v1.32.5+k3s10",
+      "v1.32.5+k3s9",
+      "v1.32.5+k3s2",
+    ]);
   });
 });

--- a/ui/src/lib/githubReleases.ts
+++ b/ui/src/lib/githubReleases.ts
@@ -57,6 +57,16 @@ function parseVersion(tag: string): [number, number, number] | null {
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
+// Trailing digits in the provider suffix — e.g. `+k3s10` → 10, `+k0s.2` → 2.
+// Ignores anything before `+` so a bare `v1.32.5` doesn't pull the patch
+// number into the tie-break; falls back to 0 when no suffix number exists.
+function parseSuffixNumber(tag: string): number {
+  const plus = tag.indexOf("+");
+  if (plus < 0) return 0;
+  const match = tag.slice(plus + 1).match(/(\d+)\D*$/);
+  return match ? Number(match[1]) : 0;
+}
+
 export function compareTagsDesc(a: string, b: string): number {
   const va = parseVersion(a);
   const vb = parseVersion(b);
@@ -64,7 +74,8 @@ export function compareTagsDesc(a: string, b: string): number {
     for (let i = 0; i < 3; i += 1) {
       if (va[i] !== vb[i]) return vb[i] - va[i];
     }
-    // Same MAJOR.MINOR.PATCH → fall back to lexical (e.g. "+k3s2" > "+k3s1").
+    const suffixDiff = parseSuffixNumber(b) - parseSuffixNumber(a);
+    if (suffixDiff !== 0) return suffixDiff;
     return b.localeCompare(a);
   }
   if (va) return -1;
@@ -81,8 +92,8 @@ export async function fetchKubernetesDistroReleases(
   if (cached) return cached;
 
   // per_page pulls more than `limit` so we can drop prereleases/drafts and
-  // still return `limit` stable tags.
-  const perPage = Math.max(limit * 3, 10);
+  // still return `limit` stable tags. Clamped to GitHub's max of 100.
+  const perPage = Math.min(Math.max(limit * 3, 10), 100);
   const url = `https://api.github.com/repos/${REPOS[distro]}/releases?per_page=${perPage}`;
 
   const res = await fetch(url, {

--- a/ui/src/lib/githubReleases.ts
+++ b/ui/src/lib/githubReleases.ts
@@ -1,0 +1,110 @@
+export type KubernetesDistro = "k3s" | "k0s";
+
+type GithubRelease = {
+  tag_name: string;
+  draft?: boolean;
+  prerelease?: boolean;
+};
+
+const REPOS: Record<KubernetesDistro, string> = {
+  k3s: "k3s-io/k3s",
+  k0s: "k0sproject/k0s",
+};
+
+const CACHE_PREFIX = "auroraboot:releases:v2:";
+const memoryCache = new Map<string, string[]>();
+
+function cacheKey(distro: KubernetesDistro, limit: number): string {
+  return `${CACHE_PREFIX}${distro}:${limit}`;
+}
+
+function readCache(key: string): string[] | null {
+  const mem = memoryCache.get(key);
+  if (mem) return mem;
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((t) => typeof t === "string")) {
+      memoryCache.set(key, parsed);
+      return parsed;
+    }
+  } catch {
+    // ignore corrupt cache
+  }
+  return null;
+}
+
+function writeCache(key: string, tags: string[]): void {
+  memoryCache.set(key, tags);
+  try {
+    sessionStorage.setItem(key, JSON.stringify(tags));
+  } catch {
+    // sessionStorage may be unavailable (e.g. private mode); fall back to memory only.
+  }
+}
+
+export function clearReleaseCache(): void {
+  memoryCache.clear();
+}
+
+// Parse the leading vMAJOR.MINOR.PATCH out of a tag like "v1.36.1+k3s1" so
+// backported releases (e.g. v1.30.14 cut after v1.32.5) sort under the
+// higher-versioned line even though GitHub lists them by publish date.
+function parseVersion(tag: string): [number, number, number] | null {
+  const match = tag.match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function compareTagsDesc(a: string, b: string): number {
+  const va = parseVersion(a);
+  const vb = parseVersion(b);
+  if (va && vb) {
+    for (let i = 0; i < 3; i += 1) {
+      if (va[i] !== vb[i]) return vb[i] - va[i];
+    }
+    // Same MAJOR.MINOR.PATCH → fall back to lexical (e.g. "+k3s2" > "+k3s1").
+    return b.localeCompare(a);
+  }
+  if (va) return -1;
+  if (vb) return 1;
+  return b.localeCompare(a);
+}
+
+export async function fetchKubernetesDistroReleases(
+  distro: KubernetesDistro,
+  limit: number,
+): Promise<string[]> {
+  const key = cacheKey(distro, limit);
+  const cached = readCache(key);
+  if (cached) return cached;
+
+  // per_page pulls more than `limit` so we can drop prereleases/drafts and
+  // still return `limit` stable tags.
+  const perPage = Math.max(limit * 3, 10);
+  const url = `https://api.github.com/repos/${REPOS[distro]}/releases?per_page=${perPage}`;
+
+  const res = await fetch(url, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+
+  if (!res.ok) {
+    if (res.status === 403) {
+      throw new Error(
+        "GitHub API rate limit reached. Please wait a bit and try again, or enter the version manually.",
+      );
+    }
+    throw new Error(`GitHub returned ${res.status} when listing ${distro} releases.`);
+  }
+
+  const body = (await res.json()) as GithubRelease[];
+  const tags = body
+    .filter((r) => !r.draft && !r.prerelease && typeof r.tag_name === "string")
+    .map((r) => r.tag_name)
+    .sort(compareTagsDesc)
+    .slice(0, limit);
+
+  writeCache(key, tags);
+  return tags;
+}

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -2036,8 +2036,12 @@ export function ArtifactBuilder() {
                       <InfoTooltip>
                         Pinned Kubernetes version. Leave empty to take whatever the chosen distro defaults to.
                         Must be the full provider release tag, e.g.{" "}
-                        <code>v1.36.1+k3s1</code> for k3s or{" "}
-                        <code>v1.36.1+k0s.0</code> for k0s.
+                        <code>
+                          {form.kubernetesDistro === "k0s"
+                            ? "v1.36.1+k0s.0"
+                            : "v1.36.1+k3s1"}
+                        </code>
+                        .
                       </InfoTooltip>
                     </Label>
                     <div className="flex gap-2">

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -50,6 +50,7 @@ import {
   Layers,
 } from "lucide-react";
 import { InfoTooltip } from "@/components/InfoTooltip";
+import { KubernetesReleasePicker } from "@/components/KubernetesReleasePicker";
 import { toast } from "@/hooks/useToast";
 import {
   BUILD_CONFIG_KIND,
@@ -2034,13 +2035,31 @@ export function ArtifactBuilder() {
                       Version (optional)
                       <InfoTooltip>
                         Pinned Kubernetes version. Leave empty to take whatever the chosen distro defaults to.
+                        Must be the full provider release tag, e.g.{" "}
+                        <code>v1.36.1+k3s1</code> for k3s or{" "}
+                        <code>v1.36.1+k0s.0</code> for k0s.
                       </InfoTooltip>
                     </Label>
-                    <Input
-                      placeholder="e.g. v1.28.0"
-                      value={form.kubernetesVersion || ""}
-                      onChange={(e) => update("kubernetesVersion", e.target.value)}
-                    />
+                    <div className="flex gap-2">
+                      <Input
+                        className="flex-1"
+                        placeholder={
+                          form.kubernetesDistro === "k0s"
+                            ? "e.g. v1.36.1+k0s.0"
+                            : "e.g. v1.36.1+k3s1"
+                        }
+                        value={form.kubernetesVersion || ""}
+                        onChange={(e) => update("kubernetesVersion", e.target.value)}
+                      />
+                      {(form.kubernetesDistro === "k3s" ||
+                        form.kubernetesDistro === "k0s") && (
+                        <KubernetesReleasePicker
+                          key={form.kubernetesDistro}
+                          distro={form.kubernetesDistro}
+                          onSelect={(tag) => update("kubernetesVersion", tag)}
+                        />
+                      )}
+                    </div>
                   </div>
                 </CardContent>
               </Card>

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -1,1 +1,47 @@
+import { beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
+
+// Node 24 exposes `localStorage` as an experimental global that stays
+// undefined unless the process was started with `--localstorage-file`, and
+// jsdom v30 defers to that host global instead of shimming its own. Provide
+// an in-memory Storage on both `window` and `globalThis` so app code that
+// touches `localStorage`/`sessionStorage` works uniformly under vitest.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+function installStorage(name: "localStorage" | "sessionStorage"): void {
+  const current = (globalThis as unknown as Record<string, unknown>)[name];
+  if (current && typeof (current as Storage).clear === "function") return;
+  const storage = new MemoryStorage();
+  Object.defineProperty(globalThis, name, { value: storage, configurable: true });
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, name, { value: storage, configurable: true });
+  }
+}
+
+installStorage("localStorage");
+installStorage("sessionStorage");
+
+beforeEach(() => {
+  globalThis.localStorage?.clear();
+  globalThis.sessionStorage?.clear();
+});


### PR DESCRIPTION
The Kubernetes distro Version input in the Artifact Builder previously suggested a bare semver like `v1.28.0`, but k3s/k0s only publish under suffixed tags (`v1.36.1+k3s1`, `v1.36.1+k0s.0`) so pinning-by-hand often 404'd during the build. See kairos-io/kairos#4184.

Add a small popover next to the field: on click it queries the public GitHub releases API for the selected distro, filters out drafts and prereleases, sorts by semver descending so backports don't outrank higher minor lines, and shows the top 5 tags. Clicking one fills the input. Results are cached per (distro, limit) in sessionStorage so repeat opens don't burn rate-limit budget.

Also make the placeholder and tooltip distro-aware to document the required tag format up front.

Fixes https://github.com/kairos-io/kairos/issues/4184