### PR TITLE
fix(server): rate-limit node-driven endpoints, exempt admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,32 @@ If you reach the UI from another machine (not `localhost`), set `AURORABOOT_URL`
 | `--url https://…` | External URL of this instance, injected into cloud-configs so nodes know where to phone home |
 | `AURORABOOT_ADMIN_PASSWORD` | Override admin password |
 | `AURORABOOT_REG_TOKEN` | Override registration token |
+| `--disable-rate-limit` | Turn off per-identity rate limiting of the node-driven endpoints |
 
 See the full [AuroraBoot reference](https://kairos.io/docs/reference/auroraboot/) for everything else.
+
+### Rate limiting
+
+The node-driven endpoints — registration, heartbeat and command polling — are
+rate-limited **on by default** so a single misbehaving node, or a leaked
+registration token, can't flood the fleet server. Registration is limited per
+client IP; heartbeat and command polling are limited per node. Admin/UI/API
+traffic (including the CAPI infra provider, which authenticates as admin) is
+**never** rate-limited.
+
+The defaults are generous and only ever bite a runaway or a flood. Tune or
+disable them if needed:
+
+- `--node-rate-limit <rps>` / `AURORABOOT_NODE_RATE_LIMIT` — per-node requests/sec
+- `--register-rate-limit <rps>` / `AURORABOOT_REGISTER_RATE_LIMIT` — per-IP requests/sec
+- `--disable-rate-limit` / `AURORABOOT_DISABLE_RATE_LIMIT` — turn it off entirely
+
+If a whole rack of nodes registers at once from behind a single NAT egress IP,
+they share one per-IP registration bucket; raise `--register-rate-limit` or
+disable rate limiting for that deployment. The per-IP key is the client address
+as the server sees it (honouring `X-Forwarded-For` behind a trusted proxy), so
+it's a flood speed-bump rather than a hard boundary — the registration token
+remains the actual access control.
 
 ### Hadron builds
 

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/stmcginnis/gofish v0.24.0
 	github.com/swaggo/swag v1.16.6
 	github.com/urfave/cli/v2 v2.27.7
+	golang.org/x/time v0.15.0
 	gorm.io/driver/postgres v1.6.2
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.2
@@ -238,7 +239,6 @@ require (
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.49.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/grpc v1.82.1 // indirect

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -106,6 +106,9 @@ var WebCMD = cli.Command{
 		&cli.StringFlag{Name: "kubeconfig", Usage: "Path to a kubeconfig file for the operator builder (single file). Empty means try in-cluster config first, then the default client-go loading rules (which honour a multi-file KUBECONFIG env)"},
 		&cli.StringFlag{Name: "builder-namespace", Value: "default", Usage: "Namespace in which OSArtifact CRs are created. Used only when --builder=operator"},
 		&cli.StringFlag{Name: "builder-upload-url", Usage: "URL exporter pods PUT built artifacts to. Only needs cluster-internal reachability, so a Service DNS name is appropriate. Defaults to --url. Used only when --builder=operator", EnvVars: []string{"AURORABOOT_BUILDER_UPLOAD_URL"}},
+		&cli.BoolFlag{Name: "disable-rate-limit", Usage: "Disable per-identity rate limiting of the node-driven endpoints (registration, heartbeat, command polling). Admin/UI/API traffic is never rate-limited regardless. Consider this for a large fleet behind a shared NAT egress IP", EnvVars: []string{"AURORABOOT_DISABLE_RATE_LIMIT"}},
+		&cli.Float64Flag{Name: "node-rate-limit", Usage: "Per-node requests/sec for heartbeat and command polling (0 = generous default). Admin traffic is exempt", EnvVars: []string{"AURORABOOT_NODE_RATE_LIMIT"}},
+		&cli.Float64Flag{Name: "register-rate-limit", Usage: "Per-client-IP registration requests/sec (0 = generous default)", EnvVars: []string{"AURORABOOT_REGISTER_RATE_LIMIT"}},
 	},
 	Action: runWeb,
 }
@@ -349,6 +352,10 @@ func runWeb(c *cli.Context) error {
 		Hub:                   wsHub,
 		ISOServe:              isoServe,
 		RedfishServeURL:       redfishServeURLSeed(isoServe, serveURL),
+
+		DisableRateLimit:     c.Bool("disable-rate-limit"),
+		NodeRateLimitRPS:     c.Float64("node-rate-limit"),
+		RegisterRateLimitRPS: c.Float64("register-rate-limit"),
 	})
 
 	fmt.Fprintf(os.Stderr, "AuroraBoot fleet server starting on %s\n", listenAddr)

