### PR TITLE
feat: show node's remote IP, updated on every heartbeat

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1989,6 +1989,10 @@ const docTemplate = `{
                 "phase": {
                     "type": "string"
                 },
+                "remoteIP": {
+                    "description": "RemoteIP is the IP the server observed the node connect from at register or\nheartbeat time (kairos-io/kairos#4590), independent of Addresses: the node\ndoes not report it, and it survives even when an agent sends no addresses at\nall (e.g. the WebSocket heartbeat path, or an older agent). It tracks NAT/DHCP\nchanges because every heartbeat re-observes and overwrites it.",
+                    "type": "string"
+                },
                 "resetRequestedAt": {
                     "description": "ResetRequestedAt is when the reset command was issued (ResetState set to\npending); nil when no reset has been requested.",
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1982,6 +1982,10 @@
                 "phase": {
                     "type": "string"
                 },
+                "remoteIP": {
+                    "description": "RemoteIP is the IP the server observed the node connect from at register or\nheartbeat time (kairos-io/kairos#4590), independent of Addresses: the node\ndoes not report it, and it survives even when an agent sends no addresses at\nall (e.g. the WebSocket heartbeat path, or an older agent). It tracks NAT/DHCP\nchanges because every heartbeat re-observes and overwrites it.",
+                    "type": "string"
+                },
                 "resetRequestedAt": {
                     "description": "ResetRequestedAt is when the reset command was issued (ResetState set to\npending); nil when no reset has been requested.",
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -505,6 +505,14 @@ definitions:
         type: object
       phase:
         type: string
+      remoteIP:
+        description: |-
+          RemoteIP is the IP the server observed the node connect from at register or
+          heartbeat time (kairos-io/kairos#4590), independent of Addresses: the node
+          does not report it, and it survives even when an agent sends no addresses at
+          all (e.g. the WebSocket heartbeat path, or an older agent). It tracks NAT/DHCP
+          changes because every heartbeat re-observes and overwrites it.
+        type: string
       resetRequestedAt:
         description: |-
           ResetRequestedAt is when the reset command was issued (ResetState set to

--- a/internal/store/gorm/adapters.go
+++ b/internal/store/gorm/adapters.go
@@ -33,8 +33,8 @@ func (a *NodeStoreAdapter) ListByLabels(ctx context.Context, labels map[string]s
 func (a *NodeStoreAdapter) ListBySelector(ctx context.Context, sel store.CommandSelector) ([]*store.ManagedNode, error) {
 	return a.S.ListBySelector(ctx, sel)
 }
-func (a *NodeStoreAdapter) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string) error {
-	return a.S.UpdateHeartbeat(ctx, id, agentVersion, osRelease, addresses, bootState, hostname)
+func (a *NodeStoreAdapter) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string, remoteIP string) error {
+	return a.S.UpdateHeartbeat(ctx, id, agentVersion, osRelease, addresses, bootState, hostname, remoteIP)
 }
 func (a *NodeStoreAdapter) UpdatePhase(ctx context.Context, id string, phase string) error {
 	return a.S.UpdatePhase(ctx, id, phase)

--- a/internal/store/gorm/store.go
+++ b/internal/store/gorm/store.go
@@ -258,7 +258,7 @@ func (s *Store) ListBySelector(ctx context.Context, sel store.CommandSelector) (
 	return nodes, nil
 }
 
-func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string) error {
+func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string, remoteIP string) error {
 	var n store.ManagedNode
 	if err := s.db.WithContext(ctx).First(&n, "id = ?", id).Error; err != nil {
 		return err
@@ -288,6 +288,12 @@ func (s *Store) UpdateHeartbeat(ctx context.Context, id string, agentVersion str
 	// not report a hostname must not blank the one already on record.
 	if hostname != "" {
 		n.Hostname = hostname
+	}
+	// Same non-empty guard: a caller that cannot resolve a remote IP (a unit test,
+	// or a future transport that does not expose one) must not blank a value a
+	// prior heartbeat recorded.
+	if remoteIP != "" {
+		n.RemoteIP = remoteIP
 	}
 	return s.db.WithContext(ctx).Save(&n).Error
 }

--- a/internal/store/gorm/store_test.go
+++ b/internal/store/gorm/store_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Gorm Store", func() {
 				{Type: "InternalIP", Address: "10.0.10.21"},
 				{Type: "Hostname", Address: "hb1"},
 			}
-			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.5.0", osRel, addrs, "active", "hb1-renamed")).To(Succeed())
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.5.0", osRel, addrs, "active", "hb1-renamed", "203.0.113.5")).To(Succeed())
 
 			found, err := s.NodeGetByID(ctx, n.ID)
 			Expect(err).NotTo(HaveOccurred())
@@ -253,25 +253,28 @@ var _ = Describe("Gorm Store", func() {
 			Expect(found.Addresses).To(Equal(addrs))
 			Expect(found.BootState).To(Equal("active"))
 			Expect(found.Hostname).To(Equal("hb1-renamed"))
+			Expect(found.RemoteIP).To(Equal("203.0.113.5"))
 		})
 
-		It("preserves addresses, boot state and hostname when a heartbeat omits them", func() {
+		It("preserves addresses, boot state, hostname and remote IP when a heartbeat omits them", func() {
 			n := &store.ManagedNode{
 				MachineID: "hb2",
 				Hostname:  "hb2-host",
 				Addresses: []store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.22"}},
 				BootState: "active",
+				RemoteIP:  "198.51.100.9",
 			}
 			Expect(s.Register(ctx, n)).To(Succeed())
 
 			// An older agent (or the WS heartbeat path) sends nil/"" — must not wipe.
-			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "")).To(Succeed())
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "", "")).To(Succeed())
 
 			found, err := s.NodeGetByID(ctx, n.ID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found.Addresses).To(Equal([]store.NodeAddress{{Type: "InternalIP", Address: "10.0.10.22"}}))
 			Expect(found.BootState).To(Equal("active"))
 			Expect(found.Hostname).To(Equal("hb2-host"))
+			Expect(found.RemoteIP).To(Equal("198.51.100.9"))
 		})
 
 		// The bug this closes: a node registers while cloud-init has not yet
@@ -282,7 +285,7 @@ var _ = Describe("Gorm Store", func() {
 			n := &store.ManagedNode{MachineID: "a1b2c3d4", Hostname: "kairos"}
 			Expect(s.Register(ctx, n)).To(Succeed())
 
-			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "kairos-a1b2")).To(Succeed())
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "kairos-a1b2", "")).To(Succeed())
 
 			found, err := s.NodeGetByID(ctx, n.ID)
 			Expect(err).NotTo(HaveOccurred())
@@ -290,12 +293,12 @@ var _ = Describe("Gorm Store", func() {
 
 			// Idempotent: the next heartbeat reports the same name and nothing
 			// churns, and a rename later in the node's life still lands.
-			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "kairos-a1b2")).To(Succeed())
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "kairos-a1b2", "")).To(Succeed())
 			found, err = s.NodeGetByID(ctx, n.ID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found.Hostname).To(Equal("kairos-a1b2"))
 
-			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "renamed-later")).To(Succeed())
+			Expect(s.UpdateHeartbeat(ctx, n.ID, "v0.6.0", nil, nil, "", "renamed-later", "")).To(Succeed())
 			found, err = s.NodeGetByID(ctx, n.ID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found.Hostname).To(Equal("renamed-later"))

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -60,7 +60,7 @@ func (f *fakeNodeStore) ListByLabels(_ context.Context, _ map[string]string) ([]
 func (f *fakeNodeStore) ListBySelector(_ context.Context, _ store.CommandSelector) ([]*store.ManagedNode, error) {
 	return nil, nil
 }
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string, _ string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string, _ string, _ string) error {
 	return nil
 }
 func (f *fakeNodeStore) UpdatePhase(_ context.Context, _ string, _ string) error { return nil }

--- a/pkg/handlers/fakes_test.go
+++ b/pkg/handlers/fakes_test.go
@@ -119,7 +119,7 @@ func (f *fakeNodeStore) ListBySelector(_ context.Context, sel store.CommandSelec
 	return f.nodes, nil
 }
 
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, id string, agentVersion string, osRelease map[string]string, addresses []store.NodeAddress, bootState string, hostname string, remoteIP string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, n := range f.nodes {
@@ -135,6 +135,9 @@ func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, id string, agentVersi
 			}
 			if hostname != "" {
 				n.Hostname = hostname
+			}
+			if remoteIP != "" {
+				n.RemoteIP = remoteIP
 			}
 			return nil
 		}

--- a/pkg/handlers/nodes.go
+++ b/pkg/handlers/nodes.go
@@ -175,6 +175,9 @@ func (h *NodeHandler) Register(c echo.Context) error {
 		// as received — interface filtering is the agent's responsibility.
 		Addresses: req.Addresses,
 		BootState: req.BootState,
+		// RemoteIP is server-observed, not agent-reported: the request the agent
+		// just made to register is itself the observation.
+		RemoteIP: c.RealIP(),
 	}
 
 	if err := h.nodes.Register(c.Request().Context(), node); err != nil {
@@ -551,7 +554,7 @@ func (h *NodeHandler) Heartbeat(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 	}
-	if err := h.nodes.UpdateHeartbeat(c.Request().Context(), nodeID, req.AgentVersion, req.OSRelease, req.Addresses, req.BootState, req.Hostname); err != nil {
+	if err := h.nodes.UpdateHeartbeat(c.Request().Context(), nodeID, req.AgentVersion, req.OSRelease, req.Addresses, req.BootState, req.Hostname, c.RealIP()); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to update heartbeat"})
 	}
 	if err := h.nodes.UpdatePhase(c.Request().Context(), nodeID, store.PhaseOnline); err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -71,7 +71,7 @@ func (f *fakeNodeStore) ListByLabels(_ context.Context, _ map[string]string) ([]
 func (f *fakeNodeStore) ListBySelector(_ context.Context, _ store.CommandSelector) ([]*store.ManagedNode, error) {
 	return nil, nil
 }
-func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string, _ string) error {
+func (f *fakeNodeStore) UpdateHeartbeat(_ context.Context, _ string, _ string, _ map[string]string, _ []store.NodeAddress, _ string, _ string, _ string) error {
 	return nil
 }
 func (f *fakeNodeStore) UpdatePhase(_ context.Context, _ string, _ string) error { return nil }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -58,6 +58,12 @@ type ManagedNode struct {
 	// and backward-compatible: an agent that does not send them leaves the list
 	// empty. Stored as JSON, mirroring OSRelease/Labels.
 	Addresses []NodeAddress `json:"addresses,omitempty" gorm:"serializer:json"`
+	// RemoteIP is the IP the server observed the node connect from at register or
+	// heartbeat time (kairos-io/kairos#4590), independent of Addresses: the node
+	// does not report it, and it survives even when an agent sends no addresses at
+	// all (e.g. the WebSocket heartbeat path, or an older agent). It tracks NAT/DHCP
+	// changes because every heartbeat re-observes and overwrites it.
+	RemoteIP string `json:"remoteIP,omitempty"`
 	// BootState is the node's reported boot state for day-2 lifecycle (e.g. a node
 	// that booted the passive image signals a broken active image). Known values:
 	// active | passive | recovery | autoreset — but unknown values are accepted
@@ -183,11 +189,11 @@ type NodeStore interface {
 	ListBySelector(ctx context.Context, sel CommandSelector) ([]*ManagedNode, error)
 	// UpdateHeartbeat records a heartbeat: it stamps LastHeartbeat, moves the node
 	// to Online, and applies whatever the report carried. agentVersion and
-	// osRelease are always written; addresses, bootState and hostname are only
-	// written when non-empty, so a caller that does not collect a field (an older
-	// agent, or a transport that does not carry it) preserves the stored value
-	// instead of blanking it.
-	UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []NodeAddress, bootState string, hostname string) error
+	// osRelease are always written; addresses, bootState, hostname and remoteIP are
+	// only written when non-empty, so a caller that does not collect a field (an
+	// older agent, or a transport that does not carry it) preserves the stored
+	// value instead of blanking it.
+	UpdateHeartbeat(ctx context.Context, id string, agentVersion string, osRelease map[string]string, addresses []NodeAddress, bootState string, hostname string, remoteIP string) error
 	UpdatePhase(ctx context.Context, id string, phase string) error
 	SetGroup(ctx context.Context, nodeID string, groupID string) error
 	SetLabels(ctx context.Context, nodeID string, labels map[string]string) error

--- a/pkg/ws/handler.go
+++ b/pkg/ws/handler.go
@@ -144,6 +144,11 @@ func (h *AgentHandler) HandleAgentWS(c echo.Context) error {
 	}
 	defer conn.Close()
 
+	// Captured once: the connection's remote address does not change over its
+	// life, and the read loop below no longer has c in scope by the time a
+	// heartbeat frame arrives.
+	remoteIP := c.RealIP()
+
 	// Register in hub and mark node online. wc wraps conn with a per-connection
 	// write lock; all writes to this connection (here and from the hub) must go
 	// through it so they don't race.
@@ -235,7 +240,7 @@ func (h *AgentHandler) HandleAgentWS(c echo.Context) error {
 
 		switch msg.Type {
 		case "heartbeat":
-			h.handleHeartbeat(node.ID, msg.Data)
+			h.handleHeartbeat(node.ID, msg.Data, remoteIP)
 		case "command_status":
 			h.handleCommandStatus(node.ID, msg.Data)
 		default:
@@ -244,7 +249,7 @@ func (h *AgentHandler) HandleAgentWS(c echo.Context) error {
 	}
 }
 
-func (h *AgentHandler) handleHeartbeat(nodeID string, data json.RawMessage) {
+func (h *AgentHandler) handleHeartbeat(nodeID string, data json.RawMessage, remoteIP string) {
 	var hb heartbeatData
 	if err := json.Unmarshal(data, &hb); err != nil {
 		log.Printf("ws invalid heartbeat from node %s: %v", nodeID, err)
@@ -258,8 +263,10 @@ func (h *AgentHandler) handleHeartbeat(nodeID string, data json.RawMessage) {
 	// (those ride the REST register/heartbeat contract); pass nil/"" so the store
 	// preserves whatever the node reported there. The hostname is passed through:
 	// an agent that reports one is reporting its current one, and an agent that
-	// does not send "" and leaves the stored value alone.
-	if err := h.Nodes.UpdateHeartbeat(ctx, nodeID, hb.AgentVersion, hb.OSRelease, nil, "", hb.Hostname); err != nil {
+	// does not send "" and leaves the stored value alone. remoteIP, unlike those,
+	// is always known here — it is the live connection's address, not something
+	// the agent reports.
+	if err := h.Nodes.UpdateHeartbeat(ctx, nodeID, hb.AgentVersion, hb.OSRelease, nil, "", hb.Hostname, remoteIP); err != nil {
 		log.Printf("ws: failed to update heartbeat for node %s: %v", nodeID, err)
 	}
 	if err := h.Nodes.UpdatePhase(ctx, nodeID, store.PhaseOnline); err != nil {

--- a/ui/src/api/nodes.ts
+++ b/ui/src/api/nodes.ts
@@ -11,6 +11,10 @@ export interface Node {
   osRelease: Record<string, string> | null;
   agentVersion: string;
   lastHeartbeat: string | null;
+  // The IP the server observed the node connect from at register or heartbeat
+  // time. Server-side, not agent-reported, so it tracks a DHCP/NAT change even
+  // when the agent sends no addresses at all.
+  remoteIP?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/ui/src/components/NodeTable.tsx
+++ b/ui/src/components/NodeTable.tsx
@@ -43,6 +43,7 @@ export function NodeTable({ nodes, emptyAction }: NodeTableProps) {
           <TableHead>Labels</TableHead>
           <TableHead>Phase</TableHead>
           <TableHead>OS Version</TableHead>
+          <TableHead>IP</TableHead>
           <TableHead>Last Heartbeat</TableHead>
           <TableHead>Status</TableHead>
         </TableRow>
@@ -50,7 +51,7 @@ export function NodeTable({ nodes, emptyAction }: NodeTableProps) {
       <TableBody>
         {nodes.length === 0 ? (
           <TableRow>
-            <TableCell colSpan={7} className="text-center py-12">
+            <TableCell colSpan={8} className="text-center py-12">
               <div className="flex flex-col items-center gap-3 py-16">
                 <Server className="h-12 w-12 text-muted-foreground/30" />
                 <div className="text-center">
@@ -87,6 +88,7 @@ export function NodeTable({ nodes, emptyAction }: NodeTableProps) {
               </TableCell>
               <TableCell>{node.phase}</TableCell>
               <TableCell className="text-xs">{node.agentVersion || "-"}</TableCell>
+              <TableCell className="font-mono text-xs">{node.remoteIP || "-"}</TableCell>
               <TableCell className="text-xs">
                 {timeAgo(node.lastHeartbeat || "")}
               </TableCell>

--- a/ui/src/pages/NodeDetail.tsx
+++ b/ui/src/pages/NodeDetail.tsx
@@ -268,6 +268,11 @@ export function NodeDetail() {
               </div>
               <Separator />
               <div className="flex justify-between">
+                <dt className="text-muted-foreground">IP Address</dt>
+                <dd className="font-mono text-xs">{node.remoteIP || "-"}</dd>
+              </div>
+              <Separator />
+              <div className="flex justify-between">
                 <dt className="text-muted-foreground">Last Heartbeat</dt>
                 <dd>{timeAgo(node.lastHeartbeat || "")}</dd>
               </div>


### PR DESCRIPTION
## Summary

Fixes kairos-io/kairos#4590.

Adds a server-observed `RemoteIP` to a node: captured from the connection at
register time and refreshed on every heartbeat (both the REST heartbeat and
the WebSocket heartbeat path), so a DHCP/NAT change is picked up
automatically. This is distinct from the existing `Addresses` field, which is
self-reported by the agent — `RemoteIP` is what the server actually observed
the connection come from, and it is populated even when an agent sends no
addresses at all.

Shown in the node detail "Node Info" card and as a new column in the nodes
list.

## Test plan

- `go build ./...` and `go vet ./pkg/... ./internal/...` clean.
- `go test ./pkg/handlers/... ./pkg/ws/... ./pkg/auth/... ./pkg/server/... ./internal/store/...` (every package this diff touches) all pass.
- `go test ./internal/cmd/...` fails in my sandbox on unrelated specs (a `/tmp` write restriction the sandbox imposes); `internal/cmd` is untouched by this diff.
- Regenerated `docs/swagger.json`/`swagger.yaml`/`docs.go` via `make openapi`.
- `npm run build` (tsc + vite), `npx vitest run` (56/56), `npx eslint` all
  pass on the `ui/` side.

---

An unattended agent opened this pull request. Nobody has reviewed the diff yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181oEMJkcj7xr62r5RgzTNf
