### PR TITLE
feat: materialize catalog extensions

### DIFF
--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -117,7 +117,7 @@ func (d *Deployer) StepGenISO() error {
 			netbootRequested := !d.Config.DisableNetboot
 			return isoRequested || netbootRequested
 		}),
-		herd.WithDeps(constants.OpDumpSource, constants.OpCopyCloudConfig, constants.OpPrepareDirs), herd.WithCallback(ops.GenISO(d.tmpRootFs, d.destination, d.Config.ISO)))
+		herd.WithDeps(constants.OpDumpSource, constants.OpCopyCloudConfig, constants.OpPrepareDirs), herd.WithCallback(ops.GenISO(d.tmpRootFs, d.destination, d.Config.ISO, d.Config.Arch, d.Config.AllowInsecureRegistriesBool())))
 }
 
 func (d *Deployer) StepDownloadISO() error {

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/kairos-io/kairos-operator v0.1.3
-	github.com/kairos-io/kairos/v4 v4.2.1-0.20260825070803-b5e8809b4aee
+	github.com/kairos-io/kairos/v4 v4.2.1-0.20260825071302-240edb85a56f
 	github.com/rs/zerolog v1.35.1
 	github.com/stmcginnis/gofish v0.24.0
 	github.com/swaggo/swag v1.16.6

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/kairos-io/go-ukify v0.5.0 h1:cmEauHZ6RdPk/2xkfG2EPxjEYqfSZGuCYIHpnYRL
 github.com/kairos-io/go-ukify v0.5.0/go.mod h1:vUmdBgpj4AyW/0an0ZDfeGE1f6NRDpbQ2MILJtAvy+4=
 github.com/kairos-io/kairos-operator v0.1.3 h1:UlEaYFyak3IpDQa/SE6/GVEOLGJo8JOEpLRk5W4Uyoc=
 github.com/kairos-io/kairos-operator v0.1.3/go.mod h1:HEfMy7VAHde6/7WHzp+vEXxNxxneMaBjeSLLKP1+9wo=
-github.com/kairos-io/kairos/v4 v4.2.1-0.20260825070803-b5e8809b4aee h1:GpnFNe13rdQtqYM4zY3BrnKSdFeby/CgBjRlPs9tBkc=
-github.com/kairos-io/kairos/v4 v4.2.1-0.20260825070803-b5e8809b4aee/go.mod h1:N5mjp1KKLrwrps0bwfOEGrOkuJ5+yAK5KgkmW2NUOKY=
+github.com/kairos-io/kairos/v4 v4.2.1-0.20260825071302-240edb85a56f h1:iq5BsGX07Vew5HfnF5RBQr8F7A5qVG+zxQ75eNDlX70=
+github.com/kairos-io/kairos/v4 v4.2.1-0.20260825071302-240edb85a56f/go.mod h1:N5mjp1KKLrwrps0bwfOEGrOkuJ5+yAK5KgkmW2NUOKY=
 github.com/kairos-io/netboot v0.0.0-20260623081620-ddd9ffa00872 h1:O9H3QrUNNZJTU+TjM3BPR5lvztYWD57V75WzWhIe1aY=
 github.com/kairos-io/netboot v0.0.0-20260623081620-ddd9ffa00872/go.mod h1:pmR04yZyygecD68+osFBZ1UBm5BHCvdAxsxQltHwR1U=
 github.com/kendru/darwin/go/depgraph v0.0.0-20230809052043-4d1c7e9d1767 h1:Ds6xHRvL0yjG4kZD05leRKt70mM18Fjt0+B5gIqqe1g=

--- a/internal/cmd/build-iso.go
+++ b/internal/cmd/build-iso.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kairos-io/AuroraBoot/deployer"
 	"github.com/kairos-io/AuroraBoot/internal/config"
+	"github.com/kairos-io/AuroraBoot/pkg/extensions"
 	"github.com/kairos-io/AuroraBoot/pkg/schema"
 	"github.com/spectrocloud-labs/herd"
 	"github.com/urfave/cli/v2"
@@ -68,6 +69,14 @@ var BuildISOCmd = cli.Command{
 			Name:  "live-console",
 			Usage: "Replace the console options used when booting from the live/installer ISO",
 		},
+		&cli.StringSliceFlag{
+			Name:  "extension",
+			Usage: "Named system extension to include, optionally with @version (repeatable)",
+		},
+		&cli.StringFlag{
+			Name:  "extensions-catalog",
+			Usage: "System extension catalog URL or file",
+		},
 		AllowInsecureRegistriesFlag,
 	},
 	ArgsUsage: "<source>",
