### PR TITLE
fix(iso): materialize atomic-writer overlays

### DIFF
--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -165,7 +165,12 @@ func GenISO(srcFunc, dstFunc valueGetOnCall, i schema.ISO) func(ctx context.Cont
 			spec.RootFS = append(spec.RootFS, imagetypes.NewDirSrc(i.OverlayRootfs))
 		}
 		if i.OverlayISO != "" {
-			spec.Image = append(spec.Image, imagetypes.NewDirSrc(i.OverlayISO))
+			materializedOverlay, cleanup, err := materializeISOOverlay(i.OverlayISO)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			spec.Image = append(spec.Image, imagetypes.NewDirSrc(materializedOverlay))
 		}
 
 		buildISO := NewBuildISOAction(cfg, spec)
@@ -190,7 +195,12 @@ func InjectISO(dstFunc, isoFunc valueGetOnCall, i schema.ISO) func(ctx context.C
 
 		if i.OverlayISO != "" {
 			internal.Log.Logger.Info().Msgf("Adding overlay data in '%s' to '%s'", i.OverlayISO, isoFile)
-			err = copy.Copy(i.OverlayISO, tmp)
+			materializedOverlay, cleanup, materializeErr := materializeISOOverlay(i.OverlayISO)
+			if materializeErr != nil {
+				return materializeErr
+			}
+			defer cleanup()
+			err = copy.Copy(materializedOverlay, tmp)
 			if err != nil {
 				return err
 			}

--- a/pkg/ops/iso_overlay.go
+++ b/pkg/ops/iso_overlay.go
@@ -1,0 +1,175 @@
+package ops
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func materializeISOOverlay(source string) (string, func(), error) {
+	root, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve ISO overlay root: %w", err)
+	}
+	root, err = filepath.Abs(root)
+	if err != nil {
+		return "", nil, fmt.Errorf("make ISO overlay root absolute: %w", err)
+	}
+
+	target, err := os.MkdirTemp("", "auroraboot-iso-overlay-")
+	if err != nil {
+		return "", nil, fmt.Errorf("create ISO overlay staging directory: %w", err)
+	}
+	cleanup := func() {
+		_ = filepath.WalkDir(target, func(path string, entry os.DirEntry, err error) error {
+			if err == nil && entry.IsDir() {
+				_ = os.Chmod(path, 0o700)
+			}
+			return nil
+		})
+		_ = os.RemoveAll(target)
+	}
+
+	activeDirs := map[string]bool{}
+	if err := copyISOOverlayEntry(root, root, target, activeDirs); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return target, cleanup, nil
+}
+
+func copyISOOverlayEntry(root, source, target string, activeDirs map[string]bool) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return fmt.Errorf("inspect ISO overlay path %q: %w", source, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		linkTarget, err := os.Readlink(source)
+		if err != nil {
+			return fmt.Errorf("read ISO overlay symlink %q: %w", source, err)
+		}
+		resolved, err := filepath.EvalSymlinks(source)
+		if err != nil {
+			return fmt.Errorf("resolve ISO overlay symlink %q: %w", source, err)
+		}
+		resolved, err = filepath.Abs(resolved)
+		if err != nil {
+			return fmt.Errorf("make resolved ISO overlay path absolute: %w", err)
+		}
+		rel, err := filepath.Rel(root, resolved)
+		if err != nil {
+			return fmt.Errorf("check ISO overlay symlink %q: %w", source, err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("ISO overlay symlink %q escapes overlay root", source)
+		}
+		metadata := atomicWriterMetadata(filepath.Dir(source), root)
+		if metadata["..data"] && isAtomicWriterLink(linkTarget) {
+			return copyISOOverlayEntry(root, resolved, target, activeDirs)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create ISO overlay symlink parent: %w", err)
+		}
+		if err := os.Symlink(linkTarget, target); err != nil {
+			return fmt.Errorf("copy ISO overlay symlink %q: %w", source, err)
+		}
+		return nil
+	}
+
+	if info.IsDir() {
+		resolved, err := filepath.EvalSymlinks(source)
+		if err != nil {
+			return fmt.Errorf("resolve ISO overlay directory %q: %w", source, err)
+		}
+		if activeDirs[resolved] {
+			return fmt.Errorf("ISO overlay symlink cycle at %q", source)
+		}
+		activeDirs[resolved] = true
+		defer delete(activeDirs, resolved)
+
+		if err := os.MkdirAll(target, info.Mode().Perm()|0o700); err != nil {
+			return fmt.Errorf("create ISO overlay directory %q: %w", target, err)
+		}
+		entries, err := os.ReadDir(source)
+		if err != nil {
+			return fmt.Errorf("read ISO overlay directory %q: %w", source, err)
+		}
+		metadata := atomicWriterMetadata(source, root)
+		for _, entry := range entries {
+			if metadata[entry.Name()] {
+				continue
+			}
+			if err := copyISOOverlayEntry(root, filepath.Join(source, entry.Name()), filepath.Join(target, entry.Name()), activeDirs); err != nil {
+				return err
+			}
+		}
+		if err := os.Chmod(target, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("set ISO overlay directory mode %q: %w", target, err)
+		}
+		return nil
+	}
+
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("unsupported ISO overlay file type at %q", source)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("create ISO overlay parent directory: %w", err)
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open ISO overlay file %q: %w", source, err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("create materialized ISO overlay file %q: %w", target, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copy ISO overlay file %q: %w", source, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close materialized ISO overlay file %q: %w", target, err)
+	}
+	if err := os.Chmod(target, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("set materialized ISO overlay file mode %q: %w", target, err)
+	}
+	return nil
+}
+
+func isAtomicWriterLink(target string) bool {
+	if filepath.IsAbs(target) {
+		return false
+	}
+	clean := filepath.Clean(target)
+	return clean == "..data" || strings.HasPrefix(clean, "..data"+string(filepath.Separator))
+}
+
+func atomicWriterMetadata(dir, root string) map[string]bool {
+	metadata := map[string]bool{}
+	dataLink := filepath.Join(dir, "..data")
+	info, err := os.Lstat(dataLink)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return metadata
+	}
+	resolved, err := filepath.EvalSymlinks(dataLink)
+	if err != nil {
+		return metadata
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return metadata
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return metadata
+	}
+	if filepath.Dir(resolved) != dir {
+		return metadata
+	}
+	metadata["..data"] = true
+	metadata[filepath.Base(resolved)] = true
+	return metadata
+}

