### PR TITLE
feat: stream PXE/netboot server logs to the UI

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -563,6 +563,31 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/netboot/logs": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "description": "Returns the current (or most recent) PXE/netboot session's captured output as text/plain. For real-time updates subscribe to the UI WebSocket and filter {type:\"netboot-log\"} envelopes.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "Netboot"
+                ],
+                "summary": "Get netboot server log snapshot",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/nodes": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -556,6 +556,31 @@
                 }
             }
         },
+        "/api/v1/netboot/logs": {
+            "get": {
+                "security": [
+                    {
+                        "AdminBearer": []
+                    }
+                ],
+                "description": "Returns the current (or most recent) PXE/netboot session's captured output as text/plain. For real-time updates subscribe to the UI WebSocket and filter {type:\"netboot-log\"} envelopes.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "Netboot"
+                ],
+                "summary": "Get netboot server log snapshot",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/nodes": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -948,6 +948,23 @@ paths:
       summary: Claim a node from a group
       tags:
       - Groups
+  /api/v1/netboot/logs:
+    get:
+      description: Returns the current (or most recent) PXE/netboot session's captured
+        output as text/plain. For real-time updates subscribe to the UI WebSocket
+        and filter {type:"netboot-log"} envelopes.
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: string
+      security:
+      - AdminBearer: []
+      summary: Get netboot server log snapshot
+      tags:
+      - Netboot
   /api/v1/nodes:
     get:
       description: Returns every registered node. Optional group/label filters.

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -282,7 +282,7 @@ func runWeb(c *cli.Context) error {
 	bmcTargetStore := &gormstore.BMCTargetStoreAdapter{S: store}
 	settingsStore := &gormstore.SettingsStoreAdapter{S: store}
 
-	netbootManager := netbootmgr.NewManager()
+	netbootManager := netbootmgr.NewManager(wsHub.UI)
 
 	// Optional Redfish ISO-serve: serves a local artifact ISO over a tokenized,
 	// BMC-reachable URL so virtual-media (URL-pull) deploys work without an

--- a/internal/netbootmgr/manager.go
+++ b/internal/netbootmgr/manager.go
@@ -1,7 +1,9 @@
 package netbootmgr
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +18,20 @@ type Status struct {
 	Port       string `json:"port"`
 }
 
+// LogSink receives the netboot server's output as it happens, so a UI client
+// watching a PXE boot in progress can see why it fails instead of only a
+// stalled "Running" badge (kairos-io/kairos#4596). Satisfied by
+// *ws.UIHub.BroadcastNetbootLogChunk; kept as a narrow interface here so this
+// package does not import pkg/ws.
+type LogSink interface {
+	BroadcastNetbootLogChunk(chunk string)
+}
+
+// maxLogBytes bounds the retained log so a long-running or noisy PXE server
+// (a node retrying DHCP forever) cannot grow this without limit; it is an
+// in-memory debugging aid, not a durable log store.
+const maxLogBytes = 256 * 1024
+
 // Manager manages a PXE/netboot server lifecycle.
 type Manager struct {
 	mu      sync.Mutex
@@ -23,14 +39,49 @@ type Manager struct {
 	status  Status
 	address string
 	port    string
+	logSink LogSink
+	logBuf  bytes.Buffer
 }
 
-// NewManager creates a new netboot Manager with default settings.
-func NewManager() *Manager {
+// NewManager creates a new netboot Manager with default settings. logSink may
+// be nil (e.g. in tests), in which case output is still captured for
+// GetLogs but never broadcast live.
+func NewManager(logSink LogSink) *Manager {
 	return &Manager{
 		address: "0.0.0.0",
 		port:    "8090",
+		logSink: logSink,
 	}
+}
+
+// logWriter tees a running command's output to the process's own
+// stdout/stderr (unchanged operational behaviour), into the Manager's bounded
+// snapshot buffer, and — line by line — to the live broadcaster.
+type logWriter struct {
+	m      *Manager
+	passOn io.Writer
+}
+
+func (w *logWriter) Write(p []byte) (int, error) {
+	w.m.mu.Lock()
+	if w.m.logBuf.Len()+len(p) > maxLogBytes {
+		// Drop the oldest bytes rather than the newest: a debugging session
+		// cares about what just happened, not the start of a long-idle server.
+		overflow := w.m.logBuf.Len() + len(p) - maxLogBytes
+		b := w.m.logBuf.Bytes()
+		w.m.logBuf.Reset()
+		if overflow < len(b) {
+			w.m.logBuf.Write(b[overflow:])
+		}
+	}
+	w.m.logBuf.Write(p)
+	sink := w.m.logSink
+	w.m.mu.Unlock()
+
+	if sink != nil {
+		sink.BroadcastNetbootLogChunk(string(p))
+	}
+	return w.passOn.Write(p)
 }
 
 // Start launches the netboot server for the given artifact.
@@ -60,8 +111,11 @@ func (m *Manager) Start(artifactsDir, artifactID string) error {
 	// AuroraBoot start-pixie args: <cloud-config> <squashfs> <address> <port> <initrd> <kernel>
 	// Use empty string for cloud-config (not required for netboot).
 	cmd := exec.Command("auroraboot", "start-pixie", "", squashfs, m.address, m.port, initrd, kernel)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	// A fresh session starts with a clean log: the previous run's output (if
+	// any) is no longer relevant to debugging this one.
+	m.logBuf.Reset()
+	cmd.Stdout = &logWriter{m: m, passOn: os.Stdout}
+	cmd.Stderr = &logWriter{m: m, passOn: os.Stderr}
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start netboot server: %w", err)
@@ -117,4 +171,13 @@ func (m *Manager) GetStatus() Status {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.status
+}
+
+// GetLogs returns a snapshot of the current (or most recently run) netboot
+// session's captured stdout/stderr, bounded to maxLogBytes. Empty before the
+// first Start call.
+func (m *Manager) GetLogs() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.logBuf.String()
 }

--- a/internal/netbootmgr/manager.go
+++ b/internal/netbootmgr/manager.go
@@ -56,7 +56,9 @@ func NewManager(logSink LogSink) *Manager {
 
 // logWriter tees a running command's output to the process's own
 // stdout/stderr (unchanged operational behaviour), into the Manager's bounded
-// snapshot buffer, and — line by line — to the live broadcaster.
+// snapshot buffer, and to the live broadcaster. Each Write() call forwards
+// its raw chunk as one broadcast; chunks are not split into lines, so a
+// broadcast can carry a partial line.
 type logWriter struct {
 	m      *Manager
 	passOn io.Writer

--- a/internal/netbootmgr/manager_test.go
+++ b/internal/netbootmgr/manager_test.go
@@ -1,0 +1,84 @@
+package netbootmgr
+
+import (
+	"strings"
+	"testing"
+)
+
+type fakeSink struct {
+	chunks []string
+}
+
+func (f *fakeSink) BroadcastNetbootLogChunk(chunk string) {
+	f.chunks = append(f.chunks, chunk)
+}
+
+func TestGetLogsEmptyBeforeStart(t *testing.T) {
+	m := NewManager(nil)
+	if got := m.GetLogs(); got != "" {
+		t.Errorf("GetLogs() before any Start = %q, want empty", got)
+	}
+}
+
+func TestLogWriterAppendsBroadcastsAndPassesThrough(t *testing.T) {
+	sink := &fakeSink{}
+	m := NewManager(sink)
+	var passOn strings.Builder
+	w := &logWriter{m: m, passOn: &passOn}
+
+	n, err := w.Write([]byte("dhcp: request from 00:11:22:33:44:55\n"))
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if n != len("dhcp: request from 00:11:22:33:44:55\n") {
+		t.Errorf("Write returned n=%d, want full length", n)
+	}
+
+	if got := m.GetLogs(); got != "dhcp: request from 00:11:22:33:44:55\n" {
+		t.Errorf("GetLogs() = %q, want the written chunk", got)
+	}
+	if passOn.String() != "dhcp: request from 00:11:22:33:44:55\n" {
+		t.Errorf("passOn writer = %q, want the written chunk", passOn.String())
+	}
+	if len(sink.chunks) != 1 || sink.chunks[0] != "dhcp: request from 00:11:22:33:44:55\n" {
+		t.Errorf("sink.chunks = %v, want a single matching chunk", sink.chunks)
+	}
+}
+
+func TestLogWriterNilSinkDoesNotPanic(t *testing.T) {
+	m := NewManager(nil)
+	w := &logWriter{m: m, passOn: &strings.Builder{}}
+	if _, err := w.Write([]byte("no sink wired\n")); err != nil {
+		t.Fatalf("Write returned error with a nil sink: %v", err)
+	}
+	if got := m.GetLogs(); got != "no sink wired\n" {
+		t.Errorf("GetLogs() = %q, want the written chunk even with no sink", got)
+	}
+}
+
+func TestLogWriterBoundsBufferToMaxLogBytes(t *testing.T) {
+	m := NewManager(nil)
+	w := &logWriter{m: m, passOn: &strings.Builder{}}
+
+	// Write well past the cap in two chunks, so the bound has to trim
+	// mid-buffer, not just refuse a single too-large write.
+	first := strings.Repeat("a", maxLogBytes-10)
+	second := strings.Repeat("b", 100)
+	if _, err := w.Write([]byte(first)); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if _, err := w.Write([]byte(second)); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	got := m.GetLogs()
+	if len(got) != maxLogBytes {
+		t.Fatalf("GetLogs() length = %d, want exactly maxLogBytes (%d)", len(got), maxLogBytes)
+	}
+	if !strings.HasSuffix(got, second) {
+		t.Errorf("GetLogs() should retain the most recent write in full")
+	}
+	if strings.Contains(got, "a") == false {
+		t.Errorf("GetLogs() should still retain some of the older content, not just the newest write")
+	}
+}

--- a/pkg/handlers/deploy.go
+++ b/pkg/handlers/deploy.go
@@ -208,6 +208,19 @@ func (h *DeployHandler) NetbootStatus(c echo.Context) error {
 	return c.JSON(http.StatusOK, h.netboot.GetStatus())
 }
 
+// NetbootLogs handles GET /api/v1/netboot/logs.
+//
+//	@Summary		Get netboot server log snapshot
+//	@Description	Returns the current (or most recent) PXE/netboot session's captured output as text/plain. For real-time updates subscribe to the UI WebSocket and filter {type:"netboot-log"} envelopes.
+//	@Tags			Netboot
+//	@Produce		plain
+//	@Security		AdminBearer
+//	@Success		200	{string}	string
+//	@Router			/api/v1/netboot/logs [get]
+func (h *DeployHandler) NetbootLogs(c echo.Context) error {
+	return c.String(http.StatusOK, h.netboot.GetLogs())
+}
+
 // --- RedFish deploy ---
 
 type deployRedfishRequest struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -353,6 +353,7 @@ func New(cfg Config) *echo.Echo {
 		adminGroup.POST("/netboot/start", deployHandler.StartNetboot)
 		adminGroup.POST("/netboot/stop", deployHandler.StopNetboot)
 		adminGroup.GET("/netboot/status", deployHandler.NetbootStatus)
+		adminGroup.GET("/netboot/logs", deployHandler.NetbootLogs)
 		adminGroup.POST("/artifacts/:id/deploy/redfish", deployHandler.DeployRedfish)
 		adminGroup.GET("/redfish/quirk-profiles", deployHandler.ListQuirkProfiles)
 		adminGroup.POST("/bmc-targets", deployHandler.CreateBMCTarget)

--- a/pkg/ws/hub.go
+++ b/pkg/ws/hub.go
@@ -160,6 +160,21 @@ func (h *UIHub) BroadcastLogChunk(buildID string, chunk string) {
 	})
 }
 
+// BroadcastNetbootLogChunk fans out a chunk of the PXE/netboot server's live
+// output to every connected UI client as a
+// {"type":"netboot-log","data":{"chunk":…}} envelope, so a client watching a
+// PXE boot in progress can see why it stalls or fails (kairos-io/kairos#4596).
+// There is at most one netboot session at a time (internal/netbootmgr.Manager
+// is a singleton), so unlike build-log there is no id to filter on.
+func (h *UIHub) BroadcastNetbootLogChunk(chunk string) {
+	h.Broadcast(map[string]any{
+		"type": "netboot-log",
+		"data": map[string]any{
+			"chunk": chunk,
+		},
+	})
+}
+
 // IsOnline returns true if the node has an active WebSocket connection.
 func (h *Hub) IsOnline(nodeID string) bool {
 	h.mu.RLock()

--- a/ui/src/api/deployments.ts
+++ b/ui/src/api/deployments.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "./client";
+import { apiFetch, apiFetchText } from "./client";
 
 // EjectState is the finalize/eject lifecycle of a deployment. "" means the
 // deployment is not armed for eject (policy off); the rest track the auto/manual
@@ -206,6 +206,12 @@ export const startNetboot = (artifactId: string) =>
     method: "POST",
     body: JSON.stringify({ artifactId }),
   });
+
+// getNetbootLogs fetches a snapshot of the current (or most recent) PXE
+// session's captured output. For live updates, subscribe to the UI
+// WebSocket and filter {type: "netboot-log"} envelopes.
+export const getNetbootLogs = (): Promise<string> =>
+  apiFetchText("/api/v1/netboot/logs");
 
 export const stopNetboot = () =>
   apiFetch("/api/v1/netboot/stop", { method: "POST" });

--- a/ui/src/components/DeployDialog.tsx
+++ b/ui/src/components/DeployDialog.tsx
@@ -63,6 +63,12 @@ export function DeployDialog({
   const [pxeLoading, setPxeLoading] = useState(false);
   const [netbootLogs, setNetbootLogs] = useState("");
   const logPaneRef = useRef<HTMLPreElement | null>(null);
+  // Bumped whenever a new netboot session starts, so a getNetbootLogs()
+  // response from before Start (or from a stale reconnect resync) can be
+  // told apart from the current session and dropped instead of overwriting
+  // a freshly-cleared pane (kairos-io/AuroraBoot#806 review).
+  const netbootEpochRef = useRef(0);
+  const netbootStatusRef = useRef<NetbootStatus | null>(null);
 
   // RedFish state
   const [bmcTargets, setBmcTargets] = useState<BMCTarget[]>([]);
@@ -110,7 +116,12 @@ export function DeployDialog({
   useEffect(() => {
     if (hasNetboot) {
       getNetbootStatus().then(setNetbootStatus).catch(() => {});
-      getNetbootLogs().then(setNetbootLogs).catch(() => {});
+      const epoch = netbootEpochRef.current;
+      getNetbootLogs()
+        .then((text) => {
+          if (netbootEpochRef.current === epoch) setNetbootLogs(text);
+        })
+        .catch(() => {});
     }
     if (hasIso) {
       listBMCTargets().then(setBmcTargets).catch(() => {});
@@ -118,16 +129,38 @@ export function DeployDialog({
     }
   }, [hasNetboot, hasIso]);
 
+  useEffect(() => {
+    netbootStatusRef.current = netbootStatus;
+  });
+
   // Live PXE server output (kairos-io/kairos#4596): the snapshot fetch above
   // gets you caught up, this keeps you live while the dialog is open. There
   // is at most one netboot session at a time, so every chunk belongs to the
   // session currently shown here — no id to filter on.
-  useUIWebSocket((msg) => {
+  const { connected: wsConnected } = useUIWebSocket((msg) => {
     if (msg.type !== "netboot-log" || !hasNetboot) return;
     const data = msg.data as { chunk?: string };
     if (!data.chunk) return;
     setNetbootLogs((prev) => prev + data.chunk);
   });
+
+  // Re-sync the log snapshot once per WebSocket (re)connection, the same
+  // pattern ArtifactDetail uses for build logs: a drop that misses live
+  // chunks would otherwise leave the pane silently incomplete. Guarded by
+  // the same epoch as the initial fetch, so a resync racing a fresh Start
+  // can't overwrite it either.
+  const lastWsConnected = useRef(false);
+  useEffect(() => {
+    const justConnected = wsConnected && !lastWsConnected.current;
+    lastWsConnected.current = wsConnected;
+    if (!justConnected || !hasNetboot || !netbootStatusRef.current?.running) return;
+    const epoch = netbootEpochRef.current;
+    getNetbootLogs()
+      .then((text) => {
+        if (netbootEpochRef.current === epoch) setNetbootLogs(text);
+      })
+      .catch(() => {});
+  }, [wsConnected, hasNetboot]);
 
   // Auto-scroll the log pane to the newest line as chunks arrive.
   useEffect(() => {
@@ -186,6 +219,9 @@ export function DeployDialog({
       } else {
         // A fresh session gets a fresh pane: the server resets its own log
         // buffer on Start, so stale text from a previous run must not linger.
+        // Bump the epoch first so any in-flight getNetbootLogs() response
+        // from before this Start is recognized as stale and dropped.
+        netbootEpochRef.current += 1;
         setNetbootLogs("");
         await startNetboot(artifactId);
       }

--- a/ui/src/components/DeployDialog.tsx
+++ b/ui/src/components/DeployDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import {
   Dialog,
@@ -35,6 +35,16 @@ import {
 } from "@/api/deployments";
 import { type QuirkProfile, listQuirkProfiles } from "@/api/redfish";
 import { useUIWebSocket } from "@/hooks/useUIWebSocket";
+import { ansiToHtml } from "@/lib/ansi";
+
+// Memoized per-line renderer, same reasoning as ArtifactDetail's build-log
+// LogLine: a live netboot session appends one chunk at a time, and without
+// memo every chunk would re-run ansiToHtml over every prior line.
+const NetbootLogLine = memo(function NetbootLogLine({ line }: { line: string }) {
+  return (
+    <div dangerouslySetInnerHTML={{ __html: ansiToHtml(line) || "&nbsp;" }} />
+  );
+});
 
 // Minimum hardware AuroraBoot wants before deploying. Kept deliberately simple
 // and visible: a node below either threshold raises a warning that the operator
@@ -62,7 +72,7 @@ export function DeployDialog({
   const [netbootStatus, setNetbootStatus] = useState<NetbootStatus | null>(null);
   const [pxeLoading, setPxeLoading] = useState(false);
   const [netbootLogs, setNetbootLogs] = useState("");
-  const logPaneRef = useRef<HTMLPreElement | null>(null);
+  const logPaneRef = useRef<HTMLDivElement | null>(null);
   // Bumped whenever a new netboot session starts, so a getNetbootLogs()
   // response from before Start (or from a stale reconnect resync) can be
   // told apart from the current session and dropped instead of overwriting
@@ -132,6 +142,14 @@ export function DeployDialog({
   useEffect(() => {
     netbootStatusRef.current = netbootStatus;
   });
+
+  // Pre-split once per update so ansiToHtml runs per-line (SGR color state
+  // from one line must not bleed into the next) instead of over the whole
+  // buffer.
+  const netbootLogLines = useMemo(
+    () => (netbootLogs ? netbootLogs.split("\n") : []),
+    [netbootLogs],
+  );
 
   // Live PXE server output (kairos-io/kairos#4596): the snapshot fetch above
   // gets you caught up, this keeps you live while the dialog is open. There
@@ -326,12 +344,14 @@ export function DeployDialog({
                       <span className="text-xs text-muted-foreground">live</span>
                     )}
                   </div>
-                  <pre
+                  <div
                     ref={logPaneRef}
                     className="text-xs font-mono bg-muted/50 rounded-b-md p-3 max-h-64 overflow-y-auto overflow-x-auto whitespace-pre-wrap"
                   >
-                    {netbootLogs}
-                  </pre>
+                    {netbootLogLines.map((line, i) => (
+                      <NetbootLogLine key={i} line={line} />
+                    ))}
+                  </div>
                 </div>
               )}
             </TabsContent>

--- a/ui/src/components/DeployDialog.tsx
+++ b/ui/src/components/DeployDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 import {
   Dialog,
@@ -31,8 +31,10 @@ import {
   getNetbootStatus,
   startNetboot,
   stopNetboot,
+  getNetbootLogs,
 } from "@/api/deployments";
 import { type QuirkProfile, listQuirkProfiles } from "@/api/redfish";
+import { useUIWebSocket } from "@/hooks/useUIWebSocket";
 
 // Minimum hardware AuroraBoot wants before deploying. Kept deliberately simple
 // and visible: a node below either threshold raises a warning that the operator
@@ -59,6 +61,8 @@ export function DeployDialog({
   // PXE state
   const [netbootStatus, setNetbootStatus] = useState<NetbootStatus | null>(null);
   const [pxeLoading, setPxeLoading] = useState(false);
+  const [netbootLogs, setNetbootLogs] = useState("");
+  const logPaneRef = useRef<HTMLPreElement | null>(null);
 
   // RedFish state
   const [bmcTargets, setBmcTargets] = useState<BMCTarget[]>([]);
@@ -106,12 +110,30 @@ export function DeployDialog({
   useEffect(() => {
     if (hasNetboot) {
       getNetbootStatus().then(setNetbootStatus).catch(() => {});
+      getNetbootLogs().then(setNetbootLogs).catch(() => {});
     }
     if (hasIso) {
       listBMCTargets().then(setBmcTargets).catch(() => {});
       listQuirkProfiles().then(setProfiles).catch(() => {});
     }
   }, [hasNetboot, hasIso]);
+
+  // Live PXE server output (kairos-io/kairos#4596): the snapshot fetch above
+  // gets you caught up, this keeps you live while the dialog is open. There
+  // is at most one netboot session at a time, so every chunk belongs to the
+  // session currently shown here — no id to filter on.
+  useUIWebSocket((msg) => {
+    if (msg.type !== "netboot-log" || !hasNetboot) return;
+    const data = msg.data as { chunk?: string };
+    if (!data.chunk) return;
+    setNetbootLogs((prev) => prev + data.chunk);
+  });
+
+  // Auto-scroll the log pane to the newest line as chunks arrive.
+  useEffect(() => {
+    const el = logPaneRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [netbootLogs]);
 
   // Poll netboot status while running
   useEffect(() => {
@@ -162,6 +184,9 @@ export function DeployDialog({
       if (netbootStatus?.running) {
         await stopNetboot();
       } else {
+        // A fresh session gets a fresh pane: the server resets its own log
+        // buffer on Start, so stale text from a previous run must not linger.
+        setNetbootLogs("");
         await startNetboot(artifactId);
       }
       const status = await getNetbootStatus();
@@ -250,6 +275,29 @@ export function DeployDialog({
                   {netbootStatus?.running ? "Stop Netboot" : "Start Netboot"}
                 </Button>
               </div>
+
+              {/* Live PXE server log, so a stalled/failed boot is debuggable
+                  instead of just a status badge (kairos-io/kairos#4596). Shown
+                  once a session has produced any output, and kept visible
+                  after Stop so a failure can still be read back. */}
+              {netbootLogs && (
+                <div className="rounded-md border">
+                  <div className="flex items-center justify-between px-3 py-2 border-b">
+                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Netboot Log
+                    </span>
+                    {netbootStatus?.running && (
+                      <span className="text-xs text-muted-foreground">live</span>
+                    )}
+                  </div>
+                  <pre
+                    ref={logPaneRef}
+                    className="text-xs font-mono bg-muted/50 rounded-b-md p-3 max-h-64 overflow-y-auto overflow-x-auto whitespace-pre-wrap"
+                  >
+                    {netbootLogs}
+                  </pre>
+                </div>
+              )}
             </TabsContent>
           )}
 

--- a/ui/src/test/deployDialog.netbootLogs.test.tsx
+++ b/ui/src/test/deployDialog.netbootLogs.test.tsx
@@ -100,4 +100,35 @@ describe("DeployDialog: netboot log pane", () => {
     wsOnMessage!({ type: "build-log", data: { id: "x", chunk: "unrelated\n" } });
     expect(screen.queryByText(/unrelated/)).not.toBeInTheDocument();
   });
+
+  it("renders ANSI color codes as terminal output instead of raw escape bytes (kairos-io/AuroraBoot#806)", async () => {
+    render(
+      <MemoryRouter>
+        <DeployDialog
+          artifactId="artifact-1"
+          artifactFiles={["kairos.squashfs"]}
+          hasNetboot={true}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/dhcp: server started/)).toBeInTheDocument();
+    });
+
+    const ESC = "";
+    wsOnMessage!({
+      type: "netboot-log",
+      data: { chunk: `${ESC}[32mtftp: sent kairos-kernel${ESC}[0m\n` },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/tftp: sent kairos-kernel/)).toBeInTheDocument();
+    });
+    // The raw escape sequence must not land in the DOM as literal text.
+    expect(document.body.textContent).not.toContain(`${ESC}[32m`);
+    // ansiToHtml renders SGR color codes as a styled span, not plain text.
+    expect(document.body.innerHTML).toMatch(/<span style="[^"]*">tftp: sent kairos-kernel<\/span>/);
+  });
 });

--- a/ui/src/test/deployDialog.netbootLogs.test.tsx
+++ b/ui/src/test/deployDialog.netbootLogs.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+vi.mock("@/api/deployments", async () => {
+  const actual = await vi.importActual<typeof import("@/api/deployments")>(
+    "@/api/deployments",
+  );
+  return {
+    ...actual,
+    getNetbootStatus: vi.fn(async () => ({
+      running: true,
+      artifactId: "artifact-1",
+      address: "0.0.0.0",
+      port: "8090",
+    })),
+    getNetbootLogs: vi.fn(async () => "dhcp: server started\n"),
+    startNetboot: vi.fn(async () => ({})),
+    stopNetboot: vi.fn(async () => ({})),
+    listBMCTargets: vi.fn(async () => []),
+  };
+});
+
+vi.mock("@/api/redfish", () => ({
+  listQuirkProfiles: vi.fn(async () => []),
+}));
+
+// Captures the onMessage callback so the test can simulate a live WS chunk
+// without standing up a real WebSocket (jsdom has none by default).
+let wsOnMessage: ((msg: { type: string; data: unknown }) => void) | null = null;
+vi.mock("@/hooks/useUIWebSocket", () => ({
+  useUIWebSocket: (onMessage: (msg: { type: string; data: unknown }) => void) => {
+    wsOnMessage = onMessage;
+    return { connected: true };
+  },
+}));
+
+import { DeployDialog } from "@/components/DeployDialog";
+
+beforeEach(() => {
+  wsOnMessage = null;
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe("DeployDialog: netboot log pane", () => {
+  it("shows the snapshot log and appends live WS chunks", async () => {
+    render(
+      <MemoryRouter>
+        <DeployDialog
+          artifactId="artifact-1"
+          artifactFiles={["kairos.squashfs"]}
+          hasNetboot={true}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/dhcp: server started/)).toBeInTheDocument();
+    });
+
+    expect(wsOnMessage).not.toBeNull();
+    wsOnMessage!({ type: "netboot-log", data: { chunk: "tftp: sent kairos-kernel\n" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/tftp: sent kairos-kernel/)).toBeInTheDocument();
+    });
+    // The snapshot line is still there — live chunks append, they don't replace.
+    expect(screen.getByText(/dhcp: server started/)).toBeInTheDocument();
+  });
+
+  it("ignores WS messages of a different type", async () => {
+    render(
+      <MemoryRouter>
+        <DeployDialog
+          artifactId="artifact-1"
+          artifactFiles={["kairos.squashfs"]}
+          hasNetboot={true}
+          onClose={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/dhcp: server started/)).toBeInTheDocument();
+    });
+
+    wsOnMessage!({ type: "build-log", data: { id: "x", chunk: "unrelated\n" } });
+    expect(screen.queryByText(/unrelated/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes kairos-io/kairos#4596 in part.

**Scope note up front:** this closes the half of the problem AuroraBoot can
see today. The netboot server's own output (DHCP requests, TFTP/HTTP file
serves, why it fails to hand a node its files) is now captured and streamed
to the UI. What happens on the node *after* it has the kernel/initrd — a
boot or install failure past the PXE handoff — is not visible anywhere
server-side yet (no console/serial capture, no early-boot phone-home); that
would be a materially larger follow-up, not something this PR attempts.

**What changed:**
- `internal/netbootmgr`: the `start-pixie` subprocess's stdout/stderr, which
  previously went straight to the AuroraBoot process's own output and
  nowhere else, is now teed into a bounded (256 KiB) per-session buffer and
  broadcast live, reusing the existing build-log WS pattern rather than
  inventing a new one.
- New `GET /api/v1/netboot/logs` snapshot endpoint (mirrors
  `GET /api/v1/artifacts/:id/logs`).
- New `{"type":"netboot-log","data":{"chunk":...}}` WS envelope (mirrors
  `build-log`; no id needed since there is at most one netboot session at a
  time).
- Deploy dialog's PXE tab: a log pane appears once a session has produced
  output, shows the snapshot, then appends live chunks, and stays visible
  after Stop so a failure is still readable.

## Test plan

- `go build ./...`, `go vet ./pkg/... ./internal/...` clean.
- `go test ./pkg/... ./internal/store/... ./internal/netbootmgr/...` — all
  pass, including new unit tests for the log buffer (bounding, broadcast
  fan-out, nil-sink safety).
- Regenerated `docs/swagger.json`/`swagger.yaml`/`docs.go` via `make openapi`.
- `npm run build` (tsc + vite), `npx vitest run` (58/58, including a new
  test for the log pane's snapshot-then-live-append behavior), `npx eslint`
  all pass on the `ui/` side.

---

An unattended agent opened this pull request. Nobody has reviewed the diff yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181oEMJkcj7xr62r5RgzTNf
