### PR TITLE
fix(build): convert raw disks on a private copy to avoid the shared-file race

### DIFF
--- a/pkg/ops/convert_copy_test.go
+++ b/pkg/ops/convert_copy_test.go
@@ -1,0 +1,112 @@
+package ops
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("raw-disk conversion on a private copy", func() {
+	const rawContent = "original-raw-bytes-that-must-survive-conversion"
+	var dir, raw string
+
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+		raw = filepath.Join(dir, "kairos-test.raw")
+		Expect(os.WriteFile(raw, []byte(rawContent), 0o644)).To(Succeed())
+	})
+
+	Describe("convertRawOnCopy", func() {
+		It("runs the converter on a copy and leaves the original raw untouched", func() {
+			// A converter that destroys its source (the way Raw2Gce truncates and
+			// Raw2Azure renames the raw in place). If it were handed the original
+			// instead of a copy, the raw-survives assertion below would fail.
+			convert := func(source string) (string, error) {
+				Expect(source).NotTo(Equal(raw), "converter must receive a copy, not the original raw")
+				Expect(os.Remove(source)).To(Succeed())
+				out := source + ".converted"
+				return out, os.WriteFile(out, []byte("output"), 0o644)
+			}
+
+			dst, err := convertRawOnCopy(dir, convert)
+			Expect(err).NotTo(HaveOccurred())
+
+			// The output was moved next to the raw under <raw>.<ext>.
+			Expect(dst).To(Equal(filepath.Join(dir, "kairos-test.raw.converted")))
+			Expect(dst).To(BeAnExistingFile())
+
+			// The original raw survived, byte-for-byte.
+			got, err := os.ReadFile(raw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(got)).To(Equal(rawContent))
+
+			// The throwaway work directory was cleaned up.
+			entries, err := os.ReadDir(dir)
+			Expect(err).NotTo(HaveOccurred())
+			for _, e := range entries {
+				Expect(e.Name()).NotTo(HavePrefix(".convert-"))
+			}
+		})
+
+		It("errors when the build dir has no raw disk", func() {
+			_, err := convertRawOnCopy(GinkgoT().TempDir(), func(string) (string, error) { return "", nil })
+			Expect(err).To(MatchError(ContainSubstring("one and only one raw disk")))
+		})
+
+		It("propagates the converter error and leaves the raw untouched", func() {
+			_, err := convertRawOnCopy(dir, func(string) (string, error) { return "", errors.New("boom") })
+			Expect(err).To(MatchError(ContainSubstring("boom")))
+			Expect(raw).To(BeAnExistingFile())
+			got, _ := os.ReadFile(raw)
+			Expect(string(got)).To(Equal(rawContent))
+		})
+
+		It("keeps the shared raw intact when converters run concurrently", func() {
+			// One converter mutates its copy in place, the other renames its copy
+			// away — the two destructive patterns that raced on the shared raw
+			// before this change. Run over the same build dir at once; the
+			// original raw must survive both.
+			mutating := func(source string) (string, error) {
+				if err := os.WriteFile(source, []byte("mutated"), 0o644); err != nil {
+					return "", err
+				}
+				out := source + ".gce"
+				return out, os.WriteFile(out, []byte("gce"), 0o644)
+			}
+			renaming := func(source string) (string, error) {
+				out := source + ".vhd"
+				return out, os.Rename(source, out)
+			}
+
+			var wg sync.WaitGroup
+			errs := make([]error, 2)
+			wg.Add(2)
+			go func() { defer wg.Done(); _, errs[0] = convertRawOnCopy(dir, mutating) }()
+			go func() { defer wg.Done(); _, errs[1] = convertRawOnCopy(dir, renaming) }()
+			wg.Wait()
+
+			Expect(errs[0]).NotTo(HaveOccurred())
+			Expect(errs[1]).NotTo(HaveOccurred())
+			got, err := os.ReadFile(raw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(got)).To(Equal(rawContent), "the shared raw must be intact after both conversions")
+			Expect(filepath.Join(dir, "kairos-test.raw.gce")).To(BeAnExistingFile())
+			Expect(filepath.Join(dir, "kairos-test.raw.vhd")).To(BeAnExistingFile())
+		})
+	})
+
+	Describe("ConvertRawDiskToMAAS", func() {
+		It("produces <raw>.gz and leaves the original raw in place", func() {
+			Expect(ConvertRawDiskToMAAS(dir)(context.Background())).To(Succeed())
+			Expect(filepath.Join(dir, "kairos-test.raw.gz")).To(BeAnExistingFile())
+			got, err := os.ReadFile(raw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(got)).To(Equal(rawContent))
+		})
+	})
+})

