### PR TITLE
fix(security): constant-time comparison for admin/node bearer tokens

### DIFF
--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -13,6 +14,15 @@ import (
 
 // ContextKeyNodeID is the key used to store the authenticated node ID in the echo context.
 const ContextKeyNodeID = "nodeID"
+
+// secureCompare reports whether a and b are equal using a constant-time
+// comparison, so a bearer-token / admin-password check does not leak, via
+// response timing, how many leading bytes of the secret matched. Plain string
+// == returns early on the first differing byte; subtle.ConstantTimeCompare does
+// not, and returns 0 for unequal-length inputs without a data-dependent branch.
+func secureCompare(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
 
 // AuthNodeID returns the authenticated node ID set by NodeAPIKeyMiddleware, or
 // "" when the request was not authenticated as a node (e.g. an admin-bearer
@@ -52,7 +62,7 @@ func AdminMiddleware(password string) echo.MiddlewareFunc {
 			if token == "" {
 				token = c.QueryParam("token")
 			}
-			if token == "" || token != password {
+			if token == "" || !secureCompare(token, password) {
 				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			}
 			return next(c)
@@ -102,9 +112,9 @@ func AgentOrAdminMiddleware(password string, nodeStore store.NodeStore) echo.Mid
 			if token == "" {
 				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			}
-			// Admin first — a constant-time-ish equality is fine here; the
-			// admin password is never a valid node API key.
-			if token == password {
+			// Admin first — the admin password is never a valid node API key,
+			// so the order is unambiguous.
+			if secureCompare(token, password) {
 				return next(c)
 			}
 			node, err := nodeStore.GetByAPIKey(c.Request().Context(), token)
@@ -131,7 +141,7 @@ func DownloadMiddleware(password string, nodeStore store.NodeStore) echo.Middlew
 				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			}
 			// Check admin password
-			if token == password {
+			if secureCompare(token, password) {
 				return next(c)
 			}
 			// Check node API key

--- a/pkg/auth/secure_compare_internal_test.go
+++ b/pkg/auth/secure_compare_internal_test.go
@@ -1,0 +1,27 @@
+package auth
+
+import "testing"
+
+// secureCompare is a thin constant-time wrapper; this locks its equality
+// contract (and that it does not panic on empty / unequal-length inputs, which
+// bearer-token comparisons routinely feed it).
+func TestSecureCompare(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"equal", "correct-horse-battery", "correct-horse-battery", true},
+		{"different same length", "aaaaaaaa", "bbbbbbbb", false},
+		{"different length prefix", "secret", "secretx", false},
+		{"empty vs secret", "", "secret", false},
+		{"both empty", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := secureCompare(tc.a, tc.b); got != tc.want {
+				t.Fatalf("secureCompare(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Routes the admin-password / node-API-key checks in `AdminMiddleware`, `AgentOrAdminMiddleware`, and `DownloadMiddleware` through a `secureCompare` helper backed by `crypto/subtle.ConstantTimeCompare`, instead of plain string `==` (which returns on the first differing byte and leaks, via response timing, how many leading bytes of the secret a caller guessed).

Behaviour is unchanged — a correct token still authenticates, a wrong or empty one is still rejected — so it's transparent to every API client (nodes, UI, the fleet/CAPI integration); only the timing side-channel is closed. Adds an internal unit test for the helper (equal / unequal / unequal-length / empty).

Refs: kairos-io/kairos#4117 (fleet-server hardening, 'smaller but real').

_Note: the GCE/VHD raw-disk race this PR originally also carried was reworked into the copy-based fix in #730 (which covers GCE, VHD and MAAS), so this PR is now the constant-time change alone._