### PR TITLE
fix(ui): show real phonehome values in cloud config preview

### DIFF
--- a/ui/src/lib/cloudConfigPreview.test.ts
+++ b/ui/src/lib/cloudConfigPreview.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parse } from "yaml";
 
-import { buildCloudConfigPreview } from "./cloudConfigPreview";
+import { buildCloudConfigPreview, stripPhonehome } from "./cloudConfigPreview";
 import { PHONEHOME_SAFE_DEFAULTS } from "./buildConfig";
 
 const base: Parameters<typeof buildCloudConfigPreview>[0] = {
@@ -87,5 +87,66 @@ describe("buildCloudConfigPreview", () => {
       extraYAML: `${protoKey}:\n  polluted: true\nk3s:\n  enabled: false`,
     });
     expect(Object.prototype).not.toHaveProperty("polluted");
+  });
+
+  it("falls back to placeholders when no real registration values are given", () => {
+    const doc = docBody(buildCloudConfigPreview(base));
+    const phonehome = doc.phonehome as Record<string, unknown>;
+    expect(phonehome.url).toBe("<server-url>");
+    expect(phonehome.registration_token).toBe("<token>");
+  });
+
+  it("uses the real url and token when provided", () => {
+    const doc = docBody(
+      buildCloudConfigPreview({
+        ...base,
+        registrationUrl: "https://auroraboot.example.com",
+        registrationToken: "real-token-value",
+      }),
+    );
+    const phonehome = doc.phonehome as Record<string, unknown>;
+    expect(phonehome.url).toBe("https://auroraboot.example.com");
+    expect(phonehome.registration_token).toBe("real-token-value");
+  });
+
+  it("keeps showing real values after the extra YAML is edited", () => {
+    const doc = docBody(
+      buildCloudConfigPreview({
+        ...base,
+        extraYAML: "k3s:\n  enabled: false",
+        registrationUrl: "https://auroraboot.example.com",
+        registrationToken: "real-token-value",
+      }),
+    );
+    const phonehome = doc.phonehome as Record<string, unknown>;
+    expect(phonehome.url).toBe("https://auroraboot.example.com");
+    expect(phonehome.registration_token).toBe("real-token-value");
+  });
+});
+
+describe("stripPhonehome", () => {
+  it("removes the phonehome block from a baked cloud config", () => {
+    const baked =
+      "#cloud-config\nphonehome:\n  url: https://real.example.com\n  registration_token: real-token\nk3s:\n  enabled: true\n";
+    const stripped = stripPhonehome(baked);
+    expect(stripped).not.toMatch(/phonehome/);
+    expect(stripped).not.toMatch(/real-token/);
+    expect(parse(stripped.replace(/^#cloud-config\n?/, ""))).toEqual({
+      k3s: { enabled: true },
+    });
+  });
+
+  it("leaves config without a phonehome block untouched", () => {
+    const config = "#cloud-config\nk3s:\n  enabled: true\n";
+    expect(stripPhonehome(config)).toBe(config);
+  });
+
+  it("returns the input unchanged when it is not valid YAML", () => {
+    const invalid = "not: valid: yaml: [";
+    expect(stripPhonehome(invalid)).toBe(invalid);
+  });
+
+  it("returns empty input unchanged", () => {
+    expect(stripPhonehome("")).toBe("");
   });
 });

--- a/ui/src/lib/cloudConfigPreview.ts
+++ b/ui/src/lib/cloudConfigPreview.ts
@@ -16,6 +16,11 @@ export interface CloudConfigPreviewInput {
   password: string;
   sshKeys: string;
   extraYAML: string;
+  // Real values for the phonehome block. Optional because they load
+  // asynchronously (registrationToken) or may be unavailable; fall back to
+  // placeholders so the preview never blocks on them.
+  registrationUrl?: string;
+  registrationToken?: string;
 }
 
 const UNSAFE_MERGE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -71,8 +76,8 @@ export function buildCloudConfigPreview(input: CloudConfigPreviewInput): string 
 
   if (input.registerAuroraBoot) {
     doc.phonehome = {
-      url: "<server-url>",
-      registration_token: "<token>",
+      url: input.registrationUrl || "<server-url>",
+      registration_token: input.registrationToken || "<token>",
       group: input.groupName,
       allowed_commands: [...input.allowedCommands],
     };
@@ -124,4 +129,35 @@ export function buildCloudConfigPreview(input: CloudConfigPreviewInput): string 
   }
 
   return `#cloud-config\n${stringify(doc)}`;
+}
+
+// A cloned artifact's stored cloudConfig is the full baked document, which
+// includes the real phonehome url/registration_token in effect at clone
+// time. That block must never re-enter the wizard as "extra" YAML: the
+// backend already re-injects phonehome from live settings at build time
+// (buildCloudConfig in pkg/handlers/artifacts.go), and forwarding a stale
+// copy back as extra YAML would let it override those live values with
+// whatever was true when the artifact was cloned.
+export function stripPhonehome(yamlText: string): string {
+  const trimmed = yamlText.trim();
+  if (!trimmed) {
+    return yamlText;
+  }
+  let body = trimmed;
+  const hadHeader = body.startsWith("#cloud-config");
+  if (hadHeader) {
+    body = body.replace(/^#cloud-config\s*\n?/, "");
+  }
+  let doc: YamlValue;
+  try {
+    doc = parse(body);
+  } catch {
+    return yamlText;
+  }
+  if (!isMap(doc) || !("phonehome" in doc)) {
+    return yamlText;
+  }
+  delete doc.phonehome;
+  const rest = stringify(doc);
+  return hadHeader ? `#cloud-config\n${rest}` : rest;
 }

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -9,11 +9,12 @@ import {
   type SecureBootKeySet,
 } from "@/api/artifacts";
 import { listGroups, type Group } from "@/api/groups";
+import { getRegistrationToken } from "@/api/settings";
 import {
   PHONEHOME_SAFE_DEFAULTS,
   PHONEHOME_DESTRUCTIVE_COMMANDS,
 } from "@/lib/buildConfig";
-import { buildCloudConfigPreview } from "@/lib/cloudConfigPreview";
+import { buildCloudConfigPreview, stripPhonehome } from "@/lib/cloudConfigPreview";
 import { renderHadronMiddleContent } from "@/lib/hadronContent";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -733,11 +734,18 @@ export function ArtifactBuilder() {
   const [advancedConfig, setAdvancedConfig] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
 
+  // Real phonehome values for the Review-step preview, same source Import.tsx
+  // uses for its curl command. Kept separate from the submitted form: the
+  // backend re-injects these from live settings at build time, so the
+  // preview only needs to read them, never send them.
+  const [registrationToken, setRegistrationToken] = useState("");
+
   const importInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     listGroups().then(setGroups).catch(() => {});
     listSecureBootKeySets().then(setKeySets).catch(() => {});
+    getRegistrationToken().then((t) => setRegistrationToken(t.token)).catch(() => {});
   }, []);
 
   // After focusFirstError queues a focusTarget and setStep has re-rendered
