### PR TITLE
fix(netboot): share state between build-triggered and dashboard netboot starts

### DIFF
--- a/deployer/steps.go
+++ b/deployer/steps.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/kairos-io/AuroraBoot/internal/netbootmgr"
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
 
 	"github.com/kairos-io/AuroraBoot/pkg/ops"
@@ -207,9 +208,20 @@ func (d *Deployer) StepStartNetboot() error {
 		herd.EnableIf(d.netbootOption),
 		herd.Background,
 		herd.WithDeps(constants.OpExtractNetboot, constants.OpCopyCloudConfig),
-		herd.WithCallback(
-			ops.StartPixiecore(d.cloudConfigPath(), d.netBootListenAddr(), d.netbootPort(), d.squashFSfile, d.initrdFile, d.kernelFile, d.Config.NetBoot),
-		),
+		herd.WithCallback(func(ctx context.Context) error {
+			// The server threads its netbootmgr.Manager through the context
+			// (see internal/cmd/web.go); the CLI never does. When present,
+			// route through it so this build-triggered start shares the same
+			// state as the dashboard's Start/Stop/Status endpoints -- without
+			// this, a build with the netboot output enabled silently starts a
+			// server the UI has no way to see or stop, and a later manual
+			// "Start Netboot" collides with it on the same port instead of
+			// reporting "already running".
+			if mgr := netbootmgr.FromContext(ctx); mgr != nil {
+				return mgr.StartWithPaths(filepath.Base(d.destination()), d.cloudConfigPath(), d.squashFSfile(), d.initrdFile(), d.kernelFile())
+			}
+			return ops.StartPixiecore(d.cloudConfigPath(), d.netBootListenAddr(), d.netbootPort(), d.squashFSfile, d.initrdFile, d.kernelFile, d.Config.NetBoot)(ctx)
+		}),
 	)
 }
 

--- a/internal/builder/auroraboot/builder.go
+++ b/internal/builder/auroraboot/builder.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kairos-io/AuroraBoot/deployer"
+	"github.com/kairos-io/AuroraBoot/internal/netbootmgr"
 	"github.com/kairos-io/AuroraBoot/pkg/builder"
 	"github.com/kairos-io/AuroraBoot/pkg/constants"
 	"github.com/kairos-io/AuroraBoot/pkg/schema"
