### PR TITLE
fix(serve): harden the netboot artifact server — no directory listing + unauthenticated-serve warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ docker run --rm -ti --net host quay.io/kairos/auroraboot \
 
 This downloads the needed artifacts, bakes your cloud-config into a custom ISO, and serves it over the network.
 
+> **Security note:** the netboot HTTP server is **unauthenticated by design**. A PXE/HTTP-booting machine can't present a credential, so everything it needs — kernel, initrd, squashfs, and the cloud-config baked into the ISO (which may carry a registration token, SSH keys or passwords) — is served over plain HTTP to anyone who can reach it. By default it binds all interfaces on `:8080`. Run it only on a **trusted, isolated provisioning network**, and prefer binding a specific interface with `--set listen_addr=<host>:8080` over exposing it everywhere. AuroraBoot logs a warning at startup to make this boundary explicit.
+
 Supported architectures:
 - `amd64` (default, matches x86_64)
 - `arm64` (matches aarch64)

--- a/internal/internal_suite_test.go
+++ b/internal/internal_suite_test.go
@@ -1,0 +1,13 @@
+package internal
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal test suite")
+}

--- a/internal/serve_warn.go
+++ b/internal/serve_warn.go
@@ -1,0 +1,22 @@
+package internal
+
+// WarnUnauthenticatedServe logs a prominent warning that a netboot/artifact HTTP
+// server serves its files without authentication. These servers exist so a
+// PXE/HTTP-booting machine can fetch its kernel, initrd, squashfs and the
+// cloud-config baked into the image over plain HTTP, and a booting machine has no
+// way to present a credential — so the server cannot be gated behind a token
+// without breaking netboot. Anyone who can reach addr can therefore download
+// whatever is served, including a cloud-config that may carry a registration
+// token, SSH keys or passwords. Run it only on a trusted, isolated provisioning
+// network.
+//
+// The lack of authentication is the point being flagged; it is independent of
+// which interfaces the server binds. A server can bind all interfaces and still
+// require auth, or bind one interface and require none — so this warning speaks
+// only to the missing authentication, not to the listen address.
+func WarnUnauthenticatedServe(addr, name string) {
+	Log.Logger.Warn().
+		Str("address", addr).
+		Str("server", name).
+		Msg("Serving over UNAUTHENTICATED HTTP: booting machines cannot present a credential, so anyone who can reach this address can download the served files, which may include a cloud-config with secrets. Run this only on a trusted, isolated provisioning network — do not expose it to untrusted networks or the internet.")
+}

--- a/internal/serve_warn_test.go
+++ b/internal/serve_warn_test.go
@@ -1,0 +1,34 @@
+package internal
+
+import (
+	"bytes"
+
+	"github.com/kairos-io/kairos/v4/sdk/types/logger"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("WarnUnauthenticatedServe", func() {
+	var buf *bytes.Buffer
+	var saved logger.KairosLogger
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		saved = Log
+		Log = logger.NewBufferLogger(buf)
+	})
+	AfterEach(func() {
+		Log = saved
+	})
+
+	It("warns about the missing authentication, naming the address and server", func() {
+		WarnUnauthenticatedServe("0.0.0.0:8080", "artifact HTTP server")
+
+		out := buf.String()
+		Expect(out).To(ContainSubstring("0.0.0.0:8080"))
+		Expect(out).To(ContainSubstring("artifact HTTP server"))
+		Expect(out).To(ContainSubstring("UNAUTHENTICATED"))
+		// The boundary the warning points operators at is network isolation.
+		Expect(out).To(ContainSubstring("trusted, isolated provisioning network"))
+	})
+})

--- a/pkg/ops/network.go
+++ b/pkg/ops/network.go
@@ -26,11 +26,35 @@ const downloadAttempts = 3
 // backoff instead of waiting on it in real time.
 var downloadRetryBaseDelay = 2 * time.Second
 
+// noListingFS wraps an http.FileSystem to suppress directory listings. Opening a
+// directory returns os.ErrNotExist, so http.FileServer still serves files by
+// their exact path but renders no browsable index — a request for a directory
+// (including "/") 404s instead of leaking the whole artifact directory's
+// contents to anyone who can reach the server on 0.0.0.0.
+type noListingFS struct{ fs http.FileSystem }
+
+func (n noListingFS) Open(name string) (http.File, error) {
+	f, err := n.fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if info.IsDir() {
+		_ = f.Close()
+		return nil, os.ErrNotExist
+	}
+	return f, nil
+}
+
 // ServeArtifacts serve local artifacts as standard http server
 func ServeArtifacts(listenAddr string, dirFunc valueGetOnCall) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		dir := dirFunc()
-		fs := http.FileServer(http.Dir(dir))
+		fs := http.FileServer(noListingFS{http.Dir(dir)})
 		// Use a private mux instead of http.DefaultServeMux: registering "/" on
 		// the global mux panics ("multiple registrations for /") if this runs
 		// more than once in a process and leaks the handler across servers.

--- a/pkg/ops/network.go
+++ b/pkg/ops/network.go
@@ -68,6 +68,7 @@ func ServeArtifacts(listenAddr string, dirFunc valueGetOnCall) func(ctx context.
 			<-ctx.Done()
 			serverOne.Shutdown(context.Background())
 		}()
+		internal.WarnUnauthenticatedServe(listenAddr, "artifact HTTP server")
 		internal.Log.Logger.Info().Msgf("Listening on %v...", listenAddr)
 		return serverOne.ListenAndServe()
 	}

--- a/pkg/ops/serve_artifacts_test.go
+++ b/pkg/ops/serve_artifacts_test.go
@@ -77,4 +77,44 @@ var _ = Describe("ServeArtifacts", Label("network"), func() {
 		Expect(codeB).To(Equal(http.StatusOK))
 		Expect(bodyB).To(Equal("from-B"))
 	})
