### PR TITLE
fix(test): use file-backed SQLite in integration suite, not :memory:

### DIFF
--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/gorilla/websocket"
@@ -26,6 +27,8 @@ const (
 )
 
 var (
+	nodeGormStore *gormstore.Store
+
 	// testRegToken starts at a fixed seed value and is kept in sync with
 	// the server's active token by the Settings rotation specs — rotating
 	// the token invalidates the previous value (RegistrationTokenAuth reads
@@ -90,9 +93,14 @@ func (m *mockArtifactBuilder) Cancel(_ context.Context, id string) error {
 }
 
 var _ = BeforeSuite(func() {
-	// Create in-memory SQLite store with shared cache so all connections see the same data.
-	store, err := gormstore.New("file::memory:?cache=shared")
+	// File-backed SQLite store, NOT :memory: — WAL mode and busy_timeout do not
+	// apply to in-memory databases, so concurrent writers (e.g. the WebSocket
+	// heartbeat path) can hit "database is locked" even though the store sets
+	// both. Matches the pattern in internal/store/gorm/concurrency_test.go.
+	dbPath := filepath.Join(GinkgoT().TempDir(), "integration.db")
+	store, err := gormstore.New(dbPath)
 	Expect(err).NotTo(HaveOccurred())
+	nodeGormStore = store
 
 	nodeStore := &gormstore.NodeStoreAdapter{S: store}
 	commandStore := &gormstore.CommandStoreAdapter{S: store}
@@ -123,6 +131,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	if testServer != nil {
 		testServer.Close()
+	}
+	if nodeGormStore != nil {
+		Expect(nodeGormStore.Close()).To(Succeed())
 	}
 })
 


### PR DESCRIPTION
## Problem

The `unit-tests` job fails intermittently on `test/integration/websocket_test.go` with `database table is locked: managed_nodes`. The failing spec is "WebSocket should receive heartbeat and update node info".

## Root cause

SQLite's WAL mode and `busy_timeout` do not apply to in-memory databases. `test/integration/suite_test.go` used `file::memory:?cache=shared`, so the store's lock-avoidance settings (set in `internal/store/gorm/store.go`) never actually took effect there. `internal/store/gorm/concurrency_test.go` already documents this and deliberately uses a file-backed DB instead.

## Fix

Switch the integration suite to a file-backed temp DB, matching the existing pattern in `concurrency_test.go`. Also closes the store in `AfterSuite`, since a file-backed DB needs cleanup that `:memory:` did not.

## Testing

- `go test -count=1 ./test/integration/...` — 40/40 specs pass.
- `ginkgo -repeat=9 ./test/integration/...` — 10 consecutive runs, 40/40 passing every time (previously failed intermittently).
- `go test -count=1 ./internal/store/...` — passes.

Note: this is an unattended agent PR. `mauro-agent` opened this without a human reading the diff first. Mauro reviews before merge.

Fixes the flake first seen on unrelated PR #742's CI run.