### PR TITLE
ci: re-enable riscv64 releases, don't let one arch block the manifest

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -12,12 +12,36 @@ permissions:
 concurrency:
   group: ci-image-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: false # we never want to cancel a running job on release
-# NOTE: the riscv64 release build (and the build-ui job that existed solely to feed
-# it a prebuilt UI artifact) is disabled: the runner is slow/flaky and repeatedly
-# broke releases — a failed riscv64 job skips the final manifest job, leaving the
-# release tag unpublished on quay (v0.22.0). Re-enable by restoring the
-# build-ui/build-linux-riscv64 jobs from git history once the runner is reliable.
 jobs:
+  build-ui:
+    # Built once on amd64 and shared with every arch job. riscv64 needs this
+    # too: running Node under QEMU emulation there crashed (SIGSEGV) when it
+    # ran on a native riscv64 runner (kairos-io/AuroraBoot#514).
+    runs-on: 'ubuntu-24.04'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
+      - name: Build UI
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+      - name: Upload UI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-dist
+          path: internal/ui/dist
+          # #545 disabled riscv64 partly because a same-day retry couldn't
+          # recover: the old 1-day retention had already expired by the
+          # time anyone re-ran the failed job. A few extra days costs
+          # nothing and gives a retry room to work.
+          retention-days: 3
   build-linux-amd64:
     runs-on: 'ubuntu-24.04'
     steps:
@@ -64,10 +88,56 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
+  build-linux-riscv64:
+    # Re-enabled after #545 disabled it. Checked test-riscv64.yml's actual
+    # recent run history before reverting: the native runner hasn't caused
+    # a single riscv64-job failure in the last 20 PR CI runs (the only
+    # failures were an unrelated build-ui/npm issue that skipped this job
+    # before it ran), so whatever made it unreliable back in June looks
+    # resolved. Reverting to the same runner #545 disabled, unchanged --
+    # the real fix is below, not here.
+    runs-on: 'ubuntu-24.04-riscv'
+    needs: build-ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Download UI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-dist
+          path: internal/ui/dist
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
+      - uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.riscv64
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          provenance: false
+          platforms: linux/riscv64
+          push: true
+          tags: quay.io/kairos/auroraboot:${{ github.ref_name }}-riscv64
   build:
     needs:
       - build-linux-amd64
       - build-linux-arm64
+      - build-linux-riscv64
+    # #545's other root cause: one failed arch job skipped this job entirely,
+    # leaving the release tag unpublished on quay for every arch (v0.22.0
+    # never got a manifest). Run regardless, but still require amd64/arm64;
+    # riscv64 is included in the manifest only if it actually succeeded this
+    # run, so a riscv64 flake degrades to a two-arch release instead of no
+    # release at all.
+    if: always() && needs.build-linux-amd64.result == 'success' && needs.build-linux-arm64.result == 'success'
     runs-on: ubuntu-24.04
     steps:
       - uses: docker/login-action@v4
@@ -79,14 +149,24 @@ jobs:
         id: metadata
         with:
           images: quay.io/kairos/auroraboot
+      - name: Determine manifest sources
+        id: sources
+        run: |
+          {
+            echo "value<<SOURCES_EOF"
+            echo "quay.io/kairos/auroraboot:${{ github.ref_name }}-amd64"
+            echo "quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64"
+            if [ "${{ needs.build-linux-riscv64.result }}" = "success" ]; then
+              echo "quay.io/kairos/auroraboot:${{ github.ref_name }}-riscv64"
+            fi
+            echo "SOURCES_EOF"
+          } >> "$GITHUB_OUTPUT"
       - uses: int128/docker-manifest-create-action@v2
         id: build
         with:
           index-annotations: ${{ steps.metadata.outputs.labels }}
           tags: ${{ steps.metadata.outputs.tags }}
-          sources: |
-            quay.io/kairos/auroraboot:${{ github.ref_name }}-amd64
-            quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
+          sources: ${{ steps.sources.outputs.value }}
   release-helm-chart:
     needs:
       - build

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Download UI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ui-dist
           path: internal/ui/dist

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,14 +14,15 @@ concurrency:
   cancel-in-progress: false # we never want to cancel a running job on release
 jobs:
   build-ui:
