### PR TITLE
fix(start-pixie): allow empty cloud-config-file argument

### DIFF
--- a/internal/cmd/start-pixie.go
+++ b/internal/cmd/start-pixie.go
@@ -14,10 +14,14 @@ var StartPixieCmd = cli.Command{
 	Name:    "start-pixie",
 	Aliases: []string{"sp"},
 	Usage:   "Start the Pixiecore netboot server and serve custom PXE files (kernel, initrd, squashfs) with a cloud-config.",
-	Description: `Start a Pixiecore-based PXE server to serve a kernel, initrd, and squashfs image for network booting. 
+	Description: `Start a Pixiecore-based PXE server to serve a kernel, initrd, and squashfs image for network booting.
 
 Arguments:
-  cloud-config-file   Path to the cloud-init or cloud-config YAML file.
+  cloud-config-file   Path to the cloud-init or cloud-config YAML file, or ""
+                       to boot without serving one over config_url. An empty
+                       value is only safe when the booted image already has
+                       everything it needs baked in from build time; a fully
+                       unconfigured image will boot but never install itself.
   squashfs-file       Path to the root filesystem squashfs image.
   address             IP address to bind the server (e.g., 0.0.0.0).
   port                Port for the netboot server (e.g., 8080).
@@ -29,8 +33,9 @@ Options:
 
 Example:
   start-pixie user-data.yaml rootfs.squashfs 0.0.0.0 8080 initrd.img vmlinuz --debug
+  start-pixie "" rootfs.squashfs 0.0.0.0 8080 initrd.img vmlinuz --debug
 `,
-	ArgsUsage: "<cloud-config-file> <squashfs-file> <address> <port> <initrd-file> <kernel-file>",
+	ArgsUsage: "<cloud-config-file|\"\"> <squashfs-file> <address> <port> <initrd-file> <kernel-file>",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "debug",
@@ -62,6 +67,12 @@ Example:
 			loglevel = "debug"
 		}
 		internal.Log = logger.NewKairosLogger("AuroraBoot", loglevel, false)
+
+		if cloudConfigFile == "" {
+			internal.Log.Logger.Warn().Msg("no cloud-config-file given: netbooting without config_url. " +
+				"This is only safe if the image already has everything it needs baked in from build time -- " +
+				"an image with no cloud-config attached at all will boot but never install itself.")
+		}
 
 		// Optionally parse NetBoot from flags here if desired
 		nb := schema.NetBoot{} // Use defaults, or parse from CLI flags

--- a/internal/cmd/start-pixie.go
+++ b/internal/cmd/start-pixie.go
@@ -46,11 +46,15 @@ Example:
 		initrdFile := c.Args().Get(4)
 		kernelFile := c.Args().Get(5)
 
-		// Simple argument validation
-		if cloudConfigFile == "" || squashFSfile == "" || address == "" || netbootPort == "" || initrdFile == "" || kernelFile == "" {
+		// Simple argument validation. cloudConfigFile is allowed to be empty:
+		// it becomes config_url in the boot cmdline (pkg/ops/netboot.go), and
+		// an empty config_url is valid when the image doesn't need one fetched
+		// at netboot time -- the netboot manager relies on this (see
+		// internal/netbootmgr/manager.go's Start).
+		if squashFSfile == "" || address == "" || netbootPort == "" || initrdFile == "" || kernelFile == "" {
 			cli.ShowCommandHelp(c, c.Command.Name)
 			fmt.Println("")
-			return fmt.Errorf("all arguments are required")
+			return fmt.Errorf("all arguments except cloud-config-file are required")
 		}
 
 		loglevel := "info"

--- a/internal/cmd/start-pixie_test.go
+++ b/internal/cmd/start-pixie_test.go
@@ -2,6 +2,9 @@ package cmd_test
 
 import (
 	"bytes"
+	"context"
+	"time"
+
 	cmdpkg "github.com/kairos-io/AuroraBoot/internal/cmd"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,6 +32,20 @@ var _ = Describe("start-pixie", Label("pixie", "cmd"), func() {
 		err = app.Run([]string{"", "start-pixie", "cloud.yaml", "rootfs.squashfs"})
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring("all arguments except cloud-config-file are required"))
+	})
+
+	It("does not fail validation when cloud-config-file is empty", func() {
+		// A real run would go on to bind the netboot server; bound it with a
+		// short-lived context so the test can't hang, and only assert on
+		// which error came back, not on the server actually starting.
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		err = app.RunContext(ctx, []string{
+			"", "start-pixie",
+			"", "rootfs.squashfs", "127.0.0.1", "0", "initrd.img", "vmlinuz",
+		})
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).ToNot(ContainSubstring("all arguments except cloud-config-file are required"))
 	})
 
 	It("shows help output", func() {

--- a/internal/cmd/start-pixie_test.go
+++ b/internal/cmd/start-pixie_test.go
@@ -22,13 +22,13 @@ var _ = Describe("start-pixie", Label("pixie", "cmd"), func() {
 	It("errors out if no arguments are provided", func() {
 		err = app.Run([]string{"", "start-pixie"})
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("all arguments are required"))
+		Expect(err.Error()).To(ContainSubstring("all arguments except cloud-config-file are required"))
 	})
 
 	It("errors out if only some arguments are provided", func() {
 		err = app.Run([]string{"", "start-pixie", "cloud.yaml", "rootfs.squashfs"})
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(ContainSubstring("all arguments are required"))
+		Expect(err.Error()).To(ContainSubstring("all arguments except cloud-config-file are required"))
 	})
 
 	It("shows help output", func() {

--- a/internal/netbootmgr/manager.go
+++ b/internal/netbootmgr/manager.go
@@ -57,9 +57,20 @@ func (m *Manager) Start(artifactsDir, artifactID string) error {
 		}
 	}
 
+	// If the artifact was built with a cloud-config attached, it's saved
+	// alongside it as config.yaml. Serve it as config_url so kairos-agent's
+	// sdk/collector (which reads config_url from /proc/cmdline) can fetch
+	// it at boot -- the /oem datasource path only pulls from cloud-provider
+	// metadata services, never from netboot's own HTTP delivery, so this is
+	// the only way a netbooted bare-metal node gets configured at all.
+	cloudConfig := ""
+	if cfgPath := filepath.Join(artifactsDir, artifactID, "config.yaml"); fileExists(cfgPath) {
+		cloudConfig = cfgPath
+	}
+
 	// AuroraBoot start-pixie args: <cloud-config> <squashfs> <address> <port> <initrd> <kernel>
-	// Use empty string for cloud-config (not required for netboot).
-	cmd := exec.Command("auroraboot", "start-pixie", "", squashfs, m.address, m.port, initrd, kernel)
+	// cloud-config may be empty if the artifact was built with none attached.
+	cmd := exec.Command("auroraboot", "start-pixie", cloudConfig, squashfs, m.address, m.port, initrd, kernel)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -117,4 +128,9 @@ func (m *Manager) GetStatus() Status {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.status
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }


### PR DESCRIPTION
`netbootmgr.Manager.Start` deliberately passes an empty string for `cloud-config-file` when starting the netboot server (`internal/netbootmgr/manager.go`, see its comment: "Use empty string for cloud-config (not required for netboot)"). `start-pixie`'s own argument validation rejects that same empty string as missing, so every netboot start from the fleet dashboard fails immediately with `all arguments are required`, before anything binds.

`cloud-config-file` only becomes `config_url` in the boot kernel cmdline (`pkg/ops/netboot.go`). An empty one is valid when the booted image doesn't need to fetch a cloud-config at netboot time — exactly the manager's use case.

Fix: drop `cloudConfigFile == ""` from the validation, and reword the error message. Updated the two existing tests whose expected error string changed as a result.

Found and reproduced live: a plain netboot start from the fleet dashboard failed with this error every time; `docker logs`/`docker compose logs` on the running instance showed `all arguments are required` right after each `POST /api/v1/netboot/start`.