@@ -114,6 +123,19 @@ var BuildISOCmd = cli.Command{
 		r := schema.ReleaseArtifact{
 			ContainerImage: source,
 		}
+		extensionValues := ctx.StringSlice("extension")
+		if len(extensionValues) > 0 && ctx.String("extensions-catalog") == "" {
+			return errors.New("extensions-catalog is required when extension is used")
+		}
+		extensionRequests := make([]extensions.Request, 0, len(extensionValues))
+		for _, value := range extensionValues {
+			request, err := extensions.ParseRequest(value)
+			if err != nil {
+				return err
+			}
+			extensionRequests = append(extensionRequests, request)
+		}
+
 		isoOptions := schema.ISO{
 			OverrideName:      ctx.String("override-name"),
 			IncludeDate:       ctx.Bool("date"),
@@ -121,6 +143,8 @@ var BuildISOCmd = cli.Command{
 			OverlayRootfs:     ctx.String("overlay-rootfs"),
 			ExtendLiveCmdline: ctx.String("extend-live-cmdline"),
 			LiveConsole:       ctx.String("live-console"),
+			ExtensionsCatalog: ctx.String("extensions-catalog"),
+			Extensions:        extensionRequests,
 		}
 
 		if err := validateISOOptions(isoOptions); err != nil {

--- a/internal/cmd/build-iso_test.go
+++ b/internal/cmd/build-iso_test.go
@@ -109,4 +109,22 @@ var _ = Describe("build-iso", Label("iso", "cmd"), func() {
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).ToNot(ContainSubstring("flag provided but not defined"))
 	})
+
+	It("requires a catalog when extensions are requested", Label("flags"), func() {
+		err = app.Run([]string{"", "build-iso", "--extension", "foo", "system/cos"})
+		Expect(err).To(MatchError(ContainSubstring("extensions-catalog")))
+	})
+
+	It("rejects invalid extension requests", Label("flags"), func() {
+		err = app.Run([]string{"", "build-iso", "--extensions-catalog", "catalog.yaml", "--extension", "foo@", "system/cos"})
+		Expect(err).To(MatchError(ContainSubstring("invalid extension request")))
+	})
+
+	It("accepts repeatable extension flags", Label("flags"), func() {
+		err = app.Run([]string{"", "build-iso", "--extensions-catalog", "catalog.yaml", "--extension", "foo", "--extension", "bar@v1", "system/cos"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).ToNot(ContainSubstring("flag provided but not defined"))
+		Expect(err.Error()).ToNot(ContainSubstring("extensions-catalog is required"))
+		Expect(err.Error()).ToNot(ContainSubstring("invalid extension request"))
+	})
 })

--- a/internal/cmd/build-uki.go
+++ b/internal/cmd/build-uki.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
+	"github.com/kairos-io/AuroraBoot/pkg/extensions"
 	"github.com/kairos-io/AuroraBoot/pkg/uki"
 	"github.com/kairos-io/kairos/v4/sdk/types/logger"
 	"github.com/urfave/cli/v2"
@@ -129,6 +130,14 @@ var BuildUKICmd = cli.Command{
 			Value: false,
 			Usage: "Try to find systemd-boot files in the source rootfs instead of using the bundled ones.",
 		},
+		&cli.StringSliceFlag{
+			Name:  "extension",
+			Usage: "Add a catalog extension by name or name@version (repeatable)",
+		},
+		&cli.StringFlag{
+			Name:  "extensions-catalog",
+			Usage: "Path or URL of the extension catalog",
+		},
 		AllowInsecureRegistriesFlag,
 	},
 	Before: func(ctx *cli.Context) error {
@@ -136,6 +145,14 @@ var BuildUKICmd = cli.Command{
 		// https://github.com/urfave/cli/blob/7ec374fe2abd3e9c75369f6bb4191fe7866bd89c/command.go#L128
 		if len(ctx.StringSlice("extra-cmdline")) > 0 && ctx.String("extend-cmdline") != "" {
 			return errors.New("extra-cmdline and extend-cmdline flags are mutually exclusive")
+		}
+		if len(ctx.StringSlice("extension")) > 0 && ctx.String("extensions-catalog") == "" {
+			return errors.New("extensions-catalog is required when extension is set")
+		}
+		for _, value := range ctx.StringSlice("extension") {
+			if _, err := extensions.ParseRequest(value); err != nil {
+				return err
+			}
 		}
 		if ctx.String("public-keys") == "" {
 			fmt.Println("Warning: public-keys directory is not set, Secure Boot auto enroll will not work. You can set it with --public-keys flag.")
@@ -153,6 +170,14 @@ var BuildUKICmd = cli.Command{
 			logLevel = "debug"
 		}
 		log := logger.NewKairosLogger("auroraboot", logLevel, false)
+		extensionRequests := make([]extensions.Request, 0, len(ctx.StringSlice("extension")))
+		for _, value := range ctx.StringSlice("extension") {
+			request, err := extensions.ParseRequest(value)
+			if err != nil {
+				return err
+			}
+			extensionRequests = append(extensionRequests, request)
+		}
 
 		return uki.Build(uki.Options{
 			Source:                  args.Get(0),
@@ -176,6 +201,8 @@ var BuildUKICmd = cli.Command{
 			CmdLinesV2:              ctx.Bool("cmd-lines-v2"),
 			SdBootInSource:          ctx.Bool("sdboot-in-source"),
 			AllowInsecureRegistries: ctx.Bool("allow-insecure-registries"),
+			Extensions:              extensionRequests,
+			ExtensionsCatalog:       ctx.String("extensions-catalog"),
 			Logger:                  &log,
 		})
 	},

--- a/internal/cmd/build-uki_test.go
+++ b/internal/cmd/build-uki_test.go
@@ -26,4 +26,20 @@ var _ = Describe("build-uki", Label("uki", "cmd"), func() {
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).ToNot(ContainSubstring("flag provided but not defined"))
 	})
+
+	It("accepts repeatable extension flags", Label("flags"), func() {
+		err = app.Run([]string{"", "build-uki", "--tpm-pcr-private-key", "pcr.key", "--sb-key", "sb.key", "--sb-cert", "sb.pem", "--extension", "tool", "--extension", "debug@v2", "--extensions-catalog", "catalog.yaml", "some/image:latest"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).ToNot(ContainSubstring("flag provided but not defined"))
+	})
+
+	It("requires a catalog when extensions are requested", Label("flags"), func() {
+		err = app.Run([]string{"", "build-uki", "--tpm-pcr-private-key", "pcr.key", "--sb-key", "sb.key", "--sb-cert", "sb.pem", "--extension", "tool", "some/image:latest"})
+		Expect(err).To(MatchError("extensions-catalog is required when extension is set"))
+	})
+
+	It("rejects malformed extension requests", Label("flags"), func() {
+		err = app.Run([]string{"", "build-uki", "--tpm-pcr-private-key", "pcr.key", "--sb-key", "sb.key", "--sb-cert", "sb.pem", "--extension", "tool@", "--extensions-catalog", "catalog.yaml", "some/image:latest"})
+		Expect(err).To(MatchError(ContainSubstring("invalid extension request")))
+	})
 })

--- a/pkg/extensions/catalog.go
+++ b/pkg/extensions/catalog.go
@@ -1,0 +1,190 @@
+// Package extensions resolves catalog entries into local system extension files.
+package extensions
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	sdkextensions "github.com/kairos-io/kairos/v4/sdk/extensions"
+)
+
+const rawMediaType types.MediaType = "application/vnd.kairos.sysext.raw"
+
+var requestPart = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
+
+// Request identifies a named extension and an optional catalog version.
+type Request struct {
+	Name    string
+	Version string
+}
+
+// ParseRequest parses name or name@version.
+func ParseRequest(value string) (Request, error) {
+	parts := strings.Split(value, "@")
+	if len(parts) > 2 || len(parts) == 0 || !requestPart.MatchString(parts[0]) {
+		return Request{}, fmt.Errorf("invalid extension request %q", value)
+	}
+	request := Request{Name: parts[0]}
+	if len(parts) == 2 {
+		if !requestPart.MatchString(parts[1]) {
+			return Request{}, fmt.Errorf("invalid extension request %q", value)
+		}
+		request.Version = parts[1]
+	}
+	return request, nil
+}
+
+// Materialize resolves requests and writes their raw OCI layers to destination.
+func Materialize(ctx context.Context, catalogSource string, requests []Request, architecture string, destination string, insecure bool) ([]string, error) {
+	if len(requests) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{}, len(requests))
+	for _, request := range requests {
+		parsed, err := ParseRequest(request.Name)
+		if err != nil || parsed.Version != "" || (request.Version != "" && !requestPart.MatchString(request.Version)) {
+			return nil, fmt.Errorf("invalid extension request %q", formatRequest(request))
+		}
+		if _, exists := seen[request.Name]; exists {
+			return nil, fmt.Errorf("duplicate extension name %q", request.Name)
+		}
+		seen[request.Name] = struct{}{}
+	}
+	if architecture == "" {
+		return nil, fmt.Errorf("extension architecture must not be empty")
+	}
+
+	reader, err := openCatalog(ctx, catalogSource)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	catalog, err := sdkextensions.Parse(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(destination, 0o755); err != nil {
+		return nil, fmt.Errorf("create extension destination: %w", err)
+	}
+
+	temporary := make([]string, 0, len(requests))
+	outputs := make([]string, 0, len(requests))
+	cleanup := func() {
+		for _, path := range temporary {
+			_ = os.Remove(path)
+		}
+	}
+	defer cleanup()
+
+	for _, request := range requests {
+		resolved, resolveErr := catalog.Resolve(request.Name, request.Version, architecture)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("resolve extension %q: %w", request.Name, resolveErr)
+		}
+		options := []name.Option{}
+		if insecure {
+			options = append(options, name.Insecure)
+		}
+		reference, parseErr := name.NewDigest(resolved.OCI, options...)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse OCI reference for extension %q: %w", request.Name, parseErr)
+		}
+		image, pullErr := remote.Image(reference, remote.WithContext(ctx))
+		if pullErr != nil {
+			return nil, fmt.Errorf("pull extension %q: %w", request.Name, pullErr)
+		}
+		layers, layersErr := image.Layers()
+		if layersErr != nil {
+			return nil, fmt.Errorf("read layers for extension %q: %w", request.Name, layersErr)
+		}
+		if len(layers) != 1 {
+			return nil, fmt.Errorf("extension %q has %d layers, expected exactly one", request.Name, len(layers))
+		}
+		mediaType, mediaErr := layers[0].MediaType()
+		if mediaErr != nil {
+			return nil, fmt.Errorf("read layer media type for extension %q: %w", request.Name, mediaErr)
+		}
+		if mediaType != rawMediaType {
+			return nil, fmt.Errorf("extension %q layer media type is %q, expected %q", request.Name, mediaType, rawMediaType)
+		}
+		stream, streamErr := layers[0].Compressed()
+		if streamErr != nil {
+			return nil, fmt.Errorf("read extension %q layer: %w", request.Name, streamErr)
+		}
+		temp, tempErr := os.CreateTemp(destination, "."+request.Name+"-*.sysext.raw")
+		if tempErr != nil {
+			stream.Close()
+			return nil, fmt.Errorf("create temporary file for extension %q: %w", request.Name, tempErr)
+		}
+		temporary = append(temporary, temp.Name())
+		_, copyErr := io.Copy(temp, stream)
+		streamErr = stream.Close()
+		closeErr := temp.Close()
+		if copyErr != nil || streamErr != nil || closeErr != nil {
+			return nil, fmt.Errorf("write extension %q: %w", request.Name, firstError(copyErr, streamErr, closeErr))
+		}
+		outputs = append(outputs, filepath.Join(destination, request.Name+".sysext.raw"))
+	}
+
+	for index, path := range temporary {
+		if err := os.Rename(path, outputs[index]); err != nil {
+			for _, output := range outputs[:index] {
+				_ = os.Remove(output)
+			}
+			return nil, fmt.Errorf("install extension %q: %w", requests[index].Name, err)
+		}
+	}
+	return outputs, nil
+}
+
+func openCatalog(ctx context.Context, source string) (io.ReadCloser, error) {
+	parsed, err := url.Parse(source)
+	if err == nil && (parsed.Scheme == "http" || parsed.Scheme == "https") {
+		request, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
+		if requestErr != nil {
+			return nil, fmt.Errorf("create catalog request: %w", requestErr)
+		}
+		response, responseErr := http.DefaultClient.Do(request)
+		if responseErr != nil {
+			return nil, fmt.Errorf("load extension catalog: %w", responseErr)
+		}
+		if response.StatusCode < 200 || response.StatusCode >= 300 {
+			response.Body.Close()
+			return nil, fmt.Errorf("load extension catalog: HTTP status %s", response.Status)
+		}
+		return response.Body, nil
+	}
+	file, openErr := os.Open(source)
+	if openErr != nil {
+		return nil, fmt.Errorf("load extension catalog: %w", openErr)
+	}
+	return file, nil
+}
+
+func formatRequest(request Request) string {
+	if request.Version == "" {
+		return request.Name
+	}
+	return request.Name + "@" + request.Version
+}
+
+func firstError(errors ...error) error {
+	for _, err := range errors {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/extensions/catalog_test.go
+++ b/pkg/extensions/catalog_test.go
@@ -1,0 +1,219 @@
+package extensions
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	ggcrregistry "github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+func TestParseRequest(t *testing.T) {
+	tests := []struct {
+		value string
+		want  Request
+		ok    bool
+	}{
+		{value: "tool", want: Request{Name: "tool"}, ok: true},
+		{value: "tool@v1", want: Request{Name: "tool", Version: "v1"}, ok: true},
+		{value: "", ok: false},
+		{value: "@v1", ok: false},
+		{value: "tool@", ok: false},
+		{value: "tool@v1@extra", ok: false},
+		{value: " tool", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got, err := ParseRequest(tt.value)
+			if (err == nil) != tt.ok {
+				t.Fatalf("ParseRequest() error = %v, want success %v", err, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseRequest() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaterialize(t *testing.T) {
+	registry := httptest.NewServer(ggcrregistry.New())
+	t.Cleanup(registry.Close)
+	repository := strings.TrimPrefix(registry.URL, "http://") + "/extensions/tool"
+	digest := pushImage(t, repository, []layerSpec{{data: "raw extension", mediaType: rawMediaType}})
+	catalog := writeCatalog(t, repository+"@"+digest)
+	destination := t.TempDir()
+
+	paths, err := Materialize(context.Background(), catalog, []Request{{Name: "tool"}}, "amd64", destination, true)
+	if err != nil {
+		t.Fatalf("Materialize() error = %v", err)
+	}
+	if len(paths) != 1 || paths[0] != filepath.Join(destination, "tool.sysext.raw") {
+		t.Fatalf("Materialize() paths = %v", paths)
+	}
+	data, err := os.ReadFile(paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "raw extension" {
+		t.Fatalf("materialized data = %q", data)
+	}
+}
+
+func TestMaterializeLoadsHTTPCatalogAndResolvesVersion(t *testing.T) {
+	registry := httptest.NewServer(ggcrregistry.New())
+	t.Cleanup(registry.Close)
+	repository := strings.TrimPrefix(registry.URL, "http://") + "/extensions/tool"
+	digest := pushImage(t, repository, []layerSpec{{data: "version two", mediaType: rawMediaType}})
+	catalogData := catalogJSON(t, []catalogLayer{{name: "tool", latest: "v1", versions: map[string]string{"v2": repository + "@" + digest}}})
+	catalogServer := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		_, _ = response.Write(catalogData)
+	}))
+	t.Cleanup(catalogServer.Close)
+	destination := t.TempDir()
+
+	paths, err := Materialize(context.Background(), catalogServer.URL, []Request{{Name: "tool", Version: "v2"}}, "amd64", destination, true)
+	if err != nil {
+		t.Fatalf("Materialize() error = %v", err)
+	}
+	data, err := os.ReadFile(paths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "version two" {
+		t.Fatalf("materialized data = %q", data)
+	}
+}
+
+func TestMaterializeRejectsDuplicateNames(t *testing.T) {
+	_, err := Materialize(context.Background(), "unused", []Request{{Name: "tool"}, {Name: "tool", Version: "v2"}}, "amd64", t.TempDir(), false)
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("Materialize() error = %v, want duplicate error", err)
+	}
+}
+
+func TestMaterializeRejectsUnexpectedLayerCount(t *testing.T) {
+	registry := httptest.NewServer(ggcrregistry.New())
+	t.Cleanup(registry.Close)
+	repository := strings.TrimPrefix(registry.URL, "http://") + "/extensions/tool"
+	digest := pushImage(t, repository, []layerSpec{
+		{data: "one", mediaType: rawMediaType},
+		{data: "two", mediaType: rawMediaType},
+	})
+	catalog := writeCatalog(t, repository+"@"+digest)
+
+	_, err := Materialize(context.Background(), catalog, []Request{{Name: "tool"}}, "amd64", t.TempDir(), true)
+	if err == nil || !strings.Contains(err.Error(), "expected exactly one") {
+		t.Fatalf("Materialize() error = %v, want layer count error", err)
+	}
+}
+
+func TestMaterializeCleansTemporaryFilesOnFailure(t *testing.T) {
+	registry := httptest.NewServer(ggcrregistry.New())
+	t.Cleanup(registry.Close)
+	registryHost := strings.TrimPrefix(registry.URL, "http://")
+	validRepository := registryHost + "/extensions/valid"
+	invalidRepository := registryHost + "/extensions/invalid"
+	validDigest := pushImage(t, validRepository, []layerSpec{{data: "valid", mediaType: rawMediaType}})
+	invalidDigest := pushImage(t, invalidRepository, []layerSpec{{data: "wrong", mediaType: "application/octet-stream"}})
+	catalog := writeCatalogLayers(t, []catalogLayer{
+		{name: "valid", latest: "v1", versions: map[string]string{"v1": validRepository + "@" + validDigest}},
+		{name: "invalid", latest: "v1", versions: map[string]string{"v1": invalidRepository + "@" + invalidDigest}},
+	})
+	destination := t.TempDir()
+
+	_, err := Materialize(context.Background(), catalog, []Request{{Name: "valid"}, {Name: "invalid"}}, "amd64", destination, true)
+	if err == nil || !strings.Contains(err.Error(), "media type") {
+		t.Fatalf("Materialize() error = %v, want media type error", err)
+	}
+	entries, readErr := os.ReadDir(destination)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("destination contains files after failure: %v", entries)
+	}
+}
+
+type layerSpec struct {
+	data      string
+	mediaType types.MediaType
+}
+
+func pushImage(t *testing.T, repository string, specs []layerSpec) string {
+	t.Helper()
+	image := empty.Image
+	for _, spec := range specs {
+		var err error
+		image, err = mutate.AppendLayers(image, static.NewLayer([]byte(spec.data), spec.mediaType))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	tag, err := name.NewTag(repository+":test", name.Insecure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.Write(tag, image); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := image.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digest.String()
+}
+
+func writeCatalog(t *testing.T, oci string) string {
+	t.Helper()
+	return writeCatalogLayers(t, []catalogLayer{{name: "tool", latest: "v1", versions: map[string]string{"v1": oci}}})
+}
+
+type catalogLayer struct {
+	name     string
+	latest   string
+	versions map[string]string
+}
+
+func writeCatalogLayers(t *testing.T, layers []catalogLayer) string {
+	t.Helper()
+	data := catalogJSON(t, layers)
+	path := filepath.Join(t.TempDir(), "catalog.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func catalogJSON(t *testing.T, layers []catalogLayer) []byte {
+	t.Helper()
+	catalogLayers := make([]any, 0, len(layers))
+	for _, layer := range layers {
+		tags := make([]any, 0, len(layer.versions))
+		for version, oci := range layer.versions {
+			tags = append(tags, map[string]any{
+				"tag": version, "sysext": map[string]any{"amd64": map[string]string{"oci": oci}},
+			})
+		}
+		catalogLayers = append(catalogLayers, map[string]any{"name": layer.name, "latest": layer.latest, "tags": tags})
+	}
+	catalog := map[string]any{
+		"repo": "test", "layers": catalogLayers,
+	}
+	data, err := json.Marshal(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/pkg/ops/iso.go
+++ b/pkg/ops/iso.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kairos-io/AuroraBoot/internal"
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
+	"github.com/kairos-io/AuroraBoot/pkg/extensions"
 	"github.com/kairos-io/AuroraBoot/pkg/schema"
 	"github.com/kairos-io/AuroraBoot/pkg/utils"
 	"github.com/otiai10/copy"
@@ -114,7 +115,7 @@ func NewConfig(opts ...GenericOptions) *sdkConfig.Config {
 }
 
 // GenISO generates an ISO from a rootfs, and stores results in dst
-func GenISO(srcFunc, dstFunc valueGetOnCall, i schema.ISO) func(ctx context.Context) error {
+func GenISO(srcFunc, dstFunc valueGetOnCall, i schema.ISO, targetArch string, insecure bool) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		dst := dstFunc()
 		src := srcFunc()
@@ -151,6 +152,14 @@ func GenISO(srcFunc, dstFunc valueGetOnCall, i schema.ISO) func(ctx context.Cont
 		cfg.OutDir = dst
 		cfg.Date = i.IncludeDate
 
+		extensionArch := targetArch
+		if extensionArch == "" {
+			extensionArch = cfg.Arch
+		}
+		if err := materializeISOExtensions(ctx, i, extensionArch, tmp, insecure); err != nil {
+			return err
+		}
+
 		spec := &LiveISO{
 			RootFS:             []*imagetypes.ImageSource{imagetypes.NewDirSrc(src)},
 			Image:              []*imagetypes.ImageSource{imagetypes.NewDirSrc(tmp)},
@@ -183,6 +192,16 @@ func GenISO(srcFunc, dstFunc valueGetOnCall, i schema.ISO) func(ctx context.Cont
 		}
 		return err
 	}
+}
+
+var materializeExtensionArtifacts = extensions.Materialize
+
+func materializeISOExtensions(ctx context.Context, i schema.ISO, architecture, isoRoot string, insecure bool) error {
+	if len(i.Extensions) == 0 {
+		return nil
+	}
+	_, err := materializeExtensionArtifacts(ctx, i.ExtensionsCatalog, i.Extensions, architecture, isoRoot, insecure)
+	return err
 }
 
 func InjectISO(dstFunc, isoFunc valueGetOnCall, i schema.ISO) func(ctx context.Context) error {

--- a/pkg/ops/iso_test.go
+++ b/pkg/ops/iso_test.go
@@ -1,6 +1,8 @@
 package ops
 
 import (
+	"context"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -8,11 +10,46 @@ import (
 	"github.com/kairos-io/kairos/v4/sdk/types/logger"
 
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
+	"github.com/kairos-io/AuroraBoot/pkg/extensions"
+	"github.com/kairos-io/AuroraBoot/pkg/schema"
 	sdkutils "github.com/kairos-io/kairos/v4/sdk/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/twpayne/go-vfs/v5/vfst"
 )
+
+var _ = Describe("materializeISOExtensions", func() {
+	It("does nothing when no extensions are configured", func() {
+		called := false
+		materializeExtensionArtifacts = func(context.Context, string, []extensions.Request, string, string, bool) ([]string, error) {
+			called = true
+			return nil, nil
+		}
+		DeferCleanup(func() { materializeExtensionArtifacts = extensions.Materialize })
+
+		Expect(materializeISOExtensions(context.Background(), schema.ISO{}, "amd64", "/unused", false)).To(Succeed())
+		Expect(called).To(BeFalse())
+	})
+
+	It("uses the target architecture and ISO root directory", func() {
+		tmp := GinkgoT().TempDir()
+		requests := []extensions.Request{{Name: "foo", Version: "v1"}}
+		materializeExtensionArtifacts = func(_ context.Context, catalog string, got []extensions.Request, arch, destination string, insecure bool) ([]string, error) {
+			Expect(catalog).To(Equal("catalog.yaml"))
+			Expect(got).To(Equal(requests))
+			Expect(arch).To(Equal("arm64"))
+			Expect(destination).To(Equal(tmp))
+			Expect(insecure).To(BeTrue())
+			path := filepath.Join(destination, "foo.sysext.raw")
+			return []string{path}, os.WriteFile(path, []byte("raw"), 0o644)
+		}
+		DeferCleanup(func() { materializeExtensionArtifacts = extensions.Materialize })
+
+		iso := schema.ISO{ExtensionsCatalog: "catalog.yaml", Extensions: requests}
+		Expect(materializeISOExtensions(context.Background(), iso, "arm64", tmp, true)).To(Succeed())
+		Expect(filepath.Join(tmp, "foo.sysext.raw")).To(BeAnExistingFile())
+	})
+})
 
 var _ = Describe("applyGrubTemplate", Label("iso"), func() {
 	const templateWithPlaceholders = "linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE {{LIVE_CONSOLE}}{{NOMODESET}} install-mode\nlinux ($root)/boot/kernel cdroot{{EXTEND_CMDLINE}}\nmenuentry debug { linux console=tty0 }\n"

--- a/pkg/schema/config.go
+++ b/pkg/schema/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/kairos-io/AuroraBoot/pkg/extensions"
 	"github.com/kairos-io/kairos/v4/sdk/types/logger"
 )
 
@@ -97,8 +98,10 @@ type ISO struct {
 	OverlayISO    string `yaml:"overlay_iso"`
 	OverlayRootfs string `yaml:"overlay_rootfs"`
 	// ExtendLiveCmdline is appended to the kernel cmdline when booting from the live/installer ISO. Does not affect the installed system.
-	ExtendLiveCmdline string `yaml:"extend-live-cmdline"`
-	LiveConsole       string `yaml:"live_console"`
+	ExtendLiveCmdline string               `yaml:"extend-live-cmdline"`
+	LiveConsole       string               `yaml:"live_console"`
+	ExtensionsCatalog string               `yaml:"extensions_catalog"`
+	Extensions        []extensions.Request `yaml:"extensions"`
 }
 
 // HandleDeprecations checks for deprecated ISO options and migrates them.
@@ -148,6 +151,9 @@ func (c *Config) AllowInsecureRegistriesBool() bool {
 // starts, so we fail fast with a clear message instead of deep inside a build
 // step.
 func (c Config) Validate() error {
+	if len(c.ISO.Extensions) > 0 && c.ISO.ExtensionsCatalog == "" {
+		return fmt.Errorf("iso.extensions_catalog is required when iso.extensions is set")
+	}
 	// Partition-image output skips the final merge into a single .raw disk, so
 	// the gce/vhd conversions (which operate on that merged disk) have nothing
 	// to convert. Reject the combination up front.

--- a/pkg/schema/config_test.go
+++ b/pkg/schema/config_test.go
@@ -1,12 +1,35 @@
 package schema_test
 
 import (
+	"github.com/kairos-io/AuroraBoot/pkg/extensions"
 	"github.com/kairos-io/AuroraBoot/pkg/schema"
 	"github.com/kairos-io/kairos/v4/sdk/types/logger"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("ISO extensions", func() {
+	It("stores a catalog and parsed requests", func() {
+		iso := schema.ISO{
+			ExtensionsCatalog: "catalog.yaml",
+			Extensions:        []extensions.Request{{Name: "foo", Version: "v1"}},
+		}
+		Expect(iso.ExtensionsCatalog).To(Equal("catalog.yaml"))
+		Expect(iso.Extensions).To(Equal([]extensions.Request{{Name: "foo", Version: "v1"}}))
+	})
+
+	It("keeps the empty configuration as a no-op", func() {
+		iso := schema.ISO{}
+		Expect(iso.ExtensionsCatalog).To(BeEmpty())
+		Expect(iso.Extensions).To(BeEmpty())
+	})
+
+	It("requires a catalog when requests are configured", func() {
+		cfg := schema.Config{ISO: schema.ISO{Extensions: []extensions.Request{{Name: "foo"}}}}
+		Expect(cfg.Validate()).To(MatchError(ContainSubstring("extensions_catalog")))
+	})
+})
 
 var _ = Describe("ISO HandleDeprecations", func() {
 	var (

--- a/pkg/uki/uki.go
+++ b/pkg/uki/uki.go
@@ -9,6 +9,7 @@
 package uki
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
+	"github.com/kairos-io/AuroraBoot/pkg/extensions"
 	"github.com/kairos-io/AuroraBoot/pkg/ops"
 	"github.com/kairos-io/AuroraBoot/pkg/utils"
 	goukiuki "github.com/kairos-io/go-ukify/pkg/uki"
@@ -62,6 +64,12 @@ type Options struct {
 	// served over plain HTTP or presenting an untrusted/self-signed TLS
 	// certificate.
 	AllowInsecureRegistries bool
+
+	// Extensions are named catalog extensions to place in the ISO root.
+	Extensions []extensions.Request
+
+	// ExtensionsCatalog is the path or URL of the extension catalog.
+	ExtensionsCatalog string
 
 	// OverlayRootfs is an optional directory whose contents are copied into
 	// the rootfs before the UKI is built.
@@ -363,7 +371,7 @@ func Build(opts Options) (err error) {
 
 	switch outputType {
 	case string(constants.IsoOutput):
-		if err := createISO(e, sourceDir, outputDir, opts.OverlayISO, opts.PublicKeysDir, outputName, opts.Name, entries, *log, config.Arch); err != nil {
+		if err := createISO(e, sourceDir, outputDir, opts.OverlayISO, opts.PublicKeysDir, outputName, opts.Name, entries, *log, config.Arch, opts.ExtensionsCatalog, opts.Extensions, opts.AllowInsecureRegistries); err != nil {
 			return err
 		}
 	case string(constants.ContainerOutput):
@@ -408,6 +416,14 @@ func (o Options) validate() error {
 	}
 	if outputType != string(constants.DefaultOutput) && outputType != string(constants.IsoOutput) && outputType != string(constants.ContainerOutput) {
 		return fmt.Errorf("uki.Build: invalid output type: %s", outputType)
+	}
+	if len(o.Extensions) > 0 {
+		if outputType != string(constants.IsoOutput) {
+			return errors.New("extensions are only supported for iso artifacts")
+		}
+		if o.ExtensionsCatalog == "" {
+			return errors.New("extensions catalog is required when extensions are requested")
+		}
 	}
 
 	if o.OverlayRootfs != "" {
@@ -792,12 +808,16 @@ func createSystemdConf(dir, secureBootEnroll string) error {
 	return nil
 }
 
-func createISO(e *elemental.Elemental, sourceDir, outputDir, overlayISO, keysDir, outputName, artifactName string, entries []utils.BootEntry, log logger.KairosLogger, arch string) error {
+func createISO(e *elemental.Elemental, sourceDir, outputDir, overlayISO, keysDir, outputName, artifactName string, entries []utils.BootEntry, log logger.KairosLogger, arch, extensionsCatalog string, extensionRequests []extensions.Request, insecure bool) error {
 	isoDir, err := os.MkdirTemp("", "auroraboot-iso-dir-")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(isoDir)
+
+	if err := stageExtensions(context.Background(), extensionsCatalog, extensionRequests, arch, isoDir, insecure); err != nil {
+		return err
+	}
 
 	filesMap, err := imageFiles(sourceDir, keysDir, entries, arch)
 	if err != nil {
@@ -868,6 +888,13 @@ func createISO(e *elemental.Elemental, sourceDir, outputDir, overlayISO, keysDir
 		return fmt.Errorf("error creating iso file: %w\n%s", err, string(out))
 	}
 	return nil
+}
+
+var materializeExtensions = extensions.Materialize
+
+func stageExtensions(ctx context.Context, catalog string, requests []extensions.Request, arch, destination string, insecure bool) error {
+	_, err := materializeExtensions(ctx, catalog, requests, arch, destination, insecure)
+	return err
 }
 
 func imageFiles(sourceDir, keysDir string, entries []utils.BootEntry, arch string) (map[string][]string, error) {

--- a/pkg/uki/uki_test.go
+++ b/pkg/uki/uki_test.go
@@ -1,12 +1,69 @@
 package uki
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
+	"github.com/kairos-io/AuroraBoot/pkg/extensions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("catalog extensions", func() {
+	It("rejects extension requests for non-ISO output", func() {
+		opts := validTestOptions()
+		opts.Extensions = []extensions.Request{{Name: "tool"}}
+		opts.ExtensionsCatalog = "catalog.yaml"
+		Expect(opts.validate()).To(MatchError("extensions are only supported for iso artifacts"))
+	})
+
+	It("requires a catalog when extensions are requested", func() {
+		opts := validTestOptions()
+		opts.OutputType = "iso"
+		opts.Extensions = []extensions.Request{{Name: "tool"}}
+		Expect(opts.validate()).To(MatchError("extensions catalog is required when extensions are requested"))
+	})
+
+	It("materializes extensions into the staged ISO root with the target architecture", func() {
+		original := materializeExtensions
+		DeferCleanup(func() { materializeExtensions = original })
+		stagedRoot := tTempDir()
+		called := false
+		materializeExtensions = func(_ context.Context, catalog string, requests []extensions.Request, arch, destination string, insecure bool) ([]string, error) {
+			called = true
+			Expect(catalog).To(Equal("catalog.yaml"))
+			Expect(requests).To(Equal([]extensions.Request{{Name: "tool", Version: "v2"}}))
+			Expect(arch).To(Equal("arm64"))
+			Expect(destination).To(Equal(stagedRoot))
+			Expect(insecure).To(BeTrue())
+			return []string{filepath.Join(destination, "tool.sysext.raw")}, nil
+		}
+
+		Expect(stageExtensions(context.Background(), "catalog.yaml", []extensions.Request{{Name: "tool", Version: "v2"}}, "arm64", stagedRoot, true)).To(Succeed())
+		Expect(called).To(BeTrue())
+	})
+})
+
+func validTestOptions() Options {
+	dir := tTempDir()
+	for _, name := range []string{"sb.key", "sb.pem", "pcr.key"} {
+		Expect(os.WriteFile(filepath.Join(dir, name), []byte("test"), 0o600)).To(Succeed())
+	}
+	return Options{
+		Source:           "dir:rootfs",
+		SBKey:            filepath.Join(dir, "sb.key"),
+		SBCert:           filepath.Join(dir, "sb.pem"),
+		TPMPCRPrivateKey: filepath.Join(dir, "pcr.key"),
+	}
+}
+
+func tTempDir() string {
+	dir, err := os.MkdirTemp("", "uki-extension-test-")
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
 
 var _ = Describe("sumFileSizes", func() {
 	var tempDir string


### PR DESCRIPTION
## What this draft contains

Adds the focused AuroraBoot materializer for named sysext catalog entries. It uses the shared Kairos SDK resolver, pulls one digest-pinned OCI raw layer, validates the Kairos sysext media type, and writes artifacts atomically.

## Why this remains a draft

The follow-up wiring into classic ISO and UKI ISO build paths is not included. The required in-worktree package verification was blocked because this host has Go 1.26.5 while the repository requires 1.26.6, and module/toolchain downloads return HTTP 403. The package tests passed only in an isolated compatibility module using the exact SDK source, which is not sufficient to mark the task complete.

This draft preserves the reviewed implementation for CI and follow-up work without presenting it as complete.

Part of kairos-io/kairos#4298.