@@ -77,6 +78,7 @@ type Builder struct {
 	ukiBuildFn     UKIBuildFunc
 	store          store.ArtifactStore
 	logBroadcaster builder.LogBroadcaster
+	netbootManager *netbootmgr.Manager
 }
 
 type buildState struct {
@@ -158,6 +160,17 @@ func (b *Builder) WithUKIBuildFunc(fn UKIBuildFunc) *Builder {
 // the builder package doesn't have to import ws.
 func (b *Builder) WithLogBroadcaster(lb builder.LogBroadcaster) *Builder {
 	b.logBroadcaster = lb
+	return b
+}
+
+// WithNetbootManager attaches the server's shared netboot Manager, threaded
+// into the deploy context so a build with the netboot output enabled starts
+// its server through the same state the dashboard's Start/Stop/Status
+// endpoints use, instead of one the UI has no way to see or stop. The CLI
+// never sets this, and StepStartNetboot falls back to its previous
+// behavior when it's absent.
+func (b *Builder) WithNetbootManager(m *netbootmgr.Manager) *Builder {
+	b.netbootManager = m
 	return b
 }
 
@@ -353,6 +366,9 @@ func (b *Builder) run(ctx context.Context, bs *buildState, opts builder.BuildOpt
 	var sink io.Writer
 	if logWriter != nil {
 		sink = logWriter
+	}
+	if b.netbootManager != nil {
+		ctx = netbootmgr.WithManager(ctx, b.netbootManager)
 	}
 	if err := b.deployFunc(ctx, config, artifact, outputDir, sink); err != nil {
 		msg := fmt.Sprintf("auroraboot failed: %v", err)

--- a/internal/cmd/web.go
+++ b/internal/cmd/web.go
@@ -217,12 +217,19 @@ func runWeb(c *cli.Context) error {
 	// handed to server.New below so the HTTP routes share it.
 	wsHub := ws.NewHub()
 
+	// Read --url again rather than passing externalURL: the fallback above
+	// rewrites externalURL to this container's own hostname, which is exactly
+	// the value nodes cannot resolve. With no --url the manager is better off
+	// finding a local interface address itself.
+	netbootManager := netbootmgr.NewManager(c.String("url"))
+
 	var artifactBuilder builder.ArtifactBuilder
 	var systemInfo handlers.APISystemBuilder
 	switch builderKind {
 	case "local":
 		artifactBuilder = auroraboot.New(artifactsDir, nil, artifactStore).
-			WithLogBroadcaster(wsHub.UI)
+			WithLogBroadcaster(wsHub.UI).
+			WithNetbootManager(netbootManager)
 		systemInfo = handlers.APISystemBuilder{
 			Backend:           "local",
 			DownloadSupported: true,
@@ -281,12 +288,6 @@ func runWeb(c *cli.Context) error {
 	deploymentStore := &gormstore.DeploymentStoreAdapter{S: store}
 	bmcTargetStore := &gormstore.BMCTargetStoreAdapter{S: store}
 	settingsStore := &gormstore.SettingsStoreAdapter{S: store}
-
-	// Read --url again rather than passing externalURL: the fallback above
-	// rewrites externalURL to this container's own hostname, which is exactly
-	// the value nodes cannot resolve. With no --url the manager is better off
-	// finding a local interface address itself.
-	netbootManager := netbootmgr.NewManager(c.String("url"))
 
 	// Optional Redfish ISO-serve: serves a local artifact ISO over a tokenized,
 	// BMC-reachable URL so virtual-media (URL-pull) deploys work without an

--- a/internal/netbootmgr/manager.go
+++ b/internal/netbootmgr/manager.go
@@ -1,6 +1,7 @@
 package netbootmgr
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -10,6 +11,27 @@ import (
 	"strings"
 	"sync"
 )
+
+// managerContextKey is unexported so only this package can set or read the
+// value it names -- callers use WithManager/FromContext instead.
+type managerContextKey struct{}
+
+// WithManager returns a copy of ctx carrying m, retrievable with FromContext.
+// The deployer's netboot step (deployer/steps.go's StepStartNetboot) uses
+// this to route an artifact-build-triggered netboot start through the same
+// Manager the dashboard's Start/Stop/Status endpoints use, instead of
+// starting a server the UI has no way to see or stop -- see
+// mission-control's incident notes on the two code paths not sharing state.
+func WithManager(ctx context.Context, m *Manager) context.Context {
+	return context.WithValue(ctx, managerContextKey{}, m)
+}
+
+// FromContext returns the Manager stored by WithManager, or nil if none was
+// set -- the normal case for the CLI, which has no dashboard to keep in sync.
+func FromContext(ctx context.Context) *Manager {
+	m, _ := ctx.Value(managerContextKey{}).(*Manager)
+	return m
+}
 
 // bindAddress is the address the netboot server listens on. It is a wildcard
 // because the server has to answer PXE clients on whichever interface they
@@ -122,13 +144,6 @@ func localIPv4() string {
 // It looks for kairos-kernel, kairos-initrd, and kairos.squashfs
 // in <artifactsDir>/<artifactID>/netboot/.
 func (m *Manager) Start(artifactsDir, artifactID string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if m.status.Running {
-		return fmt.Errorf("netboot server is already running")
-	}
-
 	netbootDir := filepath.Join(artifactsDir, artifactID, "netboot")
 
 	kernel := filepath.Join(netbootDir, "kairos-kernel")
@@ -151,6 +166,23 @@ func (m *Manager) Start(artifactsDir, artifactID string) error {
 	cloudConfig := ""
 	if cfgPath := filepath.Join(artifactsDir, artifactID, "config.yaml"); fileExists(cfgPath) {
 		cloudConfig = cfgPath
+	}
+
+	return m.StartWithPaths(artifactID, cloudConfig, squashfs, initrd, kernel)
+}
+
+// StartWithPaths launches the netboot server from already-resolved file
+// paths, bypassing the <artifactsDir>/<artifactID>/netboot/ convention Start
+// assumes. artifactID is used only for Status.ArtifactID; it need not be a
+// real artifact store ID. Exported so a caller with its own paths in hand
+// (deployer/steps.go's StepStartNetboot, via WithManager/FromContext) can
+// still register with this Manager's shared state -- see WithManager's doc.
+func (m *Manager) StartWithPaths(artifactID, cloudConfig, squashfs, initrd, kernel string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.status.Running {
+		return fmt.Errorf("netboot server is already running")
 	}
 
 	// AuroraBoot start-pixie args: <cloud-config> <squashfs> <address> <port> <initrd> <kernel>

--- a/internal/netbootmgr/manager_test.go
+++ b/internal/netbootmgr/manager_test.go
@@ -1,11 +1,26 @@
 package netbootmgr
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestWithManagerRoundTrips(t *testing.T) {
+	m := NewManager("")
+	ctx := WithManager(context.Background(), m)
+	if got := FromContext(ctx); got != m {
+		t.Errorf("FromContext = %v, want the Manager passed to WithManager", got)
+	}
+}
+
+func TestFromContextWithNoManagerSetReturnsNil(t *testing.T) {
+	if got := FromContext(context.Background()); got != nil {
+		t.Errorf("FromContext on a plain context = %v, want nil", got)
+	}
+}
 
 func TestHostFromURL(t *testing.T) {
 	cases := []struct {
@@ -138,5 +153,46 @@ func TestStartStillBindsTheWildcardWhenAdvertisingALocalAddress(t *testing.T) {
 	}
 	if s.AdvertisedAddress != advertisedHost("") {
 		t.Errorf("AdvertisedAddress = %q, want %q", s.AdvertisedAddress, advertisedHost(""))
+	}
+}
+
+// TestStartWithPathsSharesStateWithStart exists because StepStartNetboot
+// (deployer/steps.go) has its own already-resolved file paths and calls this
+// method directly, bypassing the <artifactsDir>/<artifactID>/netboot/
+// convention Start assumes. The point of StartWithPaths existing at all is
+// that this routes through the same Status/mutex Start does, so a build's
+// auto-started netboot server is visible to, and stoppable from, the same
+// dashboard endpoints a manually-started one is.
+func TestStartWithPathsSharesStateWithStart(t *testing.T) {
+	stubAuroraboot(t)
+	artifactsDir, artifactID := fakeNetbootArtifacts(t)
+	netbootDir := filepath.Join(artifactsDir, artifactID, "netboot")
+
+	m := NewManager("")
+	err := m.StartWithPaths(
+		artifactID,
+		"", // no cloud-config attached
+		filepath.Join(netbootDir, "kairos.squashfs"),
+		filepath.Join(netbootDir, "kairos-initrd"),
+		filepath.Join(netbootDir, "kairos-kernel"),
+	)
+	if err != nil {
+		t.Fatalf("StartWithPaths: %v", err)
+	}
+	defer func() { _ = m.Stop() }()
+
+	s := m.GetStatus()
+	if !s.Running {
+		t.Fatal("Running = false after a successful StartWithPaths")
+	}
+	if s.ArtifactID != artifactID {
+		t.Errorf("ArtifactID = %q, want %q", s.ArtifactID, artifactID)
+	}
+
+	// Same guard Start has: a second start while one is already running is
+	// rejected, not queued or silently collided with -- this is the bug that
+	// prompted StartWithPaths to exist, reproduced directly.
+	if err := m.StartWithPaths(artifactID, "", "x", "y", "z"); err == nil {
+		t.Error("StartWithPaths while already running: got nil error, want one")
 	}
 }


### PR DESCRIPTION
## What

A build with the "Netboot" output enabled auto-starts pixiecore as a build-pipeline step (`deployer/steps.go`'s `StepStartNetboot`), calling `ops.StartPixiecore` directly and in-process. That start never touches `netbootmgr.Manager` — the thing the dashboard's Start/Stop/Status endpoints actually track — so the server it starts is invisible to the UI and cannot be stopped from it. A later manual "Start Netboot" click then collides with the still-running one on the same ports instead of reporting it's already running.

## How this was found

Reproduced provisioning real hardware over netboot tonight. A build with the netboot output finished, silently started serving. Clicking "Start Netboot" in the dashboard an hour later failed with `listen udp 0.0.0.0:69: bind: address already in use` — there was no Stop button to press, no indication in the UI a server was even running, since `GET /api/v1/netboot/status` only reflects `netbootmgr.Manager`'s own state. The only way to recover was noticing the port conflict in the container logs and restarting the whole server.

## Fix

- Extracted `Manager.Start`'s core into `StartWithPaths(artifactID, cloudConfig, squashfs, initrd, kernel string) error`, taking already-resolved paths instead of reconstructing them from an `<artifactsDir>/<artifactID>/netboot/` convention. `Start` becomes a thin wrapper that resolves those conventional paths and delegates.
- Added `netbootmgr.WithManager`/`FromContext` to thread the server's shared `*Manager` through a `context.Context`.
- `Builder` (the server-side artifact builder) gets a `WithNetbootManager` option, matching its existing `WithLogBroadcaster` pattern, and injects the manager into the context right before running the deploy pipeline.
- `StepStartNetboot`'s callback checks `netbootmgr.FromContext(ctx)`: when present (always true server-side now), it routes through `mgr.StartWithPaths(...)`, sharing state with the dashboard. When absent (the CLI, which has no dashboard to keep in sync with), it falls back to the original direct `ops.StartPixiecore` call unchanged.

## Testing

`go build ./...` and `go vet ./...` clean across the whole module. Added `TestWithManagerRoundTrips`, `TestFromContextWithNoManagerSetReturnsNil`, and `TestStartWithPathsSharesStateWithStart` (the last one also reproduces the "already running" guard directly, the exact bug this fixes). Full `internal/netbootmgr`, `deployer`, `internal/builder/...`, and `internal/cmd` suites pass.

This is not an agent, Mauro used AI to help write this.