--- a/pkg/ops/iso_overlay_test.go
+++ b/pkg/ops/iso_overlay_test.go
@@ -1,0 +1,170 @@
+package ops
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaterializeISOOverlayDereferencesAtomicWriterSymlinks(t *testing.T) {
+	overlay := t.TempDir()
+	version := filepath.Join(overlay, "..2026_08_20_12_00_00.0000000000")
+	if err := os.MkdirAll(filepath.Join(version, "boot", "grub2"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(version, "boot", "grub2", "grub.cfg"), []byte("custom grub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(version), filepath.Join(overlay, "..data")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..data", "boot"), filepath.Join(overlay, "boot")); err != nil {
+		t.Fatal(err)
+	}
+
+	materialized, cleanup, err := materializeISOOverlay(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+
+	info, err := os.Lstat(filepath.Join(materialized, "boot"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("boot must be a real directory, got mode %s", info.Mode())
+	}
+	content, err := os.ReadFile(filepath.Join(materialized, "boot", "grub2", "grub.cfg"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "custom grub" {
+		t.Fatalf("unexpected grub.cfg content %q", content)
+	}
+	if _, err := os.Lstat(filepath.Join(materialized, "..data")); !os.IsNotExist(err) {
+		t.Fatalf("atomic-writer metadata was copied: %v", err)
+	}
+}
+
+func TestMaterializeISOOverlayRejectsEscapingSymlinks(t *testing.T) {
+	overlay := t.TempDir()
+	external := t.TempDir()
+	if err := os.WriteFile(filepath.Join(external, "secret"), []byte("do not copy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(external, "secret"), filepath.Join(overlay, "secret")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, cleanup, err := materializeISOOverlay(overlay)
+	if cleanup != nil {
+		cleanup()
+	}
+	if err == nil || !strings.Contains(err.Error(), "escapes overlay root") {
+		t.Fatalf("expected escaping symlink error, got %v", err)
+	}
+}
+
+func TestMaterializeISOOverlayPreservesOrdinaryEntries(t *testing.T) {
+	overlay := t.TempDir()
+	if err := os.WriteFile(filepath.Join(overlay, "target"), []byte("target"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(overlay, "target"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(overlay, "..keep"), []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target", filepath.Join(overlay, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	materialized, cleanup, err := materializeISOOverlay(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+
+	link, err := os.Lstat(filepath.Join(materialized, "link"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("ordinary link was dereferenced: mode %s", link.Mode())
+	}
+	if target, err := os.Readlink(filepath.Join(materialized, "link")); err != nil || target != "target" {
+		t.Fatalf("ordinary link target = %q, %v", target, err)
+	}
+	if content, err := os.ReadFile(filepath.Join(materialized, "..keep")); err != nil || string(content) != "keep" {
+		t.Fatalf("ordinary dot entry was not preserved: %q, %v", content, err)
+	}
+	info, err := os.Stat(filepath.Join(materialized, "target"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o777 {
+		t.Fatalf("target mode = %o, want 777", info.Mode().Perm())
+	}
+}
+
+func TestMaterializeISOOverlayPreservesLinkIntoOrdinaryDotDataDirectory(t *testing.T) {
+	overlay := t.TempDir()
+	if err := os.Mkdir(filepath.Join(overlay, "..data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(overlay, "..data", "file"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..data", "file"), filepath.Join(overlay, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	materialized, cleanup, err := materializeISOOverlay(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+
+	info, err := os.Lstat(filepath.Join(materialized, "link"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("ordinary ..data link was dereferenced: mode %s", info.Mode())
+	}
+}
+
+func TestMaterializeISOOverlayPopulatesReadOnlyDirectories(t *testing.T) {
+	overlay := t.TempDir()
+	readOnly := filepath.Join(overlay, "read-only")
+	if err := os.Mkdir(readOnly, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(readOnly, "file"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(readOnly, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readOnly, 0o755) })
+
+	materialized, cleanup, err := materializeISOOverlay(overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+
+	if content, err := os.ReadFile(filepath.Join(materialized, "read-only", "file")); err != nil || string(content) != "data" {
+		t.Fatalf("read-only directory content = %q, %v", content, err)
+	}
+	info, err := os.Stat(filepath.Join(materialized, "read-only"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o555 {
+		t.Fatalf("read-only directory mode = %o, want 555", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## What changed

- Materialize Kubernetes atomic-writer overlay links before ISO copies.
- Apply the staging path to generated and downloaded ISO workflows.
- Preserve ordinary links, dot-prefixed entries, and file modes.
- Reject links that resolve outside the overlay root.

## Why

Secret and ConfigMap mounts expose logical files through `..data` symlinks. The existing archive copy preserved those links, so a path such as `boot -> ..data/boot` collided with the ISO root's existing `boot/` directory.

## Verification

- Focused standard-library regression suite: PASS, 5 tests
- `git diff --check`: PASS
- Full `go test ./pkg/ops/...`: blocked before compilation because the environment returns HTTP 403 while downloading Go 1.26.6 from `proxy.golang.org`

Closes kairos-io/kairos#4324