--- a/pkg/ops/disks.go
+++ b/pkg/ops/disks.go
@@ -3,6 +3,7 @@ package ops
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -62,55 +63,88 @@ func ExtractSquashFS(srcFunc, dstFunc valueGetOnCall) func(ctx context.Context) 
 
 func ConvertRawDiskToVHD(src string) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
-		tmp, err := os.MkdirTemp("", "gendisk")
+		internal.Log.Logger.Info().Str("dir", src).Msg("Converting raw disk to VHD")
+		output, err := convertRawOnCopy(src, Raw2Azure)
 		if err != nil {
+			internal.Log.Logger.Error().Err(err).Str("dir", src).Msg("Converting raw disk to VHD failed")
 			return err
 		}
-		defer os.RemoveAll(tmp)
-
-		glob, err := filepath.Glob(filepath.Join(src, "kairos-*.raw"))
-		if err != nil {
-			return err
-		}
-
-		if len(glob) == 0 || len(glob) > 1 {
-			return fmt.Errorf("expected to find one and only one raw disk file in '%s' but found %d", src, len(glob))
-		}
-
-		internal.Log.Logger.Info().Msgf("Generating raw disk from '%s'", glob[0])
-		output, err := Raw2Azure(glob[0])
-		if err != nil {
-			internal.Log.Logger.Error().Msgf("Generating raw disk from '%s' failed with error '%s'", glob[0], err.Error())
-		} else {
-			internal.Log.Logger.Info().Msgf("Generated VHD disk '%s'", output)
-		}
-		return err
+		internal.Log.Logger.Info().Msgf("Generated VHD disk '%s'", output)
+		return nil
 	}
 }
 
 func ConvertRawDiskToGCE(src string) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
-		tmp, err := os.MkdirTemp("", "gendisk")
+		internal.Log.Logger.Info().Str("dir", src).Msg("Converting raw disk to GCE")
+		output, err := convertRawOnCopy(src, Raw2Gce)
 		if err != nil {
+			internal.Log.Logger.Error().Err(err).Str("dir", src).Msg("Converting raw disk to GCE failed")
 			return err
 		}
-		defer os.RemoveAll(tmp)
-		glob, err := filepath.Glob(filepath.Join(src, "kairos-*.raw"))
-		if err != nil {
-			return err
-		}
+		internal.Log.Logger.Info().Msgf("Generated GCE disk '%s'", output)
+		return nil
+	}
+}
 
-		if len(glob) == 0 || len(glob) > 1 {
-			return fmt.Errorf("expected to find one and only one raw disk file in '%s' but found %d", src, len(glob))
-		}
+// convertRawOnCopy runs a Raw2X converter against a PRIVATE COPY of the single
+// kairos-*.raw in dir, then moves the produced artifact back into dir under its
+// conventional <raw>.<ext> name. Working on a copy is what makes the cloud-image
+// conversions safe to run in parallel: Raw2Gce truncates its source in place and
+// Raw2Azure renames it away, so pointing them all at the one shared raw races
+// (and corrupts the raw itself, which may be a requested output). Each converter
+// instead mutates its own throwaway copy and leaves the original raw untouched.
+//
+// The work directory is a subdirectory of dir so both the copy and the final
+// os.Rename stay on the same filesystem. It is nested one level down, so a
+// concurrent converter's top-level `kairos-*.raw` glob never matches the copy.
+func convertRawOnCopy(dir string, convert func(source string) (string, error)) (string, error) {
+	glob, err := filepath.Glob(filepath.Join(dir, "kairos-*.raw"))
+	if err != nil {
+		return "", err
+	}
+	if len(glob) != 1 {
+		return "", fmt.Errorf("expected to find one and only one raw disk file in '%s' but found %d", dir, len(glob))
+	}
+	raw := glob[0]
 
-		internal.Log.Logger.Info().Msgf("Generating raw disk '%s'", glob[0])
-		output, err := Raw2Gce(glob[0])
-		if err != nil {
-			internal.Log.Logger.Error().Msgf("Generating raw disk from '%s' failed with error '%s'", src, err.Error())
-		} else {
-			internal.Log.Logger.Info().Msgf("Generated GCE disk '%s'", output)
-		}
+	work, err := os.MkdirTemp(dir, ".convert-")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(work)
+
+	workRaw := filepath.Join(work, filepath.Base(raw))
+	if err := copyFile(raw, workRaw); err != nil {
+		return "", fmt.Errorf("copying raw disk for conversion: %w", err)
+	}
+
+	output, err := convert(workRaw)
+	if err != nil {
+		return "", err
+	}
+
+	dst := filepath.Join(dir, filepath.Base(output))
+	if err := os.Rename(output, dst); err != nil {
+		return "", fmt.Errorf("moving converted disk into place: %w", err)
+	}
+	return dst, nil
+}
+
+// copyFile copies the contents of src to a new file at dst.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
 		return err
 	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }

--- a/pkg/ops/maas_output.go
+++ b/pkg/ops/maas_output.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/kairos-io/AuroraBoot/internal"
 )
@@ -53,25 +52,19 @@ func Raw2MAAS(source string) (string, error) {
 }
 
 // ConvertRawDiskToMAAS finds the single raw disk in src and compresses it into
-// the MAAS ddgz format. Mirrors ConvertRawDiskToGCE / ConvertRawDiskToVHD.
+// the MAAS ddgz format. Mirrors ConvertRawDiskToGCE / ConvertRawDiskToVHD: it
+// works on a private copy of the raw so a concurrent GCE/VHD conversion (which
+// truncates/renames the shared raw) cannot make this read a torn image, and the
+// original raw is left untouched.
 func ConvertRawDiskToMAAS(src string) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
-		glob, err := filepath.Glob(filepath.Join(src, "kairos-*.raw"))
+		internal.Log.Logger.Info().Str("dir", src).Msg("Compressing raw disk for MAAS")
+		output, err := convertRawOnCopy(src, Raw2MAAS)
 		if err != nil {
+			internal.Log.Logger.Error().Err(err).Str("dir", src).Msg("Compressing raw disk for MAAS failed")
 			return err
 		}
-
-		if len(glob) == 0 || len(glob) > 1 {
-			return fmt.Errorf("expected to find one and only one raw disk file in '%s' but found %d", src, len(glob))
-		}
-
-		internal.Log.Logger.Info().Msgf("Compressing raw disk '%s' for MAAS", glob[0])
-		output, err := Raw2MAAS(glob[0])
-		if err != nil {
-			internal.Log.Logger.Error().Msgf("Compressing raw disk from '%s' failed with error '%s'", src, err.Error())
-		} else {
-			internal.Log.Logger.Info().Msgf("Generated MAAS ddgz image '%s'", output)
-		}
-		return err
+		internal.Log.Logger.Info().Msgf("Generated MAAS ddgz image '%s'", output)
+		return nil
 	}
 }


### PR DESCRIPTION
Fixes the shared-raw-disk race across **all three** cloud-image conversions (GCE, VHD, MAAS), by working on a private copy — per @jimmykarily's review suggestion, which is both cleaner and more correct than the ordering approach this PR originally used.

## The race

GCE, VHD and MAAS each globbed the single `kairos-*.raw` and operated on it directly, so a build requesting more than one ran them in parallel over the same file. They touch it incompatibly:

| Conversion | Effect on the raw |
|---|---|
| GCE | **truncates** in place (pad to GB) |
| VHD | **renames** it away (+ VHD footer) |
| MAAS | **reads** it (gzip) |

Racing them corrupts the image, or a reader loses to a rename (`no such file`). And because GCE/VHD mutate the raw **in place**, they also corrupt the raw itself when the plain `.raw`/EFI disk is a requested output — which pure step-ordering does not fix.

## The fix (work on a copy, not serialize)

`convertRawOnCopy` copies the raw into a throwaway subdirectory, runs the converter (`Raw2Gce`/`Raw2Azure`/`Raw2MAAS`) against the **copy**, and moves the produced artifact back next to the raw under its conventional `<raw>.<ext>` name. The original raw is never mutated, so:

- the conversions are safe to run **concurrently** (no serialization, faster than ordering);
- the raw itself stays a valid deliverable;
- the DAG-ordering complexity is gone (this replaced the earlier `ConditionalOption` approach).

The `Raw2Gce`/`Raw2Azure`/`Raw2MAAS` primitives are unchanged — only the `ConvertRawDiskTo*` wrappers now route through the copy helper. The GCE/VHD wrappers already created (and never used) a `gendisk` temp dir; this is the finished version of that intent.

## Tests

Ginkgo (`pkg/ops`, matching the suite there): `convertRawOnCopy` runs the converter on a copy and leaves the original raw **byte-for-byte**; propagates converter errors without touching the raw; and — the direct proof — keeps the shared raw intact when two destructive converters (one truncating, one renaming) run **concurrently**. `ConvertRawDiskToMAAS` produces `<raw>.gz` with the raw preserved. `go build`/`vet` and the `pkg/ops` + `deployer` suites green.

Refs: kairos-io/kairos#4117.