### PR TITLE
fix(helm): expose netboot and host networking options

### DIFF
--- a/deploy/helm/auroraboot/templates/deployment.yaml
+++ b/deploy/helm/auroraboot/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "auroraboot.serviceAccountName" . }}
+      {{- if .Values.hostNetwork.enabled }}
+      hostNetwork: true
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -36,10 +39,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
+        {{- $securityContext := deepCopy .Values.securityContext }}
+        {{- if .Values.netboot.enabled }}
+        {{- $capabilities := deepCopy (default dict (get $securityContext "capabilities")) }}
+        {{- $addedCapabilities := default list (get $capabilities "add") }}
+        {{- $_ := set $capabilities "add" (uniq (concat $addedCapabilities (list "NET_RAW" "NET_BIND_SERVICE"))) }}
+        {{- $_ := set $securityContext "capabilities" $capabilities }}
+        {{- end }}
         - name: auroraboot
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.securityContext }}
+          {{- with $securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/deploy/helm/auroraboot/templates/deployment.yaml
+++ b/deploy/helm/auroraboot/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
       serviceAccountName: {{ include "auroraboot.serviceAccountName" . }}
       {{- if .Values.hostNetwork.enabled }}
       hostNetwork: true
+      dnsPolicy: {{ .Values.hostNetwork.dnsPolicy }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm/auroraboot/tests/deployment_test.yaml
+++ b/deploy/helm/auroraboot/tests/deployment_test.yaml
@@ -189,8 +189,22 @@ tests:
       - equal:
           path: spec.template.spec.hostNetwork
           value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
       - notExists:
           path: spec.template.spec.containers[0].securityContext
+
+  - it: honours a host network DNS policy override
+    set:
+      host: auroraboot.example.com
+      hostNetwork:
+        enabled: true
+        dnsPolicy: ClusterFirst
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirst
 
   - it: enables netboot privileges independently
     set:

--- a/deploy/helm/auroraboot/tests/deployment_test.yaml
+++ b/deploy/helm/auroraboot/tests/deployment_test.yaml
@@ -170,3 +170,87 @@ tests:
     asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/registration-secret"]
+
+  - it: disables host networking and netboot privileges by default
+    set:
+      host: auroraboot.example.com
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostNetwork
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: enables host networking independently
+    set:
+      host: auroraboot.example.com
+      hostNetwork:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: enables netboot privileges independently
+    set:
+      host: auroraboot.example.com
+      netboot:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostNetwork
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          value:
+            - NET_RAW
+            - NET_BIND_SERVICE
+
+  - it: enables host networking and netboot privileges together
+    set:
+      host: auroraboot.example.com
+      hostNetwork:
+        enabled: true
+      netboot:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          value:
+            - NET_RAW
+            - NET_BIND_SERVICE
+
+  - it: preserves supplied security context and capabilities when netboot is enabled
+    set:
+      host: auroraboot.example.com
+      netboot:
+        enabled: true
+      securityContext:
+        runAsUser: 1000
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - SYS_ADMIN
+            - NET_RAW
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          value:
+            - SYS_ADMIN
+            - NET_RAW
+            - NET_BIND_SERVICE

--- a/deploy/helm/auroraboot/values.yaml
+++ b/deploy/helm/auroraboot/values.yaml
@@ -80,6 +80,7 @@ netboot:
 
 hostNetwork:
   enabled: false
+  dnsPolicy: ClusterFirstWithHostNet
 
 nodeSelector: {}
 tolerations: []

--- a/deploy/helm/auroraboot/values.yaml
+++ b/deploy/helm/auroraboot/values.yaml
@@ -75,6 +75,12 @@ resources: {}
 podSecurityContext: {}
 securityContext: {}
 
+netboot:
+  enabled: false
+
+hostNetwork:
+  enabled: false
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
## Summary

- add a default-off `netboot.enabled` option that grants `NET_RAW` and `NET_BIND_SERVICE`
- add an independent, default-off `hostNetwork.enabled` option
- preserve user-supplied security context fields and capabilities
- cover defaults, independent options, combined options, and security-context merging with Helm unit tests

## Verification

- `make helm-chart-check`
- `make helm-chart-template`
- 36 Helm tests passed

Closes kairos-io/kairos#4293