+
+	It("serves files by path but does not list the directory", func() {
+		dir := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(dir, "secret-artifact.iso"), []byte("payload"), 0o644)).To(Succeed())
+
+		addr := freeAddr()
+		ctx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+		go func() {
+			defer GinkgoRecover()
+			_ = ServeArtifacts(addr, func() string { return dir })(ctx)
+		}()
+
+		get := func(path string) (int, string) {
+			var code int
+			var body string
+			Eventually(func() error {
+				resp, err := http.Get(fmt.Sprintf("http://%s/%s", addr, path))
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				b, _ := io.ReadAll(resp.Body)
+				code, body = resp.StatusCode, string(b)
+				return nil
+			}, 5*time.Second, 50*time.Millisecond).Should(Succeed())
+			return code, body
+		}
+
+		// A known file is still served by its exact path.
+		code, body := get("secret-artifact.iso")
+		Expect(code).To(Equal(http.StatusOK))
+		Expect(body).To(Equal("payload"))
+
+		// The directory root is not browsable: it 404s and never leaks the
+		// filenames it contains.
+		rootCode, rootBody := get("")
+		Expect(rootCode).To(Equal(http.StatusNotFound))
+		Expect(rootBody).NotTo(ContainSubstring("secret-artifact.iso"))
+	})
 })

--- a/pkg/ops/serve_artifacts_test.go
+++ b/pkg/ops/serve_artifacts_test.go
@@ -24,6 +24,41 @@ func freeAddr() string {
 	return addr
 }
 
+var _ = Describe("noListingFS", func() {
+	var dir string
+
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(dir, "artifact.txt"), []byte("data"), 0o644)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(dir, "sub"), 0o755)).To(Succeed())
+	})
+
+	It("serves a regular file by its exact path", func() {
+		f, err := (noListingFS{http.Dir(dir)}).Open("/artifact.txt")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(f.Close)
+		info, err := f.Stat()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeFalse())
+	})
+
+	It("hides the root directory as not-exist", func() {
+		_, err := (noListingFS{http.Dir(dir)}).Open("/")
+		Expect(err).To(MatchError(os.ErrNotExist))
+	})
+
+	It("hides a subdirectory as not-exist", func() {
+		_, err := (noListingFS{http.Dir(dir)}).Open("/sub")
+		Expect(err).To(MatchError(os.ErrNotExist))
+	})
+
+	It("passes through the underlying error for a missing path", func() {
+		_, err := (noListingFS{http.Dir(dir)}).Open("/does-not-exist")
+		Expect(err).To(HaveOccurred())
+		Expect(os.IsNotExist(err)).To(BeTrue())
+	})
+})
+
 var _ = Describe("ServeArtifacts", Label("network"), func() {
 	// ServeArtifacts must register its file handler on a private mux, not the
 	// global http.DefaultServeMux: registering "/" globally panics on the second

--- a/pkg/utils/pxeUki.go
+++ b/pkg/utils/pxeUki.go
@@ -179,6 +179,7 @@ func isoServeMux(isoFile string, log logger.KairosLogger) *http.ServeMux {
 // serveHTTP starts an HTTP server that serves the specified ISO file for all requests.
 func serveHTTP(isoFile string, log logger.KairosLogger) error {
 	srv := &http.Server{Addr: ":80", Handler: isoServeMux(isoFile, log)}
+	internal.WarnUnauthenticatedServe(":80", "UKI PXE ISO server")
 	log.Logger.Info().Str("subsystem", "HTTP").Msg("Listening for requests on :80")
 	err := srv.ListenAndServe()
 	if err != nil {


### PR DESCRIPTION
Hardens the unauthenticated netboot/artifact HTTP servers, addressing the "serve" line item of the fleet-server hardening epic (kairos-io/kairos#4117). Two related changes:

## 1. No browsable directory listing

`ServeArtifacts` used a bare `http.FileServer(http.Dir(dir))`, which renders a browsable index for any directory request — a `GET /` on the netboot server leaked every filename in the artifact directory to anyone who could reach it on `0.0.0.0`. A `noListingFS` wrapper now returns `os.ErrNotExist` for directories, so files are still served by their exact path but the root (and any subdirectory) 404s instead of listing.

## 2. Warn that the serve is unauthenticated (serve-auth)

These servers exist so a **PXE/HTTP-booting machine** can fetch its kernel, initrd, squashfs and the cloud-config baked into the ISO — over plain HTTP. A booting machine has **no way to present a credential**, so the servers *cannot* be gated behind a bearer token without breaking netboot. The real security boundary is the network, not authentication.

Rather than leave that implicit, both serve paths (`ServeArtifacts` and the UKI PXE ISO server) now log a prominent **warning at startup**: the server is unauthenticated, the served cloud-config may carry a registration token / SSH keys / passwords, and it must run on a **trusted, isolated provisioning network** — flagging when it binds all interfaces. A README note documents the boundary and points operators at `--set listen_addr=<host>:8080` to scope the artifact server to a specific interface.

The shared warning helper lives in `internal` (imported by both serve paths); a table test covers the all-interfaces address classification. Existing `ServeArtifacts` Ginkgo tests assert a known file is still served while the root 404s and does not leak filenames.

> **Why not real auth?** A token-in-URL scheme (isoserve-style opaque path baked into the pixiecore boot script) is the only PXE-compatible way to gate these servers, and it's a larger cross-cutting change through the `kairos-io/netboot`/pixiecore integration. That's tracked as a possible follow-up; this PR closes the item at the "documented boundary + no listing" level.

Refs: kairos-io/kairos#4117