@@ -949,7 +957,7 @@ export function ArtifactBuilder() {
             },
           });
           if (a.cloudConfig) {
-            setAdvancedConfig(a.cloudConfig);
+            setAdvancedConfig(stripPhonehome(a.cloudConfig));
             setShowAdvanced(true);
             setUserMode("none");
           }
@@ -998,7 +1006,7 @@ export function ArtifactBuilder() {
         });
         if (a.dockerfile) setBuildMode("dockerfile");
         if (a.cloudConfig) {
-          setAdvancedConfig(a.cloudConfig);
+          setAdvancedConfig(stripPhonehome(a.cloudConfig));
           setShowAdvanced(true);
           setUserMode("none");
         }
@@ -1056,6 +1064,8 @@ export function ArtifactBuilder() {
       password,
       sshKeys,
       extraYAML: advancedConfig,
+      registrationUrl: window.location.origin,
+      registrationToken,
     });
   }
 


### PR DESCRIPTION
Fixes kairos-io/kairos#4595.

## Problem

The Review-step cloud config preview always showed literal
`<server-url>` and `<token>` placeholders for `phonehome.url` and
`registration_token`, even though the real registration token is
already available to the UI (used in the Import page's curl
command). Editing the appended cloud config after cloning an
artifact made these placeholders reappear, which is the behavior
reported in the issue.

## Root cause

1. `buildCloudConfigPreview` hardcoded the placeholder strings with
   no way to pass real values in.
2. The clone flow copied the cloned artifact's full baked cloud
   config, phonehome secrets included, into the editable "Cloud
   Config (appended)" textarea. That field is documented as extra
   YAML only; the backend re-injects phonehome from live settings at
   build time. The real values only showed because that copied block
   happened to still match. Editing or removing it (reasonable, since
   the UI says registration is auto-injected by the server) lost the
   match and the preview fell back to the placeholders.

## Fix

- `buildCloudConfigPreview` now accepts the real registration URL and
  token and uses them when available, falling back to the placeholder
  strings otherwise.
- `ArtifactBuilder` fetches the real registration token the same way
  `Import.tsx` already does, and passes it plus `window.location.origin`
  into the preview builder, so the preview is always correct
  regardless of what is in the appended field.
- The clone-prefill flow now strips the `phonehome` block from the
  copied cloud config before it lands in the editable field, so a
  stale copy of the token/url can never be resubmitted as "extra"
  YAML and override the live values the backend injects at build time.

## Testing

- `npm run test` (`cloudConfigPreview.test.ts`, `artifactBuilder.hadron.test.tsx`)
- `npm run build`
- `npm run lint`
