### PR TITLE
fix(ui): show the real server URL in the cloud-config preview

### DIFF
--- a/ui/src/lib/cloudConfigPreview.test.ts
+++ b/ui/src/lib/cloudConfigPreview.test.ts
@@ -7,6 +7,7 @@ import { PHONEHOME_SAFE_DEFAULTS } from "./buildConfig";
 const base: Parameters<typeof buildCloudConfigPreview>[0] = {
   autoInstall: true,
   registerAuroraBoot: true,
+  serverURL: "https://fleet.example.com",
   groupName: "production",
   allowedCommands: [...PHONEHOME_SAFE_DEFAULTS],
   variant: "standard",
@@ -87,5 +88,18 @@ describe("buildCloudConfigPreview", () => {
       extraYAML: `${protoKey}:\n  polluted: true\nk3s:\n  enabled: false`,
     });
     expect(Object.prototype).not.toHaveProperty("polluted");
+  });
+
+  it("shows the real server URL in phonehome, but keeps the token masked", () => {
+    const doc = docBody(buildCloudConfigPreview(base));
+    const phonehome = doc.phonehome as Record<string, unknown>;
+    expect(phonehome.url).toBe("https://fleet.example.com");
+    expect(phonehome.registration_token).toBe("<token>");
+  });
+
+  it("falls back to a placeholder URL when the caller couldn't determine one", () => {
+    const doc = docBody(buildCloudConfigPreview({ ...base, serverURL: "" }));
+    const phonehome = doc.phonehome as Record<string, unknown>;
+    expect(phonehome.url).toBe("<server-url>");
   });
 });

--- a/ui/src/lib/cloudConfigPreview.ts
+++ b/ui/src/lib/cloudConfigPreview.ts
@@ -6,6 +6,12 @@ type YamlValue = unknown;
 export interface CloudConfigPreviewInput {
   autoInstall: boolean;
   registerAuroraBoot: boolean;
+  // The externally reachable URL this AuroraBoot instance registers nodes
+  // against (AURORABOOT_URL server-side). Shown as-is in the preview -- it's
+  // not a secret, and hiding it made a real http-vs-https misconfiguration
+  // undebuggable from the UI. Falls back to a placeholder only if the caller
+  // couldn't determine it.
+  serverURL: string;
   groupName: string;
   allowedCommands: readonly string[];
   variant: string;
@@ -71,7 +77,7 @@ export function buildCloudConfigPreview(input: CloudConfigPreviewInput): string 
 
   if (input.registerAuroraBoot) {
     doc.phonehome = {
-      url: "<server-url>",
+      url: input.serverURL || "<server-url>",
       registration_token: "<token>",
       group: input.groupName,
       allowed_commands: [...input.allowedCommands],

--- a/ui/src/pages/ArtifactBuilder.tsx
+++ b/ui/src/pages/ArtifactBuilder.tsx
@@ -1047,6 +1047,11 @@ export function ArtifactBuilder() {
     return buildCloudConfigPreview({
       autoInstall: form.provisioning.autoInstall,
       registerAuroraBoot: form.provisioning.registerAuroraBoot,
+      // Single-URL deployments (the common case) serve the dashboard from
+      // the same external URL nodes register against -- see AURORABOOT_URL
+      // server-side. Good enough for a preview; the backend remains the
+      // source of truth at build time.
+      serverURL: window.location.origin,
       groupName,
       allowedCommands: form.provisioning.allowedCommands ?? [],
       variant: form.variant,


### PR DESCRIPTION
The Review-step cloud-config preview (`ui/src/lib/cloudConfigPreview.ts`) hardcoded `phonehome.url` as the literal string `"<server-url>"`, regardless of what `AURORABOOT_URL` the running instance actually has configured. Masking `registration_token` makes sense (it's a credential). Masking the plain server URL doesn't, and it made a real `http://` vs `https://` misconfiguration undebuggable from the dashboard — found this the hard way tonight, standing up a new fleet instance: the only way to confirm what actually got baked into a built artifact was inspecting its files directly on disk after the fact.

Passes `window.location.origin` from the call site instead — correct for the common single-URL deployment where the dashboard and the registration endpoint are the same host. Falls back to the old placeholder if a caller can't determine one.

Added two tests: the real URL flows through, and the fallback still works when `serverURL` is empty. `npx vitest run` and `npx tsc --noEmit` both clean.

This is not an agent, Mauro used AI to help write this.
