### PR TITLE
fix: retry artifact download on transient failure

### DIFF
--- a/pkg/ops/network.go
+++ b/pkg/ops/network.go
@@ -12,18 +12,19 @@ import (
 	"github.com/kairos-io/AuroraBoot/internal"
 )
 
-const (
-	UserAgent = "AuroraBoot"
+const UserAgent = "AuroraBoot"
 
-	// downloadAttempts and downloadRetryBaseDelay: grab makes exactly one
-	// HTTP attempt per call and returns whatever error it hit, including a
-	// transient one (e.g. an HTTP/2 "stream error: ... PROTOCOL_ERROR"
-	// from the peer mid-transfer). A multi-GB release asset has plenty of
-	// opportunity to hit one of those, so a single failed attempt should
-	// not be the whole download's answer.
-	downloadAttempts       = 3
-	downloadRetryBaseDelay = 2 * time.Second
-)
+// downloadAttempts and downloadRetryBaseDelay: grab makes exactly one
+// HTTP attempt per call and returns whatever error it hit, including a
+// transient one (e.g. an HTTP/2 "stream error: ... PROTOCOL_ERROR"
+// from the peer mid-transfer). A multi-GB release asset has plenty of
+// opportunity to hit one of those, so a single failed attempt should
+// not be the whole download's answer.
+const downloadAttempts = 3
+
+// downloadRetryBaseDelay is a var, not a const, so tests can shrink the
+// backoff instead of waiting on it in real time.
+var downloadRetryBaseDelay = 2 * time.Second
 
 // ServeArtifacts serve local artifacts as standard http server
 func ServeArtifacts(listenAddr string, dirFunc valueGetOnCall) func(ctx context.Context) error {
@@ -79,7 +80,10 @@ func download(ctx context.Context, url, dst string) (string, error) {
 		delay := downloadRetryBaseDelay * time.Duration(attempt)
 		select {
 		case <-ctx.Done():
-			return dstFile, err
+			// Report the cancellation itself, not the transient error that
+			// prompted this backoff -- a caller checking for ctx.Err() must
+			// see it, not whatever downloadOnce last failed with.
+			return dstFile, ctx.Err()
 		case <-time.After(delay):
 		}
 	}

--- a/pkg/ops/network.go
+++ b/pkg/ops/network.go
@@ -14,6 +14,15 @@ import (
 
 const (
 	UserAgent = "AuroraBoot"
+
+	// downloadAttempts and downloadRetryBaseDelay: grab makes exactly one
+	// HTTP attempt per call and returns whatever error it hit, including a
+	// transient one (e.g. an HTTP/2 "stream error: ... PROTOCOL_ERROR"
+	// from the peer mid-transfer). A multi-GB release asset has plenty of
+	// opportunity to hit one of those, so a single failed attempt should
+	// not be the whole download's answer.
+	downloadAttempts       = 3
+	downloadRetryBaseDelay = 2 * time.Second
 )
 
 // ServeArtifacts serve local artifacts as standard http server
@@ -52,7 +61,32 @@ func DownloadArtifact(url string, isoFunc valueGetOnCall) func(ctx context.Conte
 	}
 }
 
+// download retries downloadOnce on failure, up to downloadAttempts times.
+// It does not retry after ctx is canceled -- that is a caller decision to
+// stop, not a transient failure to recover from.
 func download(ctx context.Context, url, dst string) (string, error) {
+	var dstFile string
+	var err error
+	for attempt := 1; attempt <= downloadAttempts; attempt++ {
+		dstFile, err = downloadOnce(ctx, url, dst)
+		if err == nil {
+			return dstFile, nil
+		}
+		if ctx.Err() != nil || attempt == downloadAttempts {
+			return dstFile, err
+		}
+		internal.Log.Logger.Warn().Err(err).Str("artifact", url).Int("attempt", attempt).Msg("download failed, retrying")
+		delay := downloadRetryBaseDelay * time.Duration(attempt)
+		select {
+		case <-ctx.Done():
+			return dstFile, err
+		case <-time.After(delay):
+		}
+	}
+	return dstFile, err
+}
+
+func downloadOnce(ctx context.Context, url, dst string) (string, error) {
 	// create client
 	client := grab.NewClient()
 	// https://github.com/cavaliergopher/grab/issues/104

--- a/pkg/ops/network_test.go
+++ b/pkg/ops/network_test.go
@@ -1,0 +1,94 @@
+package ops
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("download", Label("network"), func() {
+	var origDelay time.Duration
+
+	BeforeEach(func() {
+		origDelay = downloadRetryBaseDelay
+		downloadRetryBaseDelay = 200 * time.Millisecond
+	})
+
+	AfterEach(func() {
+		downloadRetryBaseDelay = origDelay
+	})
+
+	// grab issues a HEAD probe before every GET; a HEAD response other than
+	// 200 is not an error to grab (it just proceeds to the GET), so these
+	// tests fail/succeed only the GET to control the download-attempt count.
+	notFoundOnHead := func(w http.ResponseWriter, r *http.Request) bool {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound)
+			return true
+		}
+		return false
+	}
+
+	It("retries a transient failure and succeeds on a later attempt", func() {
+		var gets atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if notFoundOnHead(w, r) {
+				return
+			}
+			if gets.Add(1) == 1 {
+				w.WriteHeader(http.StatusBadGateway)
+				return
+			}
+			w.Write([]byte("payload"))
+		}))
+		defer srv.Close()
+
+		// download() is always given a destination *file* path, not a
+		// directory (its only caller passes deployer.getIsoFile()'s full
+		// ".../kairos.iso" path).
+		dst := filepath.Join(GinkgoT().TempDir(), "testfile.bin")
+		_, err := download(context.Background(), srv.URL+"/testfile.bin", dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gets.Load()).To(Equal(int32(2)))
+
+		content, readErr := os.ReadFile(dst)
+		Expect(readErr).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal("payload"))
+	})
+
+	It("stops retrying and reports ctx's error when canceled during backoff", func() {
+		var gets atomic.Int32
+		ctx, cancel := context.WithCancel(context.Background())
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if notFoundOnHead(w, r) {
+				return
+			}
+			gets.Add(1)
+			w.WriteHeader(http.StatusBadGateway)
+		}))
+		defer srv.Close()
+
+		dst := filepath.Join(GinkgoT().TempDir(), "testfile.bin")
+
+		go func() {
+			defer GinkgoRecover()
+			// Give the first attempt's GET time to fail and enter backoff,
+			// then cancel well before the (200ms) backoff elapses.
+			time.Sleep(30 * time.Millisecond)
+			cancel()
+		}()
+
+		_, err := download(ctx, srv.URL+"/testfile.bin", dst)
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue())
+		Expect(gets.Load()).To(Equal(int32(1)))
+	})
+})


### PR DESCRIPTION
Found while looking into e2e flakiness on #752's CI run: `download an iso image from a release` failed with

```
stream error: stream ID 1; PROTOCOL_ERROR; received from peer
```

`download()` in `pkg/ops/network.go` makes exactly one `grab` attempt and returns whatever error it hits. A multi-GB release asset download has plenty of room to hit a transient network error mid-transfer, and today that fails the whole run.

This wraps the existing single-attempt logic (renamed `downloadOnce`) in a retry loop: up to 3 attempts with a short backoff, no retry once `ctx` is canceled. No behavior change on success or on a genuinely permanent failure other than the extra attempts.

Not a fix for the suite-timeout failure in the same run (a different, larger question about e2e wall-clock budget); this is scoped to the transient-download half only.

This is not an agent, Mauro used AI to help write this fix.