### PR TITLE
fix(ui): keep core artifacts Kubernetes-free

### DIFF
--- a/pkg/handlers/artifacts.go
+++ b/pkg/handlers/artifacts.go
@@ -279,8 +279,8 @@ func (h *ArtifactHandler) Create(c echo.Context) error {
 		allowedCommands = append([]string(nil), phonehomeSafeDefaults...)
 	}
 
-	kubernetesEnabled := true
-	if req.KubernetesEnabled != nil {
+	kubernetesEnabled := req.Variant == "standard"
+	if kubernetesEnabled && req.KubernetesEnabled != nil {
 		kubernetesEnabled = *req.KubernetesEnabled
 	}
 

--- a/pkg/handlers/artifacts_test.go
+++ b/pkg/handlers/artifacts_test.go
@@ -193,6 +193,23 @@ var _ = Describe("ArtifactHandler", func() {
 			Expect(fb.lastOpts.CloudConfig).NotTo(ContainSubstring("k0s:"))
 		})
 
+		It("stores kubernetes as disabled for the core variant", func() {
+			as := &fakeArtifactStore{}
+			handlerWithStore := handlers.NewArtifactHandler(fb, as, nil, nil, "", "reg-token", "http://localhost:8080")
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/artifacts", strings.NewReader(`{"baseImage":"ubuntu:24.04","variant":"core","kubernetesEnabled":true,"outputs":{"iso":true}}`))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			Expect(handlerWithStore.Create(c)).To(Succeed())
+			Expect(rec.Code).To(Equal(http.StatusCreated))
+			Expect(as.records).To(HaveLen(1))
+			Expect(as.records[0].KubernetesEnabled).NotTo(BeNil())
+			Expect(*as.records[0].KubernetesEnabled).To(BeFalse())
+			Expect(fb.lastOpts.Provisioning.KubernetesEnabled).To(BeFalse())
+		})
+
 		It("merges extra k3s YAML without duplicating the top-level key", func() {
 			post(`{"baseImage":"ubuntu:24.04","variant":"standard","kubernetesDistro":"k3s","outputs":{"iso":true},"cloudConfig":"k3s:\n  enabled: true\n  cluster-cidr: 10.42.0.0/16"}`)
 			Expect(strings.Count(fb.lastOpts.CloudConfig, "k3s:")).To(Equal(1))


### PR DESCRIPTION
## What changed

- derive Kubernetes enablement from the `standard` variant at the API boundary
- persist `kubernetesEnabled: false` for core artifacts even when a client sends a contradictory true value
- add a handler regression that covers the builder options and stored record

## Why

Core builds correctly omit Kubernetes, but their stored records could still say Kubernetes was enabled. Clone and export flows then replayed state that did not match the artifact.

## Verification

- `git diff --check`
- `go test ./pkg/handlers -ginkgo.focus "stores kubernetes as disabled for the core variant"` could not start on this worker because Go 1.26.6 and missing modules returned HTTP 403 from the configured network path. CI must run the executable test.

Closes kairos-io/kairos#4354