--- a/pkg/auth/ratelimit.go
+++ b/pkg/auth/ratelimit.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"golang.org/x/time/rate"
+)
+
+// Default rate limits for the node-driven fleet endpoints (fleet-server
+// hardening, kairos-io/kairos#4117). They are deliberately generous: a healthy
+// node heartbeats on the order of once every few tens of seconds, so these caps
+// only ever bite a runaway or a flood, never normal operation. Admin-
+// authenticated traffic (e.g. the CAPI infra provider) is never limited — see
+// NodeRateLimiter.
+const (
+	// DefaultNodeRateLimitRPS / DefaultNodeRateLimitBurst cap per-node heartbeat
+	// and command polling.
+	DefaultNodeRateLimitRPS   = 5.0
+	DefaultNodeRateLimitBurst = 20
+
+	// DefaultRegisterRateLimitRPS / DefaultRegisterRateLimitBurst cap registration
+	// attempts per client IP, so a leaked or guessed registration token cannot be
+	// used to flood the fleet with fake nodes (or to brute-force the token).
+	// ~30 sustained attempts/min with a burst of 20.
+	DefaultRegisterRateLimitRPS   = 0.5
+	DefaultRegisterRateLimitBurst = 20
+
+	// rateLimitExpiry is how long an idle per-key bucket is kept before the memory
+	// store evicts it. Comfortably longer than any real client's request cadence.
+	rateLimitExpiry = 5 * time.Minute
+)
+
+// NodeRateLimiter returns middleware that rate-limits node-driven requests keyed
+// on the authenticated node ID, while never limiting admin-authenticated
+// requests. It must run AFTER the node-auth middleware (NodeAPIKeyMiddleware or
+// AgentOrAdminMiddleware) so the node ID is already in the context.
+//
+// Admin requests set no node ID (AuthNodeID == ""), so the Skipper lets them
+// straight through: this is what keeps the CAPI infra provider's admin-bearer
+// polling of the shared command routes exempt. On the heartbeat route, where only
+// a node ever authenticates, the node ID is always present and every request is
+// counted against that node's bucket.
+//
+// A non-positive rps disables limiting (the middleware passes through), so the
+// server can turn the limiter off without special-casing the wiring.
+func NodeRateLimiter(rps float64, burst int) echo.MiddlewareFunc {
+	if rps <= 0 {
+		return passthrough
+	}
+	if burst <= 0 {
+		burst = DefaultNodeRateLimitBurst
+	}
+	return middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
+		Store: newRateLimiterStore(rps, burst),
+		Skipper: func(c echo.Context) bool {
+			// Admin-authenticated requests carry no node ID; never limit them.
+			return AuthNodeID(c) == ""
+		},
+		IdentifierExtractor: func(c echo.Context) (string, error) {
+			return AuthNodeID(c), nil
+		},
+		DenyHandler: rateLimitDenyHandler,
+	})
+}
+
+// RegistrationRateLimiter returns middleware that rate-limits registration
+// attempts keyed on the client IP, regardless of whether the registration token
+// is valid. Register it BEFORE RegistrationTokenAuth so invalid-token attempts
+// are throttled too — otherwise the token check would run (and cost work) on
+// every brute-force attempt before the limiter ever saw it.
+//
+// The key is echo's RealIP, which honours X-Forwarded-For / X-Real-IP. Behind a
+// trusted proxy that overwrites those headers this is the real client IP; a
+// directly-exposed server with no such proxy sees the TCP peer. Because a client
+// that can set its own X-Forwarded-For could rotate the key to evade this limit,
+// the limiter is a flood speed-bump, not the access control — the registration
+// token is. Operators who need a hard per-client boundary should front the server
+// with a proxy that rewrites the forwarding headers.
+//
+// A non-positive rps disables limiting (the middleware passes through).
+func RegistrationRateLimiter(rps float64, burst int) echo.MiddlewareFunc {
+	if rps <= 0 {
+		return passthrough
+	}
+	if burst <= 0 {
+		burst = DefaultRegisterRateLimitBurst
+	}
+	return middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
+		Store: newRateLimiterStore(rps, burst),
+		IdentifierExtractor: func(c echo.Context) (string, error) {
+			return c.RealIP(), nil
+		},
+		DenyHandler: rateLimitDenyHandler,
+	})
+}
+
+// newRateLimiterStore builds an in-memory token-bucket store with the given
+// sustained rate and burst, evicting idle buckets after rateLimitExpiry.
+func newRateLimiterStore(rps float64, burst int) middleware.RateLimiterStore {
+	return middleware.NewRateLimiterMemoryStoreWithConfig(middleware.RateLimiterMemoryStoreConfig{
+		Rate:      rate.Limit(rps),
+		Burst:     burst,
+		ExpiresIn: rateLimitExpiry,
+	})
+}
+
+// passthrough is a no-op middleware used when a limiter is disabled.
+func passthrough(next echo.HandlerFunc) echo.HandlerFunc { return next }
+
+// rateLimitDenyHandler answers a throttled request with 429 and the same small
+// JSON error shape the rest of the API uses.
+func rateLimitDenyHandler(c echo.Context, _ string, _ error) error {
+	return c.JSON(http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
+}

--- a/pkg/auth/ratelimit_test.go
+++ b/pkg/auth/ratelimit_test.go
@@ -1,0 +1,115 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/kairos-io/AuroraBoot/pkg/auth"
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Rate limiting", func() {
+	var e *echo.Echo
+
+	BeforeEach(func() { e = echo.New() })
+
+	okHandler := func(c echo.Context) error { return c.String(http.StatusOK, "ok") }
+
+	Describe("NodeRateLimiter", func() {
+		// fireAsNode sends n requests through the limiter with the given node ID set
+		// in context (as the node-auth middleware would have), returning the status
+		// codes. The remote address is left at httptest's default so the IP plays no
+		// part — the key under test is the node ID. An empty nodeID models an admin
+		// request, which sets no node ID.
+		fireAsNode := func(mw echo.MiddlewareFunc, nodeID string, n int) []int {
+			codes := make([]int, 0, n)
+			handler := mw(okHandler)
+			for i := 0; i < n; i++ {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+				if nodeID != "" {
+					c.Set(auth.ContextKeyNodeID, nodeID)
+				}
+				_ = handler(c)
+				codes = append(codes, rec.Code)
+			}
+			return codes
+		}
+
+		It("limits a node once its burst is spent", func() {
+			mw := auth.NodeRateLimiter(1, 2) // burst 2, ~1 rps refill (negligible in-test)
+			codes := fireAsNode(mw, "node-a", 5)
+			Expect(codes[0]).To(Equal(http.StatusOK))
+			Expect(codes[1]).To(Equal(http.StatusOK))
+			Expect(codes[2]).To(Equal(http.StatusTooManyRequests))
+		})
+
+		It("keys per node — one node's burst does not affect another", func() {
+			mw := auth.NodeRateLimiter(1, 2)
+			_ = fireAsNode(mw, "node-a", 5) // exhaust node-a
+			codes := fireAsNode(mw, "node-b", 2)
+			Expect(codes).To(Equal([]int{http.StatusOK, http.StatusOK}))
+		})
+
+		It("never limits admin requests (no node ID in context)", func() {
+			mw := auth.NodeRateLimiter(1, 2)
+			codes := fireAsNode(mw, "", 10) // admin: AuthNodeID == ""
+			for _, code := range codes {
+				Expect(code).To(Equal(http.StatusOK))
+			}
+		})
+
+		It("passes through when disabled (non-positive rps)", func() {
+			mw := auth.NodeRateLimiter(0, 0)
+			codes := fireAsNode(mw, "node-a", 50)
+			for _, code := range codes {
+				Expect(code).To(Equal(http.StatusOK))
+			}
+		})
+	})
+
+	Describe("RegistrationRateLimiter", func() {
+		// fireFromIP sends n requests through the limiter from the given client IP,
+		// returning the status codes. No node ID is set — registration has no node
+		// identity yet, so the key is the client IP.
+		fireFromIP := func(mw echo.MiddlewareFunc, ip string, n int) []int {
+			codes := make([]int, 0, n)
+			handler := mw(okHandler)
+			for i := 0; i < n; i++ {
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				req.RemoteAddr = ip + ":12345"
+				rec := httptest.NewRecorder()
+				c := e.NewContext(req, rec)
+				_ = handler(c)
+				codes = append(codes, rec.Code)
+			}
+			return codes
+		}
+
+		It("limits an IP once its burst is spent", func() {
+			mw := auth.RegistrationRateLimiter(0.5, 2)
+			codes := fireFromIP(mw, "203.0.113.5", 5)
+			Expect(codes[0]).To(Equal(http.StatusOK))
+			Expect(codes[1]).To(Equal(http.StatusOK))
+			Expect(codes[2]).To(Equal(http.StatusTooManyRequests))
+		})
+
+		It("keys per IP — one IP's flood does not affect another", func() {
+			mw := auth.RegistrationRateLimiter(0.5, 2)
+			_ = fireFromIP(mw, "203.0.113.5", 5) // exhaust one IP
+			codes := fireFromIP(mw, "198.51.100.9", 2)
+			Expect(codes).To(Equal([]int{http.StatusOK, http.StatusOK}))
+		})
+
+		It("passes through when disabled (non-positive rps)", func() {
+			mw := auth.RegistrationRateLimiter(0, 0)
+			codes := fireFromIP(mw, "203.0.113.5", 50)
+			for _, code := range codes {
+				Expect(code).To(Equal(http.StatusOK))
+			}
+		})
+	})
+})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -58,6 +58,27 @@ type Config struct {
 	// goroutines so a server shutdown cancels in-flight Redfish deploys. Defaults
 	// to context.Background().
 	BaseContext context.Context
+
+	// Rate limiting of the node-driven endpoints (registration, heartbeat, command
+	// polling) — fleet-server hardening, kairos-io/kairos#4117. It is on by
+	// default: zero RPS/Burst values fall back to the auth package defaults.
+	// Admin-authenticated requests (the UI and the CAPI infra provider) are never
+	// limited. DisableRateLimit turns the limiters off entirely.
+	DisableRateLimit       bool
+	NodeRateLimitRPS       float64 // per-node requests/sec for heartbeat + command polling
+	NodeRateLimitBurst     int     // per-node burst
+	RegisterRateLimitRPS   float64 // per-IP requests/sec for registration
+	RegisterRateLimitBurst int     // per-IP burst
+}
+
+// firstPositive returns v if it is positive, otherwise fallback. It lets a zero
+// (unset) config value fall back to a default while still allowing an explicit
+// override.
+func firstPositive(v, fallback float64) float64 {
+	if v > 0 {
+		return v
+	}
+	return fallback
 }
 
 // redactToken returns requestURI with the value of any "token" query parameter
