### PR TITLE
fix(server): scope node artifact downloads to assigned images

### DIFF
--- a/pkg/auth/artifact_download_test.go
+++ b/pkg/auth/artifact_download_test.go
@@ -1,0 +1,134 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/kairos-io/AuroraBoot/pkg/auth"
+	"github.com/kairos-io/AuroraBoot/pkg/store"
+	"github.com/labstack/echo/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// fakeCommandStore is a minimal store.CommandStore for the authorization tests;
+// only ListByNode is functional.
+type fakeCommandStore struct {
+	byNode map[string][]*store.NodeCommand
+}
+
+func (f *fakeCommandStore) ListByNode(_ context.Context, nodeID string) ([]*store.NodeCommand, error) {
+	return f.byNode[nodeID], nil
+}
+func (f *fakeCommandStore) Create(context.Context, *store.NodeCommand) error { return nil }
+func (f *fakeCommandStore) GetByID(context.Context, string) (*store.NodeCommand, error) {
+	return nil, nil
+}
+func (f *fakeCommandStore) GetPending(context.Context, string) ([]*store.NodeCommand, error) {
+	return nil, nil
+}
+func (f *fakeCommandStore) MarkDelivered(context.Context, []string) error          { return nil }
+func (f *fakeCommandStore) ClaimForDelivery(context.Context, string) (bool, error) { return false, nil }
+func (f *fakeCommandStore) UpdateStatus(context.Context, string, string, string) error {
+	return nil
+}
+func (f *fakeCommandStore) UpdateStatusForNode(context.Context, string, string, string, string) error {
+	return nil
+}
+func (f *fakeCommandStore) Delete(context.Context, string) error         { return nil }
+func (f *fakeCommandStore) DeleteTerminal(context.Context, string) error { return nil }
+
+var _ = Describe("ArtifactImageMiddleware", func() {
+	const (
+		adminPass = "admin-pass"
+		artID     = "art-1"
+	)
+
+	var (
+		e  *echo.Echo
+		ns *fakeNodeStore
+		cs *fakeCommandStore
+		mw echo.MiddlewareFunc
+	)
+
+	BeforeEach(func() {
+		e = echo.New()
+		ns = &fakeNodeStore{nodes: []*store.ManagedNode{{ID: "node-1", APIKey: "node-1-key"}}}
+		cs = &fakeCommandStore{byNode: map[string][]*store.NodeCommand{}}
+		mw = auth.ArtifactImageMiddleware(adminPass, ns, cs)
+	})
+
+	// do runs GET /api/v1/artifacts/:id/image through the middleware and returns
+	// the status code. header sets a Bearer token; query sets ?token=.
+	do := func(header, query string) int {
+		target := "/api/v1/artifacts/" + artID + "/image"
+		if query != "" {
+			target += "?token=" + query
+		}
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		if header != "" {
+			req.Header.Set("Authorization", "Bearer "+header)
+		}
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(artID)
+		handler := mw(func(c echo.Context) error { return c.String(http.StatusOK, "image") })
+		_ = handler(c)
+		return rec.Code
+	}
+
+	assign := func(cmd string, source string) {
+		cs.byNode["node-1"] = []*store.NodeCommand{
+			{ManagedNodeID: "node-1", Command: cmd, Args: map[string]string{"source": source}},
+		}
+	}
+
+	It("allows the admin via the Authorization header", func() {
+		Expect(do(adminPass, "")).To(Equal(http.StatusOK))
+	})
+
+	It("allows the admin via ?token= (UI download links)", func() {
+		Expect(do("", adminPass)).To(Equal(http.StatusOK))
+	})
+
+	It("401s with no credentials", func() {
+		Expect(do("", "")).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("401s an unknown token (neither admin nor a node key)", func() {
+		Expect(do("bogus", "")).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("allows a node assigned this artifact by an upgrade command", func() {
+		assign(store.CmdUpgrade, "artifact:"+artID)
+		Expect(do("node-1-key", "")).To(Equal(http.StatusOK))
+	})
+
+	It("allows a node assigned this artifact by an upgrade-recovery command", func() {
+		assign(store.CmdUpgradeRecovery, "artifact:"+artID)
+		Expect(do("node-1-key", "")).To(Equal(http.StatusOK))
+	})
+
+	It("rejects a node API key supplied via ?token= (node keys must use the Authorization header)", func() {
+		// Even when the node IS assigned the artifact, a node key in the URL is not
+		// accepted — it would leak through logs/proxies/history. Header only.
+		assign(store.CmdUpgrade, "artifact:"+artID)
+		Expect(do("", "node-1-key")).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("403s a node with no command for this artifact", func() {
+		Expect(do("node-1-key", "")).To(Equal(http.StatusForbidden))
+	})
+
+	It("403s a node assigned a DIFFERENT artifact", func() {
+		assign(store.CmdUpgrade, "artifact:other")
+		Expect(do("node-1-key", "")).To(Equal(http.StatusForbidden))
+	})
+
+	It("403s a node whose only command naming this artifact is not an upgrade", func() {
+		assign("exec", "artifact:"+artID)
+		Expect(do("node-1-key", "")).To(Equal(http.StatusForbidden))
+	})
+})

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"io"
@@ -127,31 +128,77 @@ func AgentOrAdminMiddleware(password string, nodeStore store.NodeStore) echo.Mid
 	}
 }
 
-// DownloadMiddleware accepts either the admin password or a valid node API key.
-// Checks Authorization header and ?token= query param. Used for artifact downloads
-// so both the UI (admin) and agents (node key) can access them.
-func DownloadMiddleware(password string, nodeStore store.NodeStore) echo.MiddlewareFunc {
+// ArtifactImageMiddleware authorizes GET /api/v1/artifacts/:id/image for either an
+// admin or a node that has been assigned this artifact by an upgrade command.
+//
+// The container image is the one build artifact a node legitimately downloads: an
+// operator queues an upgrade / upgrade-recovery command whose source is
+// "artifact:<id>", the node polls it, and the agent pulls that artifact's image
+// with its node API key. So a node is authorized for exactly the artifacts some
+// command told it to install — never an arbitrary one. This stops a node (or a
+// leaked node API key) from pulling every image the fleet has ever built, which
+// may embed a cloud-config and secrets.
+//
+// Admin access is unchanged and still full, via the Authorization header or the
+// ?token= query param (the latter for the UI's browser download links; the CAPI
+// infra provider authenticates as admin over the header). A NODE API key, by
+// contrast, is accepted ONLY from the Authorization header, never from ?token= —
+// a node credential in a URL would leak through access logs, proxies, browser
+// history and Referer headers, and no node flow supplies its key that way.
+func ArtifactImageMiddleware(password string, nodeStore store.NodeStore, commandStore store.CommandStore) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			token := extractBearer(c.Request().Header.Get("Authorization"))
-			if token == "" {
-				token = c.QueryParam("token")
-			}
-			if token == "" {
+			headerToken := extractBearer(c.Request().Header.Get("Authorization"))
+			queryToken := c.QueryParam("token")
+			if headerToken == "" && queryToken == "" {
 				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			}
-			// Check admin password
-			if secureCompare(token, password) {
+			// Admin: full access, from either the header or ?token=.
+			if secureCompare(headerToken, password) || secureCompare(queryToken, password) {
 				return next(c)
 			}
-			// Check node API key
-			node, err := nodeStore.GetByAPIKey(c.Request().Context(), token)
-			if err == nil && node != nil {
-				return next(c)
+			// Otherwise the caller must be a node — authenticated ONLY via the
+			// Authorization header — and only for an artifact a command assigned it.
+			if headerToken == "" {
+				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			}
-			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			node, err := nodeStore.GetByAPIKey(c.Request().Context(), headerToken)
+			if err != nil || node == nil {
+				return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			}
+			if !nodeAssignedArtifact(c.Request().Context(), commandStore, node.ID, c.Param("id")) {
+				return c.JSON(http.StatusForbidden, map[string]string{"error": "forbidden"})
+			}
+			c.Set(ContextKeyNodeID, node.ID)
+			return next(c)
 		}
 	}
+}
+
+// nodeAssignedArtifact reports whether some upgrade / upgrade-recovery command
+// queued for nodeID names this artifact as its source ("artifact:<id>"). It does
+// not filter on command phase: once an operator has told a node to install an
+// artifact, re-fetching that same image (a retry, a resumed upgrade) is not a new
+// exposure — the boundary being enforced is WHICH artifact, not how many times. A
+// store error fails closed (treated as not assigned).
+func nodeAssignedArtifact(ctx context.Context, commandStore store.CommandStore, nodeID, artifactID string) bool {
+	if commandStore == nil || nodeID == "" || artifactID == "" {
+		return false
+	}
+	cmds, err := commandStore.ListByNode(ctx, nodeID)
+	if err != nil {
+		return false
+	}
+	want := "artifact:" + artifactID
+	for _, cmd := range cmds {
+		if cmd == nil {
+			continue
+		}
+		if (cmd.Command == store.CmdUpgrade || cmd.Command == store.CmdUpgradeRecovery) && cmd.Args["source"] == want {
+			return true
+		}
+	}
+	return false
 }
 
 // RegistrationTokenAuth returns an Echo middleware that reads the JSON body,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -259,11 +259,20 @@ func New(cfg Config) *echo.Echo {
 	adminGroup.PATCH("/artifacts/:id", artifactHandler.Update)
 	adminGroup.DELETE("/artifacts/:id", artifactHandler.Delete)
 
-	// Artifact downloads — accepts admin password OR node API key.
-	// Registered before the admin group catches them, using inline middleware.
-	dlAuth := auth.DownloadMiddleware(cfg.AdminPassword, cfg.NodeStore)
-	e.GET("/api/v1/artifacts/:id/download/*", artifactHandler.Download, dlAuth)
-	e.GET("/api/v1/artifacts/:id/image", artifactHandler.ExportImage, dlAuth)
+	// Artifact downloads (fleet-server hardening, kairos-io/kairos#4117). Scoped so
+	// a node key can't pull arbitrary build artifacts. Registered before the admin
+	// group catches them, using inline middleware.
+	//
+	// Raw build files (ISO/UKI/raw disk/netboot) are admin-only: no node flow
+	// consumes them over HTTP (netboot/Redfish read them from disk server-side), so
+	// a node key must not reach them. AdminMiddleware still honours ?token= for the
+	// UI's browser download links.
+	e.GET("/api/v1/artifacts/:id/download/*", artifactHandler.Download, auth.AdminMiddleware(cfg.AdminPassword))
+	// The container image is the one artifact a node downloads (to satisfy an
+	// "upgrade from built artifact" command), so it is admin OR a node that such a
+	// command actually assigned this artifact to — never an arbitrary artifact.
+	e.GET("/api/v1/artifacts/:id/image", artifactHandler.ExportImage,
+		auth.ArtifactImageMiddleware(cfg.AdminPassword, cfg.NodeStore, cfg.CommandStore))
 
 	// Artifact upload — per-build UploadToken bearer (minted at Create time,
 	// stored on the ArtifactRecord). Used by the operator backend's exporter

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -174,6 +174,27 @@ func (f *fakeBuilder) Status(_ context.Context, _ string) (*builder.BuildStatus,
 func (f *fakeBuilder) List(_ context.Context) ([]*builder.BuildStatus, error) { return nil, nil }
 func (f *fakeBuilder) Cancel(_ context.Context, _ string) error               { return nil }
 
+// fakeArtifactStore is a minimal store.ArtifactStore whose GetByID reports
+// not-found, so ExportImage returns 404 cleanly (rather than nil-dereferencing an
+// absent store) once a request is authorized.
+type fakeArtifactStore struct{}
+
+func (f *fakeArtifactStore) Create(context.Context, *store.ArtifactRecord) error { return nil }
+func (f *fakeArtifactStore) GetByID(context.Context, string) (*store.ArtifactRecord, error) {
+	return nil, fmt.Errorf("not found")
+}
+func (f *fakeArtifactStore) List(context.Context) ([]*store.ArtifactRecord, error) { return nil, nil }
+func (f *fakeArtifactStore) Update(context.Context, *store.ArtifactRecord) error   { return nil }
+func (f *fakeArtifactStore) UpdatePhaseMessage(context.Context, string, string, string) error {
+	return nil
+}
+func (f *fakeArtifactStore) UpdateFiles(context.Context, string, []string) error { return nil }
+func (f *fakeArtifactStore) ClearUploadToken(context.Context, string) error      { return nil }
+func (f *fakeArtifactStore) Delete(context.Context, string) error                { return nil }
+func (f *fakeArtifactStore) DeleteByPhase(context.Context, string) error         { return nil }
+func (f *fakeArtifactStore) GetLogs(context.Context, string) (string, error)     { return "", nil }
+func (f *fakeArtifactStore) AppendLog(context.Context, string, string) error     { return nil }
+
 var _ = Describe("Server", func() {
 	var (
 		e  *httptest.Server
@@ -358,6 +379,71 @@ var _ = Describe("Server", func() {
 			resp, err := http.DefaultClient.Do(req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+	})
+})
+
+var _ = Describe("Artifact download scoping", func() {
+	var (
+		e  *httptest.Server
+		ns *fakeNodeStore
+		cs *fakeCommandStore
+	)
+
+	BeforeEach(func() {
+		ns = &fakeNodeStore{nodes: []*store.ManagedNode{{ID: "node-1", APIKey: "agent-key"}}}
+		cs = &fakeCommandStore{}
+		echoApp := server.New(server.Config{
+			NodeStore:     ns,
+			CommandStore:  cs,
+			GroupStore:    &fakeGroupStore{},
+			ArtifactStore: &fakeArtifactStore{},
+			Builder:       &fakeBuilder{},
+			AdminPassword: "admin-pass",
+			RegToken:      "reg-token",
+			AuroraBootURL: "http://localhost:8080",
+		})
+		e = httptest.NewServer(echoApp)
+	})
+
+	AfterEach(func() { e.Close() })
+
+	get := func(path, bearer string) int {
+		req, _ := http.NewRequest(http.MethodGet, e.URL+path, nil)
+		if bearer != "" {
+			req.Header.Set("Authorization", "Bearer "+bearer)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	Describe("raw file download (/download/*)", func() {
+		It("rejects a node API key — these files are admin-only", func() {
+			Expect(get("/api/v1/artifacts/art-1/download/kairos.iso", "agent-key")).To(Equal(http.StatusUnauthorized))
+		})
+		It("admits the admin (auth passes; a missing file is a 404, not a 401)", func() {
+			Expect(get("/api/v1/artifacts/art-1/download/kairos.iso", "admin-pass")).NotTo(Equal(http.StatusUnauthorized))
+		})
+	})
+
+	Describe("container image (/image)", func() {
+		It("403s a node not assigned this artifact by any upgrade command", func() {
+			Expect(get("/api/v1/artifacts/art-1/image", "agent-key")).To(Equal(http.StatusForbidden))
+		})
+		It("admits a node assigned this artifact by an upgrade command (auth passes)", func() {
+			cs.cmds = []*store.NodeCommand{
+				{ID: "c1", ManagedNodeID: "node-1", Command: store.CmdUpgrade, Args: map[string]string{"source": "artifact:art-1"}},
+			}
+			code := get("/api/v1/artifacts/art-1/image", "agent-key")
+			Expect(code).NotTo(Equal(http.StatusUnauthorized))
+			Expect(code).NotTo(Equal(http.StatusForbidden))
+		})
+		It("admits the admin (auth passes)", func() {
+			code := get("/api/v1/artifacts/art-1/image", "admin-pass")
+			Expect(code).NotTo(Equal(http.StatusUnauthorized))
+			Expect(code).NotTo(Equal(http.StatusForbidden))
 		})
 	})
 })


### PR DESCRIPTION
Scopes node artifact downloads to least privilege, closing the last "breaking" item of the fleet-server hardening epic (kairos-io/kairos#4117).

## The hole

`DownloadMiddleware` accepted **any valid node API key** on both `GET /api/v1/artifacts/:id/download/*` and `GET /api/v1/artifacts/:id/image`, with **no per-artifact check**. So a node — or a leaked node API key — could pull **every image the fleet has ever built**, and those images may embed a cloud-config and secrets.

## The one real node-download flow

I mapped the actual flows across the install script, the Go client, the UI, and the upgrade/deploy paths. A node legitimately downloads an artifact in exactly **one** way: an operator queues an `upgrade` / `upgrade-recovery` command whose `Args["source"] == "artifact:<id>"`; the node polls it and pulls that artifact's **container image** via `/image` with its node key. Nothing node-side ever uses `/download/*` (netboot/Redfish read those files from disk server-side). `?token=` is only ever generated with the admin token.

## The fix (least privilege)

| Route | Before | After |
|---|---|---|
| `/download/*` (ISO/UKI/raw/netboot) | admin **or any node key** | **admin-only** (`AdminMiddleware`, still honours `?token=` for UI links) |
| `/image` (container image) | admin **or any node key** | admin **or** a node that an upgrade command actually assigned this artifact to (`ArtifactImageMiddleware`), else **403** |

Authorization keys on the **command assignment**, not the artifact's `TargetGroupID` (that's a build-time cloud-config hint, often empty — not an ACL). It deliberately does **not** filter on command phase: once a node's been told to install an artifact, re-fetching that image (a retry/resumed upgrade) isn't a new exposure — the boundary enforced is *which* artifact, not how many times. Store errors fail closed.

## CAPI-safe

Admin-authenticated callers — the UI and the CAPI infra provider — bypass both checks. When the provider issues an upgrade command to a node, that node's `/image` download is authorized **by the very command the provider issued**. The fleet contract is unchanged.

`DownloadMiddleware` (now unused, and a footgun to leave lying around) is removed.

## Tests

- **Middleware unit tests**: admin (header + `?token=`), assigned node, unassigned node → 403, wrong artifact → 403, non-upgrade command naming the artifact → 403, no/unknown token → 401.
- **Server integration tests**: node key rejected on `/download` (401), scoped on `/image` (403 unassigned; auth passes when assigned or admin) — verified end to end.

Refs: kairos-io/kairos#4117
