### PR TITLE
fix(ui): pre-populate kairos-init image on Hadron clone

### DIFF
--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -927,6 +927,7 @@ export function ArtifactBuilder() {
             kubernetesDistro: a.kubernetesDistro || "",
             kubernetesVersion: a.kubernetesVersion || "",
             kubernetesEnabled: a.variant === "standard" ? a.kubernetesEnabled ?? true : true,
+            kairosInitImage: a.kairosInitImage || "",
             outputs: {
               iso: a.iso,
               cloudImage: a.cloudImage,

--- a/ui/src/test/artifactBuilder.hadron.test.tsx
+++ b/ui/src/test/artifactBuilder.hadron.test.tsx
@@ -124,6 +124,7 @@ describe("ArtifactBuilder: Hadron clone", () => {
       kubernetesDistro: "k3s",
       kubernetesVersion: "v1.31.4+k3s1",
       kubernetesEnabled: true,
+      kairosInitImage: "quay.io/kairos/kairos-init:v0.5.0",
       iso: true,
       cloudImage: false,
       netboot: false,
@@ -153,6 +154,17 @@ describe("ArtifactBuilder: Hadron clone", () => {
     // The Kubernetes version input should carry the cloned version.
     expect(
       screen.getByDisplayValue(/v1\.31\.4\+k3s1/),
+    ).toBeInTheDocument();
+
+    // The kairos-init OCI image should also carry over (regression for the
+    // clone silently dropping this field on Hadron-based sources). It lives
+    // on the Output step, in the collapsed Advanced card.
+    fireEvent.click(screen.getByRole("button", { name: /Output/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Advanced.*Cloud config/i }),
+    );
+    expect(
+      screen.getByDisplayValue(/quay\.io\/kairos\/kairos-init:v0\.5\.0/),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Fixes kairos-io/kairos#4592.

Cloning a Hadron-based artifact rebuilds the form from the source artifact,
but the field list for that path never copied `kairosInitImage`. The
non-Hadron clone path already copies it correctly. This adds the missing
line so both paths behave the same way.

## Test plan

- `npm run build` (tsc + vite build) passes.
- `npx vitest run` — all 56 tests pass, including a new assertion on the
  existing Hadron-clone test that the kairos-init image carries over.
- `npx eslint` clean on the changed file.

---

An unattended agent opened this pull request. Nobody has reviewed the diff yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181oEMJkcj7xr62r5RgzTNf