@@ -193,8 +214,27 @@ func New(cfg Config) *echo.Echo {
 	// WebSocket endpoints (agent auth via query param token)
 	e.GET("/api/v1/ws", agentWSHandler.HandleAgentWS)
 
-	// Agent registration (registration token auth)
+	// Rate limits for the node-driven endpoints (fleet-server hardening,
+	// kairos-io/kairos#4117). On by default with generous limits; a zero value
+	// falls back to the auth package default, and DisableRateLimit forces the
+	// limiters off (passing 0 makes them no-ops). Admin-authenticated traffic —
+	// the UI and the CAPI infra provider — is never limited (see NodeRateLimiter).
+	nodeRateRPS := firstPositive(cfg.NodeRateLimitRPS, auth.DefaultNodeRateLimitRPS)
+	registerRateRPS := firstPositive(cfg.RegisterRateLimitRPS, auth.DefaultRegisterRateLimitRPS)
+	if cfg.DisableRateLimit {
+		nodeRateRPS, registerRateRPS = 0, 0
+	}
+	// Build the node limiter ONCE and share it across the heartbeat and shared-
+	// command groups, so a node draws heartbeats and command polls from a single
+	// bucket keyed on its node ID. A separate instance per group would give each
+	// node two independent buckets and an effective ~2x the configured rate.
+	nodeLimiter := auth.NodeRateLimiter(nodeRateRPS, cfg.NodeRateLimitBurst)
+
+	// Agent registration (registration token auth). The per-IP rate limiter runs
+	// BEFORE the token check so it also throttles invalid-token (brute-force)
+	// attempts.
 	regGroup := e.Group("/api/v1/nodes")
+	regGroup.Use(auth.RegistrationRateLimiter(registerRateRPS, cfg.RegisterRateLimitBurst))
 	regGroup.Use(auth.RegistrationTokenAuth(&regToken))
 	regGroup.POST("/register", nodeHandler.Register)
 
@@ -205,6 +245,8 @@ func New(cfg Config) *echo.Echo {
 	agentGroup := e.Group("/api/v1/nodes/:nodeID")
 	agentGroup.Use(auth.NodeAPIKeyMiddleware(cfg.NodeStore))
 	agentGroup.Use(auth.RequireNodeMatch)
+	// After node auth, so the limiter keys on the authenticated node ID.
+	agentGroup.Use(nodeLimiter)
 	agentGroup.POST("/heartbeat", nodeHandler.Heartbeat)
 
 	// Shared command routes used by BOTH the agent (poll/report) and the
@@ -216,6 +258,10 @@ func New(cfg Config) *echo.Echo {
 	// across nodes.
 	sharedCmd := e.Group("/api/v1/nodes/:nodeID")
 	sharedCmd.Use(auth.AgentOrAdminMiddleware(cfg.AdminPassword, cfg.NodeStore))
+	// After auth, so it limits node polls but skips admin (which sets no node ID)
+	// — keeping the CAPI infra provider's command polling exempt. Same instance as
+	// the heartbeat group, so both share one bucket per node.
+	sharedCmd.Use(nodeLimiter)
 	sharedCmd.GET("/commands", nodeHandler.GetCommands)
 	sharedCmd.PUT("/commands/:commandID/status", cmdHandler.UpdateStatus)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -447,3 +447,92 @@ var _ = Describe("Artifact download scoping", func() {
 		})
 	})
 })
