### PR TITLE
fix(cmd): stop the empty-cloud-config-file test hanging CI

### DIFF
--- a/internal/cmd/start-pixie.go
+++ b/internal/cmd/start-pixie.go
@@ -51,15 +51,10 @@ Example:
 		initrdFile := c.Args().Get(4)
 		kernelFile := c.Args().Get(5)
 
-		// Simple argument validation. cloudConfigFile is allowed to be empty:
-		// it becomes config_url in the boot cmdline (pkg/ops/netboot.go), and
-		// an empty config_url is valid when the image doesn't need one fetched
-		// at netboot time -- the netboot manager relies on this (see
-		// internal/netbootmgr/manager.go's Start).
-		if squashFSfile == "" || address == "" || netbootPort == "" || initrdFile == "" || kernelFile == "" {
+		if err := ValidateStartPixieArgs(squashFSfile, address, netbootPort, initrdFile, kernelFile); err != nil {
 			cli.ShowCommandHelp(c, c.Command.Name)
 			fmt.Println("")
-			return fmt.Errorf("all arguments except cloud-config-file are required")
+			return err
 		}
 
 		loglevel := "info"
@@ -89,4 +84,18 @@ Example:
 
 		return f(c.Context)
 	},
+}
+
+// ValidateStartPixieArgs checks the required positional arguments.
+// cloudConfigFile is deliberately not one of them: it becomes config_url in
+// the boot cmdline (pkg/ops/netboot.go), and an empty config_url is valid
+// when the image doesn't need one fetched at netboot time -- the netboot
+// manager relies on this (see internal/netbootmgr/manager.go's Start).
+// Split out from Action so it can be unit-tested without going anywhere near
+// the real server start, which binds a raw socket and blocks on network I/O.
+func ValidateStartPixieArgs(squashFSfile, address, netbootPort, initrdFile, kernelFile string) error {
+	if squashFSfile == "" || address == "" || netbootPort == "" || initrdFile == "" || kernelFile == "" {
+		return fmt.Errorf("all arguments except cloud-config-file are required")
+	}
+	return nil
 }

--- a/internal/cmd/start-pixie_test.go
+++ b/internal/cmd/start-pixie_test.go
@@ -2,8 +2,6 @@ package cmd_test
 
 import (
 	"bytes"
-	"context"
-	"time"
 
 	cmdpkg "github.com/kairos-io/AuroraBoot/internal/cmd"
 	. "github.com/onsi/ginkgo/v2"
@@ -35,17 +33,14 @@ var _ = Describe("start-pixie", Label("pixie", "cmd"), func() {
 	})
 
 	It("does not fail validation when cloud-config-file is empty", func() {
-		// A real run would go on to bind the netboot server; bound it with a
-		// short-lived context so the test can't hang, and only assert on
-		// which error came back, not on the server actually starting.
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
-		err = app.RunContext(ctx, []string{
-			"", "start-pixie",
-			"", "rootfs.squashfs", "127.0.0.1", "0", "initrd.img", "vmlinuz",
-		})
-		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).ToNot(ContainSubstring("all arguments except cloud-config-file are required"))
+		// Exercises ValidateStartPixieArgs directly -- cloud-config-file isn't
+		// one of its parameters at all, so there's nothing to pass for it.
+		// Deliberately does NOT go through app.Run/RunContext: past that
+		// point Action binds a real raw socket and blocks on network I/O,
+		// which a context timeout does not reliably interrupt (it didn't on
+		// CI, where the bind succeeds and the test hung for two hours).
+		err := cmdpkg.ValidateStartPixieArgs("rootfs.squashfs", "127.0.0.1", "0", "initrd.img", "vmlinuz")
+		Expect(err).To(BeNil())
 	})
 
 	It("shows help output", func() {


### PR DESCRIPTION
Fixes the CI failure on `unit-tests` — the regression test I added in #803 for accepting an empty `cloud-config-file` hung for the full 2-hour Ginkgo suite timeout: https://github.com/kairos-io/AuroraBoot/actions/runs/34519972825/job/103015153254

## What went wrong

The test relied on `context.WithTimeout` to interrupt the real netboot server start once validation passed:

```go
ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
err = app.RunContext(ctx, []string{...})
```

That's not reliable. On CI, the DHCP-proxy raw-socket bind apparently succeeds, and the subsequent read blocks on real network I/O that the context never actually cancels. On my own dev box the bind must have failed fast for an unrelated reason, which made the test look correct locally — it never actually exercised the cancellation path it depended on.

## Fix

Split the five required positional arguments' validation out of `Action` into `ValidateStartPixieArgs`, and test that directly. No server start anywhere near the test now — nothing left to hang on. Ran the full `internal/cmd` suite locally under a hard `timeout 60`, twice, both times 42/42 passing in under 5 seconds.

This is not an agent, Mauro used AI to help write this.