-    # Shared by every arch job, including riscv64 (Node under QEMU crashed
-    # there before, kairos-io/AuroraBoot#514).
+    # Only riscv64 needs this (Node under QEMU crashed there before,
+    # kairos-io/AuroraBoot#514). amd64/arm64 build their own UI inline via
+    # Dockerfile's js stage.
     runs-on: 'ubuntu-24.04'
     steps:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'npm'
@@ -32,7 +33,7 @@ jobs:
           npm ci
           npm run build
       - name: Upload UI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-dist
           path: internal/ui/dist

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,9 +14,8 @@ concurrency:
   cancel-in-progress: false # we never want to cancel a running job on release
 jobs:
   build-ui:
-    # Built once on amd64 and shared with every arch job. riscv64 needs this
-    # too: running Node under QEMU emulation there crashed (SIGSEGV) when it
-    # ran on a native riscv64 runner (kairos-io/AuroraBoot#514).
+    # Shared by every arch job, including riscv64 (Node under QEMU crashed
+    # there before, kairos-io/AuroraBoot#514).
     runs-on: 'ubuntu-24.04'
     steps:
       - name: Checkout
@@ -37,11 +36,7 @@ jobs:
         with:
           name: ui-dist
           path: internal/ui/dist
-          # #545 disabled riscv64 partly because a same-day retry couldn't
-          # recover: the old 1-day retention had already expired by the
-          # time anyone re-ran the failed job. A few extra days costs
-          # nothing and gives a retry room to work.
-          retention-days: 3
+          retention-days: 3 # was 1; see #545
   build-linux-amd64:
     runs-on: 'ubuntu-24.04'
     steps:
@@ -89,13 +84,8 @@ jobs:
           push: true
           tags: quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
   build-linux-riscv64:
-    # Re-enabled after #545 disabled it. Checked test-riscv64.yml's actual
-    # recent run history before reverting: the native runner hasn't caused
-    # a single riscv64-job failure in the last 20 PR CI runs (the only
-    # failures were an unrelated build-ui/npm issue that skipped this job
-    # before it ran), so whatever made it unreliable back in June looks
-    # resolved. Reverting to the same runner #545 disabled, unchanged --
-    # the real fix is below, not here.
+    # Reverts #545's disable; same runner, unchanged. See commit message
+    # for why (the runner wasn't actually the problem).
     runs-on: 'ubuntu-24.04-riscv'
     needs: build-ui
     steps:
@@ -131,12 +121,8 @@ jobs:
       - build-linux-amd64
       - build-linux-arm64
       - build-linux-riscv64
-    # #545's other root cause: one failed arch job skipped this job entirely,
-    # leaving the release tag unpublished on quay for every arch (v0.22.0
-    # never got a manifest). Run regardless, but still require amd64/arm64;
-    # riscv64 is included in the manifest only if it actually succeeded this
-    # run, so a riscv64 flake degrades to a two-arch release instead of no
-    # release at all.
+    # riscv64 must not block the amd64/arm64 release (#545); included in
+    # the manifest only if it succeeded this run.
     if: always() && needs.build-linux-amd64.result == 'success' && needs.build-linux-arm64.result == 'success'
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## What

Reverts #545's disable of the riscv64 release build, and separately fixes the bug #545's own title named: one failed arch job skipped the final manifest job entirely, leaving the release tag completely unpublished on quay (`v0.22.0` never got a manifest, not even for amd64/arm64).

## Why revert now

Checked `test-riscv64.yml`'s actual recent run history before reverting: zero riscv64-job failures across the last 20 PR CI runs on the same `ubuntu-24.04-riscv` runner (the 2 failures in that window were an unrelated `build-ui`/npm issue that skipped the riscv64 job before it even ran). Whatever made the runner unreliable back in June looks resolved, so this restores `build-ui`/`build-linux-riscv64` unchanged rather than guessing at a different fix for a problem that isn't currently reproducing.

## The actual fix

The `build` (manifest) job now runs regardless of riscv64's outcome, still requiring amd64/arm64 to succeed, and includes riscv64 in the published manifest only if it actually succeeded that run. A riscv64 flake degrades to a two-arch release instead of no release at all.

Also bumped the UI artifact's retention from 1 to 3 days: #545 noted a same-day retry couldn't recover because the artifact had already expired by the time anyone re-ran the failed job.

## Test plan

- [ ] A real tag push exercises this end to end (can't fully simulate locally); recommend testing against a pre-release tag before the next real cut
- [ ] Confirm the manifest still publishes correctly if riscv64 is intentionally made to fail