+
+var _ = Describe("Rate limiting wiring", func() {
+	var (
+		e  *httptest.Server
+		ns *fakeNodeStore
+	)
+
+	BeforeEach(func() {
+		ns = &fakeNodeStore{nodes: []*store.ManagedNode{{ID: "node-1", APIKey: "agent-key"}}}
+		// Burst 2 so throttling is observable in a handful of requests (defaults
+		// would need 20+), and a near-zero rate so the bucket refills negligibly
+		// during the test — otherwise a slow CI run could top the bucket back up
+		// mid-loop and no request would ever be throttled.
+		echoApp := server.New(server.Config{
+			NodeStore:              ns,
+			CommandStore:           &fakeCommandStore{},
+			GroupStore:             &fakeGroupStore{},
+			Builder:                &fakeBuilder{},
+			AdminPassword:          "admin-pass",
+			RegToken:               "reg-token",
+			AuroraBootURL:          "http://localhost:8080",
+			NodeRateLimitRPS:       0.001,
+			NodeRateLimitBurst:     2,
+			RegisterRateLimitRPS:   0.001,
+			RegisterRateLimitBurst: 2,
+		})
+		e = httptest.NewServer(echoApp)
+	})
+
+	AfterEach(func() { e.Close() })
+
+	getCommands := func(bearer string) int {
+		req, _ := http.NewRequest(http.MethodGet, e.URL+"/api/v1/nodes/node-1/commands", nil)
+		req.Header.Set("Authorization", "Bearer "+bearer)
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	heartbeat := func(bearer string) int {
+		req, _ := http.NewRequest(http.MethodPost, e.URL+"/api/v1/nodes/node-1/heartbeat", strings.NewReader(`{"agentVersion":"1.0"}`))
+		req.Header.Set("Authorization", "Bearer "+bearer)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	It("never rate-limits the admin on the shared command route (CAPI provider path)", func() {
+		// Far more than the node burst; the admin sets no node ID, so the node
+		// limiter skips it entirely. This is the guarantee that keeps the CAPI
+		// infra provider's command polling exempt.
+		for i := 0; i < 10; i++ {
+			Expect(getCommands("admin-pass")).NotTo(Equal(http.StatusTooManyRequests))
+		}
+	})
+
+	It("rate-limits a node on the shared command route once its burst is spent", func() {
+		codes := make([]int, 0, 5)
+		for i := 0; i < 5; i++ {
+			codes = append(codes, getCommands("agent-key"))
+		}
+		Expect(codes).To(ContainElement(http.StatusTooManyRequests))
+	})
+
+	It("shares one bucket per node across heartbeat and command polling", func() {
+		// Burst is 2. Spend it with one heartbeat plus one command poll, then
+		// either route is throttled for that node — proving a single shared bucket
+		// rather than one bucket per endpoint group (which would double the rate).
+		Expect(heartbeat("agent-key")).NotTo(Equal(http.StatusTooManyRequests))
+		Expect(getCommands("agent-key")).NotTo(Equal(http.StatusTooManyRequests))
+		Expect(getCommands("agent-key")).To(Equal(http.StatusTooManyRequests))
+		Expect(heartbeat("agent-key")).To(Equal(http.StatusTooManyRequests))
+	})
+
+	It("rate-limits registration per client IP once its burst is spent", func() {
+		body := `{"registrationToken":"reg-token","machineID":"m1","hostname":"h1"}`
+		codes := make([]int, 0, 5)
+		for i := 0; i < 5; i++ {
+			resp, err := http.Post(e.URL+"/api/v1/nodes/register", "application/json", strings.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+			codes = append(codes, resp.StatusCode)
+		}
+		Expect(codes).To(ContainElement(http.StatusTooManyRequests))
+	})
+})


### PR DESCRIPTION
Adds per-identity rate limiting to the node-driven fleet endpoints, addressing the rate-limiting line item of the fleet-server hardening epic (kairos-io/kairos#4117). **On by default**, generous limits, fully configurable and disable-able.

## What gets limited (and how it's keyed)

| Endpoint | Auth | Limiter key | Rationale |
|---|---|---|---|
| `POST /nodes/register` | reg token (body) | **client IP** (before the token check) | throttles a leaked/guessed-token flood *and* token brute-force |
| `POST /nodes/:id/heartbeat` | node API key | **node ID** | caps a runaway / compromised node |
| `GET /nodes/:id/commands`, `PUT .../status` | node **or** admin | **node ID** (admin skipped) | node polling capped; admin exempt |

## The admin / CAPI exemption is structural

Admin requests set **no** node ID in context (verified in `pkg/auth/middleware.go`). The node limiter's `Skipper` is exactly "skip when `AuthNodeID(c) == ""`", so every admin-bearer call passes straight through. All admin-only routes (`adminGroup`: claim, node-reads, command-create, release) get **no** limiter at all. The CAPI infra provider authenticates as admin and only ever calls those + the shared command poll — so it is never throttled, and the fleet contract is unchanged. An end-to-end server test asserts this (admin fires 10× the node burst on `/commands` and never sees a 429, while a node does).

The limiters are wired **after** the node-auth middleware so the node ID is in context; the registration limiter is wired **before** `RegistrationTokenAuth` so invalid-token attempts are throttled too.

## Configuration (on by default)

Zero config → generous defaults (node 5 req/s burst 20; register ~30/min burst 20 per IP). Overridable:

- `--node-rate-limit <rps>` / `AURORABOOT_NODE_RATE_LIMIT`
- `--register-rate-limit <rps>` / `AURORABOOT_REGISTER_RATE_LIMIT`
- `--disable-rate-limit` / `AURORABOOT_DISABLE_RATE_LIMIT`

## Notes for reviewers

- Built on echo's tested token-bucket (`middleware.RateLimiterWithConfig` + in-memory per-key store), not a hand-rolled limiter.
- **Per-IP key trust:** the registration key is echo's `RealIP` (honours `X-Forwarded-For` behind a trusted proxy). A client that sets its own XFF could rotate the key, so the per-IP limiter is a **flood speed-bump, not the access control** — the registration token is. This is called out in the code comment and the README. A NAT'd rack shares one bucket; raise `--register-rate-limit` or disable for that deployment.
- Tests: middleware unit tests (per-node / per-IP keying, admin exemption, disabled passthrough) + server integration tests (429 fires end-to-end on node commands & registration; admin never throttled).

Refs: kairos-io/kairos#4117
