### PR TITLE
test(integration): disable rate limiting in the shared test server

### DIFF
--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
-	"github.com/kairos-io/AuroraBoot/pkg/builder"
-	"github.com/kairos-io/AuroraBoot/pkg/server"
 	gormstore "github.com/kairos-io/AuroraBoot/internal/store/gorm"
-	"github.com/kairos-io/AuroraBoot/pkg/ws"
+	"github.com/kairos-io/AuroraBoot/pkg/builder"
 	"github.com/kairos-io/AuroraBoot/pkg/client"
+	"github.com/kairos-io/AuroraBoot/pkg/server"
+	"github.com/kairos-io/AuroraBoot/pkg/ws"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -117,8 +117,15 @@ var _ = BeforeSuite(func() {
 		Builder:       newMockArtifactBuilder(),
 		AdminPassword: testAdminPassword,
 		RegToken:      testRegToken,
-		AuroraBootURL:   "http://localhost",
+		AuroraBootURL: "http://localhost",
 		Hub:           hub,
+		// The whole suite drives one shared server from 127.0.0.1 and registers
+		// dozens of nodes across its specs. With per-IP registration rate limiting
+		// on (the default), those registrations share one bucket and exhaust its
+		// burst, so later specs' registrations flakily 429. This suite exercises
+		// fleet behaviour, not the limiter (which has its own coverage in
+		// pkg/auth/ratelimit_test.go and pkg/server), so turn it off here.
+		DisableRateLimit: true,
 	}
 
 	e := server.New(cfg)


### PR DESCRIPTION
## What

Disable rate limiting in the `test/integration` shared test server (`DisableRateLimit: true`).

## Why

Follow-up to the rate-limiting change (#772). The integration suite drives **one shared `httptest` server** and, across its specs, registers **dozens of nodes** — all from `127.0.0.1` via the same client. #772 turned on per-IP registration rate limiting by default (0.5 rps, **burst 20**). Those registrations share a single per-IP bucket, so once ~20 land faster than the refill, later specs' registrations get **429** and `registerNode`'s `"register node should succeed"` assertion fails, aborting dependent specs (e.g. `Ran 39 of 41`).

Because Ginkgo runs specs in parallel and randomized order, whether the burst is exhausted is timing-dependent — so it's **flaky**: it passed on #772's own CI by luck, then tripped on an unrelated PR ([run](https://github.com/kairos-io/AuroraBoot/actions/runs/34202990177/job/101985866871)), where a retry cleared it.

## The fix

This suite exercises fleet behaviour, not the limiter — which has dedicated coverage in `pkg/auth/ratelimit_test.go` and the `pkg/server` "Rate limiting wiring" tests — so it shouldn't be fighting the per-IP limit while registering many nodes from one IP. Disabling it in the harness makes the suite deterministic again (a registration 429 becomes impossible), with no loss of coverage.

Note this is a **test-harness** issue, not a product bug: the per-IP registration limit is a deliberate, documented default (a NATed fleet raises or disables it via `--register-rate-limit` / `--disable-rate-limit`).

Refs: kairos-io/kairos#4117
