### PR TITLE
fix(raw): don't require a shim on architectures that have none

### DIFF
--- a/pkg/ops/rawDiskGeneration.go
+++ b/pkg/ops/rawDiskGeneration.go
@@ -899,6 +899,18 @@ func (r *RawImage) copyShimOrGrub(target, which string) error {
 		return r.CopyAlpineShimAndGrub(arch, target)
 	}
 
+	// Some architectures have no shim/secure-boot convention at all yet --
+	// kairos-sdk's GetEfiShimFiles returns an empty list for them (riscv64
+	// today). That is not a missing file, it is the architecture having
+	// nothing to chain from, so treat it as a no-op rather than a failure.
+	// The grub copy below writes to the removable-media fallback path
+	// instead, since grub itself is what firmware boots directly there.
+	noShimForArch := len(sdkUtils.GetEfiShimFiles(arch)) == 0
+	if which == "shim" && noShimForArch {
+		return nil
+	}
+	writeFallback := which == "shim" || (which == "grub" && noShimForArch)
+
 	for _, f := range searchFiles {
 		_, err := r.config.Fs.Stat(filepath.Join(r.Source, f))
 		if err != nil {
@@ -926,9 +938,12 @@ func (r *RawImage) copyShimOrGrub(target, which string) error {
 		}
 		copyDone = true
 
-		// Copy the shim content to the fallback name so the system boots from fallback. This means that we do not create
-		// any bootloader entries, so our recent installation has the lower priority if something else is on the bootloader
-		if which == "shim" {
+		// Copy the shim (or, on a no-shim architecture, grub) content to
+		// the fallback name so the system boots from fallback. This means
+		// that we do not create any bootloader entries, so our recent
+		// installation has the lower priority if something else is on the
+		// bootloader.
+		if writeFallback {
 			writeShim := agentConstants.GetFallBackEfi(arch)
 			err = r.config.Fs.WriteFile(filepath.Join(target, constants.EfiBootPath, writeShim), fileContent, agentConstants.FilePerm)
 			if err != nil {
@@ -939,7 +954,7 @@ func (r *RawImage) copyShimOrGrub(target, which string) error {
 	}
 	if !copyDone {
 		r.config.Logger.Debugf("List of files searched for: %s", searchFiles)
-		return fmt.Errorf("could not find any shim file to copy")
+		return fmt.Errorf("could not find any %s file to copy", which)
 	}
 	return nil
 }


### PR DESCRIPTION
## Why

`createEFIPartitionImage` (raw disk generation) fails hard on riscv64:

```
ERR failed to copy shim error="could not find any shim file to copy"
ERR Generating raw disk ... failed with error 'could not find any shim file to copy'
```

`kairos-sdk`'s `GetEfiShimFiles("riscv64")` returns an empty list, by design
-- riscv64 has no signed-shim/secure-boot convention yet. `copyShimOrGrub`
treats that as fatal instead of "this architecture has nothing to chain
from." ISO building doesn't hit this code path, which is why ISOs already
build fine for riscv64 while raw disks don't.

Found while wiring a raw disk image for
[`mauromorales/homelab`](https://github.com/mauromorales/homelab)'s
experimental riscv64 node (`nodes/kairos-riscv64`).

## What changed

`pkg/ops/rawDiskGeneration.go`, `copyShimOrGrub`:

- When `which == "shim"` and the architecture has no shim files at all
  (`GetEfiShimFiles(arch)` is empty), return `nil` instead of erroring --
  there's nothing to copy, and that's expected, not a failure.
- The `grub` copy now also writes to the removable-media fallback EFI path
  (`GetFallBackEfi(arch)`) whenever the architecture has no shim, since grub
  itself is what firmware boots directly there, with no shim indirection.
  This generalizes the fallback-write behavior the Alpine branch already
  uses for its own no-shim case, past that one flavor.
- Minor: the "could not find any shim file to copy" error is hardcoded
  regardless of `which`; it now names the actual thing that was being
  searched for (`shim` or `grub`), which was misleading when the `grub`
  search itself came up empty.

Everything this relies on is already vendored: `kairos-agent`
`GetFallBackEfi("riscv64")` returns `BOOTRISCV64.EFI`
([confirmed](https://github.com/kairos-io/kairos-agent/blob/v2.30.2/pkg/constants/constants.go#L147-L152),
pinned at `v2.30.2` in `go.mod`), and `kairos-sdk`'s riscv64
`GetEfiGrubFiles` entries are already pinned at `v0.25.3`. No dependency
bump needed.

## Verification

`go vet ./pkg/ops/...` and the full existing `pkg/ops` test suite both pass.
No existing test exercises `createEFIPartitionImage`/`copyShimOrGrub` (the
file's own header already has `// TODO: Add testing`), so this is traced by
hand against the riscv64 cases of `GetEfiShimFiles`/`GetEfiGrubFiles`/
`GetFallBackEfi`, not covered by a new automated test here. Real end-to-end
confirmation is the downstream homelab PR's raw-image build step re-running
against this branch once merged.

---

AI assisted this pull request. A human is attending and directed it.