### PR TITLE
ci(riscv64): switch the release build to the emulated runner

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -85,9 +85,13 @@ jobs:
           push: true
           tags: quay.io/kairos/auroraboot:${{ github.ref_name }}-arm64
   build-linux-riscv64:
-    # Reverts #545's disable; same runner, unchanged. See commit message
-    # for why (the runner wasn't actually the problem).
-    runs-on: 'ubuntu-24.04-riscv'
+    # Runs emulated on a stock amd64 runner instead of the native
+    # ubuntu-24.04-riscv one. #779 timed both for this exact build
+    # (Dockerfile.riscv64, including the CGO crypto11/pkcs11 compile) and
+    # emulated finished ~10min faster (54m55s vs 1h05m02s) -- the amd64
+    # runner's extra hardware outweighs QEMU's overhead for a build this
+    # size. Drops the native-runner dependency for the release build.
+    runs-on: 'ubuntu-24.04'
     needs: build-ui
     steps:
       - name: Checkout
@@ -97,6 +101,10 @@ jobs:
         with:
           name: ui-dist
           path: internal/ui/dist
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:

--- a/.github/workflows/test-riscv64.yml
+++ b/.github/workflows/test-riscv64.yml
@@ -36,6 +36,10 @@ jobs:
           retention-days: 1
 
   build-linux-riscv64:
+    # Native-runner signal for the Go binary itself: builds and runs the
+    # test suite as real riscv64 execution, not emulated. Does not also
+    # build the Docker image any more -- build-linux-riscv64-docker below
+    # covers that on amd64+QEMU, matching image.yml's release job.
     runs-on: 'ubuntu-24.04-riscv'
     needs: build-ui
     steps:
@@ -73,24 +77,12 @@ jobs:
           file auroraboot
           ./auroraboot --version || true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Test Docker image build for riscv64
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile.riscv64
-          platforms: linux/riscv64
-          push: false
-          load: false
-
-  build-linux-riscv64-emulated:
-    # Timing experiment: same Docker build as build-linux-riscv64 above, on
-    # a stock amd64 runner under QEMU instead of the native
-    # ubuntu-24.04-riscv runner. Only the runner and the QEMU setup step
-    # differ, so the two job durations are directly comparable.
-    # Not wired into image.yml; this job never publishes anything.
+  build-linux-riscv64-docker:
+    # Mirrors image.yml's build-linux-riscv64 release job: amd64+QEMU, not
+    # the native riscv64 runner. #779 timed both for this exact build
+    # (including the CGO crypto11/pkcs11 compile) and emulated finished
+    # ~10min faster (54m55s vs 1h05m02s), so this is the CI signal for
+    # what the release actually does now.
     runs-on: 'ubuntu-24.04'
     needs: build-ui
     steps:
@@ -111,7 +103,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Test Docker image build for riscv64 (emulated)
+      - name: Test Docker image build for riscv64
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/test-riscv64.yml
+++ b/.github/workflows/test-riscv64.yml
@@ -84,3 +84,38 @@ jobs:
           platforms: linux/riscv64
           push: false
           load: false
+
+  build-linux-riscv64-emulated:
+    # Timing experiment: same Docker build as build-linux-riscv64 above, on
+    # a stock amd64 runner under QEMU instead of the native
+    # ubuntu-24.04-riscv runner. Only the runner and the QEMU setup step
+    # differ, so the two job durations are directly comparable.
+    # Not wired into image.yml; this job never publishes anything.
+    runs-on: 'ubuntu-24.04'
+    needs: build-ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download UI artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ui-dist
+          path: internal/ui/dist
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Test Docker image build for riscv64 (emulated)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.riscv64
+          platforms: linux/riscv64
+          push: false
+          load: false


### PR DESCRIPTION
## Result

Timed the identical `Dockerfile.riscv64` build (CGO `crypto11`/`pkcs11` included) both ways in this PR's own CI run:

| Runner | Duration |
|---|---|
| Native `ubuntu-24.04-riscv` | 1h05m02s |
| `ubuntu-24.04` + QEMU (emulated) | **54m55s** |

Emulated finished ~10 minutes faster. The amd64 GitHub-hosted runner's extra hardware outweighs QEMU's emulation overhead for a build this size — unlike a much heavier from-scratch OS compile, where emulation cost dominates.

## What changed

Acting on that result instead of leaving it as a side-by-side comparison:

- `image.yml`'s `build-linux-riscv64` — the actual release job — now runs on `ubuntu-24.04` with `docker/setup-qemu-action`, not the native riscv64 runner. Drops the native-runner dependency from the release path entirely. `push: true` stays; nothing else about the job changes.
- `test-riscv64.yml` no longer runs the same Docker build twice. The native `build-linux-riscv64` job keeps only the Go build/test/binary-info steps (real riscv64 execution, still worth having). The Docker build check moves to `build-linux-riscv64-docker`, which mirrors `image.yml`'s release job exactly, on amd64+QEMU.

## Test plan

- [x] Compared native vs emulated Docker-build duration on this PR's own CI run.
- [ ] Confirm `build-linux-riscv64-docker` stays green over a few more PR runs before relying on it as the only Docker-build signal.
- [ ] A real tag push exercises the changed release job end to end — recommend testing against a pre-release tag before the next real cut.

---

*AI assisted: this PR was opened by an autonomous agent (`mauro-agent`) acting under Mauro Morales's direction, authored and committed under his identity per team convention. He has not reviewed this diff yet; it is a draft for exactly that reason.*