### PR TITLE
fix(ui): document the local dev setup and fix vite's host rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,16 @@ cd AuroraBoot
 docker compose up --build -d
 ```
 
-On first boot AuroraBoot generates an admin password and a node registration token under `./data/secrets/`:
+On first boot AuroraBoot generates an admin password and a node registration token. `docker-compose.yml` keeps `/data` in a named volume, not a bind mount, so read them from inside the container:
 
 ```bash
-cat data/secrets/admin-password
-cat data/secrets/registration-token
+docker compose exec auroraboot cat /data/secrets/admin-password
+docker compose exec auroraboot cat /data/secrets/registration-token
 ```
 
 Open **http://localhost:9099**, sign in, and the welcome wizard walks you through the three steps: build an artifact, deploy it, manage the nodes that come online.
+
+If you reach the UI from another machine (not `localhost`), set `AURORABOOT_URL` to that reachable address before starting the stack. Left unset, AuroraBoot falls back to the container's hostname, which nodes can't resolve, so they can't phone home. See `--url` below.
 
 ### What you get
 
@@ -243,11 +245,14 @@ Run `auroraboot help` for the full list.
 # Backend (Go 1.26+)
 go build ./...
 go test ./...
+go run . web --listen :8080   # serves the API the frontend dev server proxies to
 
-# Frontend (Node 22+)
+# Frontend (Node 22+) — in a second terminal, with the backend above running:
 cd ui
 npm install
-npm run dev     # Vite dev server on :5173, proxies /api to :8080
+npm run dev             # Vite dev server on localhost:5173, proxies /api to :8080
+npm run dev -- --host   # same, but reachable from other machines (Vite binds localhost only by default)
+VITE_ALLOWED_HOSTS=my-machine.local npm run dev -- --host   # also needed to reach it by a LAN/mDNS name
 npm run build
 npm test
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    // Vite rejects requests whose Host header isn't recognized. Set
+    // VITE_ALLOWED_HOSTS (comma-separated) to reach the dev server via a
+    // LAN or mDNS name, e.g. VITE_ALLOWED_HOSTS=my-machine.local
+    allowedHosts: process.env.VITE_ALLOWED_HOSTS?.split(",").map((h) =>
+      h.trim(),
+    ),
     proxy: {
       "/api": {
         target: "http://localhost:8080",

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -19,9 +19,9 @@ export default defineConfig({
     // Vite rejects requests whose Host header isn't recognized. Set
     // VITE_ALLOWED_HOSTS (comma-separated) to reach the dev server via a
     // LAN or mDNS name, e.g. VITE_ALLOWED_HOSTS=my-machine.local
-    allowedHosts: process.env.VITE_ALLOWED_HOSTS?.split(",").map((h) =>
-      h.trim(),
-    ),
+    allowedHosts: process.env.VITE_ALLOWED_HOSTS?.split(",")
+      .map((h) => h.trim())
+      .filter((h) => h.length > 0),
     proxy: {
       "/api": {
         target: "http://localhost:8080",


### PR DESCRIPTION
## What

Two defects found running the local dev setup end to end (docker-compose stack + UI dev server):

1. README told readers to `cat data/secrets/admin-password` straight from the host. `docker-compose.yml` mounts a named volume, not a bind mount, so that path never appears on the host. Corrected to `docker compose exec auroraboot cat /data/secrets/admin-password`.
2. `ui/vite.config.ts` set no `allowedHosts`, so Vite 8 rejects any request whose `Host` header isn't `localhost` — reaching the dev server at a LAN or mDNS name (e.g. `stardust.local:5173`) fails outright. Added an opt-in `VITE_ALLOWED_HOSTS` env var (comma-separated) rather than hardcoding one person's machine, and documented the two-terminal dev loop (`go run . web --listen :8080`, then `npm run dev -- --host`).

Also documented `AURORABOOT_URL`'s container fallback: unset, it resolves to the container's hostname (the container ID inside Docker), which nodes can't reach, so they can't phone home. The getting-started path never mentioned the flag.

## Why

Filed as mauromorales/mission-control#257, both defects hit live while helping start the AuroraBoot web UI on stardust on 2026-08-17.

## Test plan

- [ ] Both failures were reproduced live against a real docker-compose stack before this fix existed (that reproduction is what #257 documents). This diff itself has not been re-run against a live stack in this session — no build, no docker compose, no npm run dev were executed here. Worth actually re-running both repro steps against this branch before merge, rather than trusting the diff alone.

---

🤖 Automated PR by `mauro-agent`, an AI agent operated by `@mauromorales`. Draft until he reviews it himself.