### PR TITLE
fix(config): surface --set parse errors instead of silently dropping them

### DIFF
--- a/internal/config/cloud_config_test.go
+++ b/internal/config/cloud_config_test.go
@@ -1,0 +1,78 @@
+package config_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/internal/config"
+)
+
+var _ = Describe("ReadCloudConfig", func() {
+	// The cloud-config templates use [[[ ]]] delimiters (so they don't clash with
+	// the YAML/Go the config itself may contain).
+	const tmpl = "hostname: [[[ .name ]]]\n"
+
+	It("reads a file and renders template values into it", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "cc.yaml")
+		Expect(os.WriteFile(path, []byte(tmpl), 0o644)).To(Succeed())
+
+		out, err := config.ReadCloudConfig(path, map[string]interface{}{"name": "node-a"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal("hostname: node-a\n"))
+	})
+
+	It("reads from a URL and renders it", func() {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(tmpl))
+		}))
+		DeferCleanup(srv.Close)
+
+		out, err := config.ReadCloudConfig(srv.URL, map[string]interface{}{"name": "node-b"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal("hostname: node-b\n"))
+	})
+
+	It("reads from STDIN when the source is '-'", func() {
+		r, w, err := os.Pipe()
+		Expect(err).NotTo(HaveOccurred())
+		_, _ = w.WriteString(tmpl)
+		Expect(w.Close()).To(Succeed())
+		old := os.Stdin
+		os.Stdin = r
+		DeferCleanup(func() { os.Stdin = old })
+
+		out, err := config.ReadCloudConfig("-", map[string]interface{}{"name": "node-c"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal("hostname: node-c\n"))
+	})
+
+	It("errors when the file does not exist", func() {
+		_, err := config.ReadCloudConfig("/no/such/cloud-config.yaml", nil)
+		Expect(err).To(MatchError(ContainSubstring("not found")))
+	})
+
+	It("errors when the rendered content is empty", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "empty.yaml")
+		Expect(os.WriteFile(path, []byte(""), 0o644)).To(Succeed())
+
+		_, err := config.ReadCloudConfig(path, nil)
+		Expect(err).To(MatchError(ContainSubstring("empty")))
+	})
+
+	It("errors on a malformed template", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "bad.yaml")
+		// Unclosed action delimiter — the template parser rejects it.
+		Expect(os.WriteFile(path, []byte("x: [[[ .name \n"), 0o644)).To(Succeed())
+
+		_, err := config.ReadCloudConfig(path, map[string]interface{}{"name": "x"})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,9 +116,21 @@ func ReadConfig(fileConfig, cloudConfig string, options []string) (*schema.Confi
 		return c, r, err
 	}
 
-	yaml.Unmarshal(y, c)
-	yaml.Unmarshal(y, r)
-	yaml.Unmarshal(y, &templateValues)
+	// Apply the --set values (as YAML) onto each target, surfacing type
+	// mismatches instead of dropping them. One loop rather than three copies so
+	// the single error path is exercised by any target's failure.
+	for _, target := range []struct {
+		dst   any
+		label string
+	}{
+		{c, "config"},
+		{r, "release artifact"},
+		{&templateValues, "template values"},
+	} {
+		if err := yaml.Unmarshal(y, target.dst); err != nil {
+			return c, r, fmt.Errorf("applying --set values to %s: %w", target.label, err)
+		}
+	}
 
 	if cloudConfig != "" {
 		var err error

--- a/internal/config/config_suite_test.go
+++ b/internal/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/internal/config/read_config_test.go
+++ b/internal/config/read_config_test.go
@@ -1,0 +1,52 @@
+package config_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/AuroraBoot/internal/config"
+)
+
+var _ = Describe("ReadConfig --set handling", func() {
+	It("applies well-typed --set values to the config and release without error", func() {
+		c, r, err := config.ReadConfig("", "", []string{
+			"arch=arm64",
+			"disable_iso=true",
+			"disk.gce=true",
+			"disk.size=2000",
+			"container_image=oci://example/img:tag",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Arch).To(Equal("arm64"))
+		Expect(c.DisableISOboot).To(BeTrue())
+		Expect(c.Disk.GCE).To(BeTrue())
+		Expect(c.Disk.Size).To(Equal("2000"))
+		Expect(r.ContainerImage).To(Equal("oci://example/img:tag"))
+	})
+
+	It("surfaces an error for a --set value that does not fit its field's type", func() {
+		// A non-boolean into a boolean field used to be silently dropped (the
+		// field kept its zero value, no error reported). It must now surface, so a
+		// typo in --set is not swallowed.
+		_, _, err := config.ReadConfig("", "", []string{"disable_iso=notabool"})
+		// disable_iso is a Config field, so the mismatch surfaces from the config
+		// target specifically — assert that exact wrapped error, not just "some
+		// error occurred".
+		Expect(err).To(MatchError(ContainSubstring("applying --set values to config")))
+	})
+
+	It("surfaces an error for a --set value that does not fit a release-artifact field's type", func() {
+		// container_image is a ReleaseArtifact string field and not a Config field,
+		// so the config target ignores it (unknown key) and the mismatch surfaces
+		// from the release-artifact target. A nested map cannot fit a string.
+		_, _, err := config.ReadConfig("", "", []string{"container_image.nested=x"})
+		Expect(err).To(MatchError(ContainSubstring("applying --set values to release artifact")))
+	})
+
+	It("accepts an empty option set", func() {
+		c, r, err := config.ReadConfig("", "", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c).NotTo(BeNil())
+		Expect(r).NotTo(BeNil())
+	})
+})


### PR DESCRIPTION
Closes the "ignored `yaml.Unmarshal` errors in `internal/config`" item from the fleet-server hardening backlog (kairos-io/kairos#4117).

## The bug

`ReadConfig` applies `--set key=value` pairs by rendering them to YAML and unmarshalling into the `Config`, `ReleaseArtifact`, and template-value targets — then **discarded all three `yaml.Unmarshal` errors**. A `--set` value that doesn't fit its field's type (e.g. `disk.gce=notabool` for a boolean) was silently dropped: the field kept its zero value and the operator got no indication the override was ignored.

## The fix

Return those errors. This is safe for valid input — verified empirically, since the package had **no tests**:
- Well-typed `--set` values (`disk.gce=true`, `disk.size=2000`, …) type-coerce and apply cleanly, so they don't error.
- `Config` and `ReleaseArtifact` share **no field names**, so a `--set` meant for one is just an unknown key to the other (ignored, not an error). Only a genuine type mismatch on a field that target owns now fails.
- The e2e suite's `--set` usage is all well-typed, so it won't regress.

## Tests

First tests for the package (Ginkgo): well-typed values apply to config + release without error; a malformed value now surfaces an error (`ContainSubstring("--set")`); an empty option set is accepted.

Refs: kairos-io/kairos#4117.